### PR TITLE
fix(fonts): remove fout from inter loading

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,8 @@
-import "@fontsource/inter";
-import "@fontsource/inter/500.css";
-import "@fontsource/inter/600.css";
-import "@fontsource/inter/700.css";
 import { useRouter } from "next/router";
 import { ChakraProvider } from "@chakra-ui/react";
-import "../styles/index.css";
 import { useEffect } from "react";
+
+import "../styles/index.css";
 import theme from "../theme";
 import * as gtag from "../lib/gtag";
 

--- a/styles/index.css
+++ b/styles/index.css
@@ -14,6 +14,42 @@
 
 /* Your own custom utilities */
 
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  font-display: block;
+  src: url("~@fontsource/inter/files/inter-latin-400-normal.woff")
+    format("woff");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 500;
+  font-display: block;
+  src: url("~@fontsource/inter/files/inter-latin-500-normal.woff")
+    format("woff");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 600;
+  font-display: block;
+  src: url("~@fontsource/inter/files/inter-latin-600-normal.woff")
+    format("woff");
+}
+
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 700;
+  font-display: block;
+  src: url("~@fontsource/inter/files/inter-latin-700-normal.woff")
+    format("woff");
+}
+
 body {
   @apply w-full h-full subpixel-antialiased overflow-hidden;
 }


### PR DESCRIPTION
### Description

Removes the flash of unstyled text from inter loading by redefining our own `@font-face` declarations and using `font-display: block;`.

### Tasks
[KNO-1006](https://linear.app/knock/issue/KNO-1006)
