### PR TITLE
chore: update trigger schema, mark recipients as required

### DIFF
--- a/pages/send-notifications/triggering-workflows.md
+++ b/pages/send-notifications/triggering-workflows.md
@@ -36,8 +36,8 @@ await knock.notify("new-user-invited", {
 | ---------------- | -------- | ----------------------------------------------------------------------------------------------------------- |
 | key\*            | string   | The human readable key of the workflow from the Knock dashboard                                             |
 | actor\*          | string   | The user id of the user who performed the action                                                            |
-| data\*           | map      | A map of properties that are required in the templates in this workflow                                     |
-| recipients       | string[] | A list of user ids for users that are associated with this workflow                                         |
+| recipients\*     | string[] | A list of user ids for users that are associated with this workflow                                         |
+| data             | map      | A map of properties that are required in the templates in this workflow                                     |
 | lists            | string[] | A list of names for the lists that should receive this workflow                                             |
 | cancellation_key | string   | A unique identifier to reference the workflow when canceling                                                |
 | tenant           | string   | An optional identifier of the owning tenant object for the notifications generated during this workflow run |


### PR DESCRIPTION
Changes:
* `recipients` param for triggering workflows should be a required param, not optional.
* `data` param for trigger workflows should be an optional param, not required.

Reference: https://knocklabs.slack.com/archives/C0272R6BQQH/p1625079916009000



