### PR TITLE
add link to client js sdk on two pages

### DIFF
--- a/pages/client-integration/authenticating-users.md
+++ b/pages/client-integration/authenticating-users.md
@@ -2,24 +2,23 @@
 title: Authenticating users
 ---
 
-Authenticating ensures that your users can securely access the Knock API from the client
-applications that they are using, without you exposing your secret API key and allowing blanket
-access.
+Authentication ensures your users can securely access the Knock API from your client
+applications, without you exposing your secret API key and allowing blanket
+access. 
 
-**Note: you only need to add the authentication here if you're integrating Knock on the client-side of
-your applications and leveraging feeds or preferences.**
+**Note:** This integration guide references examples from our [client-side JS SDK](https://github.com/knocklabs/knock-client-js). You only need to add the authentication outlined in this guide if you're integrating Knock on the client-side of
+your applications to use the Knock in-app feed or the Knock preferences model.
 
 ## API endpoints that require auth
 
-The following calls will require authentication to be used (when called from the client):
+The following calls require authentication (when called from the client):
 
 - Fetching a user's notification feed
 - Marking a message as read, seen, or archived
 
 ## Authentication (in development environments)
 
-In a Knock development environment you can freely use your public key to authenticate all users
-and do not need to implement any other security mechanisms.
+In a Knock development environment you can use your public key to authenticate all users. You do not need to implement any other security mechanisms.
 
 **Client SDK example**
 
@@ -42,7 +41,7 @@ knockClient.authenticate(currentUser.id);
 >
 ```
 
-Please note: in production environments you **will need to authenticate your users using a secure user token**. This ensures
+**Note:** in production environments you **will need to authenticate your users using a secure user token**. This ensures
 that your users content is protected and cannot be read by malicious actors.
 
 ## Authentication (in production environments)
@@ -53,8 +52,8 @@ an additional network request.
 
 ### 1. Generate the signing key
 
-You can find the signing key in the Knock dashboard under the "developers" section. Save the private
-key shown to you here. Please note: you won't be shown this key again, so you'll need to regenerate
+You can find the signing key in the Knock dashboard under the "Developers" page. Save the private
+key shown to you here. Note: you won't be shown this key again, so you'll need to regenerate
 it if you lose access.
 
 ### 2. Sign the JWT
@@ -134,4 +133,4 @@ knockClient.authenticate(currentUser.id, currentUser.knockToken);
 ## Avoiding authentication
 
 You can avoid authentication altogether by proxying requests to Knock via your backend,
-although we don't recommend this approach as it will mean adding more latency for your users.
+although we don't recommend this approach as it will add more latency for your users.

--- a/pages/send-notifications/delivering-notifications.md
+++ b/pages/send-notifications/delivering-notifications.md
@@ -2,32 +2,22 @@
 title: Delivering notifications
 ---
 
-## In-app feed support
+You can use Knock to power both in-app and out-of-app notifications. 
 
-We currently support in-app feeds via our own hosted feed solution. This provides real-time behavior
-as well as pre-built in-app components for you to use.
+## In-app notification support
 
-If you need to use a component library outside of React JS and are in the JS ecosystem,
-you can leverage our JS SDK otherwise you can integrate with our API directly.
+The Knock [Feed API](/reference#feeds) gives developers a way to deliver in-app notifications to feeds, inboxes, and other notification-based experiences. 
 
-## Email provider support
+There are a few ways to power in-app notifications in your product using Knock:
+- **Use our [React notification feed component](https://github.com/knocklabs/react-notification-feed).** The Knock notification feed component provides real-time updates, pagination, badge behavior, filtering, and more. It's a great way to quickly add an in-app feed to your product if you use React. 
+- **Leverage our [client-side JS SDK](https://github.com/knocklabs/knock-client-js).** This is a good approach if you need to use a component library outside of React JS but are still in the JS ecosystem. 
+- **Integrate with our [API directly](/reference#feeds).** If you're not working within the JS ecosystem in your client, you can integrate directly with the Knock Feed API to power your in-app notifications. 
 
-We currently support the following email providers:
 
-- SendGrid
-- Postmark
-- AWS SES
+## Out-of-app channel support
 
-If your provider is not listed above, please [get in touch](mailto:support@knock.app).
+We support notification delivery to the following out-of-app channel types: email, push, SMS, and 3rd-party chat apps (such as Slack.) You can see a list of which providers we support within each channel type in the "Channels" page of the Knock dashboard.
 
-## Other channels
+With Knock, you can integrate a provider once, and then use it across all of your Knock workflows. If you ever need to switch providers on a given channel, it's as simple as configuring the new provider within the Knock dashboard and updating your workflows to use the new provider. 
 
-In the case in which there are other channels that you need to support within your product we
-recommend the following strategy for the time being:
-
-1. Connect a webhook to notify you whenever there are new notifications triggered for your
-   users
-2. Receive the webhook and use it to trigger the workflow for the user from within your API
-
-In the case where you have non user related channel needs, like Slack or Microsoft Teams, please
-contact us and we can assist.
+If you use a provider that we don't currently support, please [get in touch](mailto:support@knock.app).


### PR DESCRIPTION
### Description
- PR here for [feedback we heard from Terrastruct](https://knocklabs.slack.com/archives/C02M3CA8APR/p1641316608002000) this a.m.
- This updates delivering notifications to include links to our in-app component and js sdk. I also updated out-of-date language on channel support while I was in here. 
- I also added a link to the client js sdk on our page about client auth.

