### PR TITLE
fix: add destructuring on node sdk import

### DIFF
--- a/pages/getting-started/quick-start.md
+++ b/pages/getting-started/quick-start.md
@@ -34,7 +34,7 @@ Best practice is to make an identify call to Knock when a new user is created an
 We don't take your user data lightly. For more on our security practices, contact us at [security@knock.app](mailto:security@knock.app?subject=Question%about%Knock's%security%practices).
 
 ```javascript
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 app.post("/signup", async (req, res) => {
@@ -63,7 +63,7 @@ To create your first workflow, log into the [Knock dashboard](https://dashboard.
 When you want to notify a set of users simply call the `notify` function to trigger the workflow you want to send. When calling the `notify` function, you'll pass in the `recipients` you want to receive messages sent by the workflow, as well as the `data` (which we received during step 4) required to populate those messages.
 
 ```javascript
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // In our hypothetical document collaboration app

--- a/pages/send-and-manage-data/lists.md
+++ b/pages/send-and-manage-data/lists.md
@@ -37,7 +37,7 @@ it. The name of the list can be any string identifier, however we suggest using 
 `project.project_123.followers`.
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // Sending only user ids
@@ -86,7 +86,7 @@ Users can be added to a list at any time. If the user is already present on the 
 for the user will be merged (if provided).
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // Users can be added in batches of 100 at a time
@@ -104,7 +104,7 @@ When users are no longer required to be part of a list (e.g. they un-followed a 
 can be removed using the SDK:
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // Users can be removed in batches of 100 at a time
@@ -116,7 +116,7 @@ await knock.lists.removeUsers(`project.${project.id}.followers`, [user.id]);
 You can get a list as well as a paginated set of its members (in ascending order).
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 const { pageInfo, list } = await knock.lists.get(
@@ -130,7 +130,7 @@ If a list is no longer needed, the entire list can be deleted and will subsequen
 available for use:
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // Users can be removed in batches of 100 at a time

--- a/pages/send-and-manage-data/users.md
+++ b/pages/send-and-manage-data/users.md
@@ -10,7 +10,7 @@ product.
 If you've used a Customer Data Platform (CDP) like Segment before, sending data to Knock will be familiar to you.
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 await knock.users.identify(user.id, {
@@ -83,7 +83,7 @@ Once sent to Knock, the user object returned to you in the Knock payload looks l
 You can batch send user objects, which is useful for when you're onboarding onto Knock.
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const chunk = require("lodash.chunk");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/pages/send-notifications/canceling-workflows.md
+++ b/pages/send-notifications/canceling-workflows.md
@@ -18,7 +18,7 @@ You can read about generating workflow cancellation keys and some best practices
 [triggering workflows guide](/send-notifications/triggering-workflows#generating-a-cancellation-key).
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 // Some invite approval code to reference a previously created invite
@@ -42,7 +42,7 @@ In some cases you may need to cancel a workflow for a subset of recipients only.
 by specifying the recipients list on the cancellation:
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 await knock.workflows.cancel("new-user-invited", userInvite.id, {

--- a/pages/send-notifications/triggering-workflows.md
+++ b/pages/send-notifications/triggering-workflows.md
@@ -13,7 +13,7 @@ may have indicated through their `preferences` that they don't wish to be notifi
 Workflows are triggered via a call to the `notify` endpoint, which tells Knock to run a specified payload of `recipients` and `data` through the workflow specified by the call.
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 await knock.notify("new-user-invited", {
@@ -44,7 +44,7 @@ await knock.notify("new-user-invited", {
 ### Sending to users
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 
 await knock.notify("welcome-to-knock", {
@@ -73,7 +73,7 @@ recommend using an idempotency key with enough entropy, like a uuid v4.
 We'll keep idempotency keys in our system for at least 7 days before they are purged.
 
 ```js
-const Knock = require("@knocklabs/node");
+const { Knock } = require("@knocklabs/node");
 const uuid = require("uuid4");
 const knock = new Knock(process.env.KNOCK_API_KEY);
 


### PR DESCRIPTION
### Description
- I found all places in docs where we were importing knock node sdk without destructuring Knock on import and updated to { Knock } 