### PR TITLE
feat: add reference page for email layout

### DIFF
--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -39,6 +39,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/setting-channel-data", title: "Setting channel data" },
       { slug: "/delivering-notifications", title: "Delivering notifications" },
       { slug: "/reference-liquid-helpers", title: "Reference: liquid helpers" },
+      { slug: "/reference-email-layout", title: "Reference: email layout" },
     ],
   },
   {

--- a/pages/send-notifications/designing-workflows.md
+++ b/pages/send-notifications/designing-workflows.md
@@ -164,6 +164,8 @@ Moreover, please note the following features of the components:
 * **Button components** can be configured to use your brand colors by default, so you can ensure your brand elements are consistent across all of your product messaging. To configure your brand colors, head over to the branding settings page in your dashboard. ("Settings" page → "Branding" tab)
 * **HTML components** can contain any valid HTML markup and provide an "escape hatch" for advanced use cases where more complex markups are needed.
 
+When using the visual template editor, a handful of CSS styles are auto-generated and included in the email layout to provide base styles for certain components. Refer to the [reference guide](/send-notifications/reference-email-layout#generated-css-styles) for more details.
+
 Lastly, if you ever want to take complete control of the notification template and manually edit in the code editor, you can do so via the "Enter code editor" button found at the bottom of the editor. When opting out of the visual template editor, any components used in the template document will be translated into the equivalent HTML for you to take over.
 
 ### Previewing and testing your notification template

--- a/pages/send-notifications/reference-email-layout.md
+++ b/pages/send-notifications/reference-email-layout.md
@@ -1,0 +1,54 @@
+---
+title: "Reference: email layout"
+---
+
+This is a reference guide of special Knock variables, and generated CSS styles that are used in email layouts.
+
+## Special Knock variables
+
+There are a few special variables used in email layouts to populate and assemble the final email notification template.
+
+| Variable           | Description                                                                                                                                                                                                                          |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `content`          | A notification template defined in an email channel step will be inserted into this variable. **This is a required variable, and must be present somewhere in every layout.**                                                        |
+| `footer_links`     | A list of footer links, as configured in the layout editor, will be injected into this variable.                                                                                                                                     |
+
+## Generated CSS styles
+
+When you use the [visual template editor](/send-notifications/designing-workflows#visual-editing-with-drag-and-drop-components) to build your email notification template, we auto-generate and include the following CSS styles in the email layout. They provide base styles for certain components, which you can override or extend them as needed.
+
+
+```css Base component styles
+/* Button components */
+.block-row.block-row--button_set-v1 .block-button {
+  display: inline-block;
+  box-sizing: border-box;
+  text-decoration: none;
+  -webkit-text-size-adjust: none;
+}
+.block-row.block-row--button_set-v1 .block-button.block-button--outline {
+  border-style: solid;
+}
+.block-row.block-row--button_set-v1 .block-button.block-button--sm {
+  font-size: 14px;
+  line-height: 20px;
+  min-width: 32px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+/* Divider component */
+.block-row.block-row--divider-v1 .block-divider {
+  border-bottom: 1px solid #DDDEE1;
+}
+
+/* Markdown components */
+.block-row.block-row--markdown-v1 .block-markdown > :first-child {
+  margin-top: 0;
+}
+.block-row.block-row--markdown-v1 .block-markdown > :last-child {
+  margin-bottom: 0;
+}
+```


### PR DESCRIPTION
### Description
This PR adds a new reference page for email layout, which documents a few auto-generated CSS styles for the visual block editor. 

### Tasks
[KNO-1223](https://linear.app/knock/issue/KNO-1223/[doc]-draft-documentation-for-the-new-email-message-template-editor)

### Screenshots

<img width="1440" alt="CleanShot 2022-05-10 at 19 08 06@2x" src="https://user-images.githubusercontent.com/4471723/167739102-236730b2-a3a7-45af-9dc3-8511b199055f.png">

<img width="1439" alt="CleanShot 2022-05-10 at 19 08 20@2x" src="https://user-images.githubusercontent.com/4471723/167739108-4e29ba12-58c3-492a-8f6a-31adea85207e.png">


