### PR TITLE
fix typo on api ref

### DIFF
--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -1121,7 +1121,7 @@ Marks the given message as the `status`, recording an event in the process.
   <Attribute
     name="status"
     type="enum"
-    description="One of `seen`, `read`, `archive`"
+    description="One of `seen`, `read`, `archived`"
   />
 </Attributes>
 


### PR DESCRIPTION
### Description
Fixing typo we discussed here in slack: https://knocklabs.slack.com/archives/C01Q4R82QAU/p1632933848022500