### PR TITLE
feat: KNO-118 hide lists from the docs

### DIFF
--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -30,7 +30,7 @@ const sidebarContent: SidebarSection[] = [
     pages: [
       { slug: "/concepts", title: "Concepts" },
       { slug: "/users", title: "Managing users" },
-      { slug: "/lists", title: "Managing lists" },
+      // { slug: "/lists", title: "Managing lists" },
       { slug: "/preferences", title: "Modeling preferences" },
       { slug: "/environments", title: "Environments" },
       { slug: "/multi-tenancy", title: "Multi-tenancy support" },

--- a/pages/getting-started/how-knock-works.md
+++ b/pages/getting-started/how-knock-works.md
@@ -21,10 +21,11 @@ Here's a visual of how these concepts work together:
 
 ![How Knock works diagram](/images/how-knock-works.png)
 
-And here's a brief description of how each concept functions within Knock. 
-- [Users.](/send-and-manage-data/users) A User represents an individual that will receive messages. You'll use the User object to store important attributes about your recipients (e.g. name, email) to be used in personalizing and delivering the messages you send with Knock. 
-- [Lists.](/send-and-manage-data/lists) A List groups users together to represent sets of individuals who need to be notified as a group.
-Lists typically map to your relationship hierarchies such as groups, teams, project members, or resource followers.
+And here's a brief description of how each concept functions within Knock.
+
+- [Users.](/send-and-manage-data/users) A User represents an individual that will receive messages. You'll use the User object to store important attributes about your recipients (e.g. name, email) to be used in personalizing and delivering the messages you send with Knock.
+  <!-- - [Lists.](/send-and-manage-data/lists) A List groups users together to represent sets of individuals who need to be notified as a group. -->
+  <!-- Lists typically map to your relationship hierarchies such as groups, teams, project members, or resource followers. -->
 - [Preferences.](/send-and-manage-data/preferences) A Preference indicates a user's willingness to receive a particular kind of notification. Preferences belong to a User in Knock.
 - [Channels.](/send-notifications/delivering-notifications) A Channel is a destination for your messages. It can be an out-of-app channel such as a SendGrid email integration, or an in-app channel such as the [Knock notification feed](/notification-feeds/overview). Channels are configured in the Knock dashboard as part of the [setup process](/getting-started/quick-start). 
 - [Workflows.](/send-notifications/designing-workflows) A Workflow orchestrates the delivery of messages to your end users. When you configure a workflow you'll determine which channels its messages should route to, what those messages should look like on each channel, as well as any functions—batch, throttle, digest—you want applied to the messages prior to delivery. A workflow is triggered by a `notify` call, usually when something occurs in your product that you want your users to know about (e.g. a new comment.)

--- a/pages/getting-started/quick-start.md
+++ b/pages/getting-started/quick-start.md
@@ -96,6 +96,6 @@ This was a simple overview to send your first notification with Knock. Read on t
 
 - [Sending & managing data concepts](/send-and-manage-data/concepts)
 - [Notification feeds](/notification-feeds/getting-started)
-- [Managing users with lists](/send-and-manage-data/lists)
+<!-- - [Managing users with lists](/send-and-manage-data/lists) -->
 
 <br />

--- a/pages/send-and-manage-data/concepts.md
+++ b/pages/send-and-manage-data/concepts.md
@@ -14,14 +14,14 @@ The user object can contain other key-value pairs that can be used to further pe
 
 [Read more →](/send-and-manage-data/users)
 
-## Lists
+<!-- ## Lists
 
 A list groups users together to represent sets of individuals who may need to be notified as a group.
 Lists typically map to your relationship hierarchies such as groups, teams, or project members. Lists
 are an essential abstraction for when your system needs to notify many users at once as the result
 of a triggered workflow (such as a new comment workflow that sends messages to all members of the parent document.)
 
-[Read more →](/send-and-manage-data/lists)
+[Read more →](/send-and-manage-data/lists) -->
 
 ## Preferences
 


### PR DESCRIPTION
### Description

Per the conversation in Slack, we don't have lists fully developed yet.
This has led to some confusion by our customers. This hides links to
list-related documentation until further notice.

See here: https://knocklabs.slack.com/archives/C0272R6BQQH/p1627066980012400?thread_ts=1627065084.011600&cid=C0272R6BQQH

### Todos

- [ ] Add a task to linear for later restoring Lists documentation?

### Tasks

- [KNO-118](https://linear.app/knock/issue/KNO-118)
