### PR TITLE
feat(kno-1425): fix search on mobile devices

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -149,6 +149,7 @@ const Autocomplete = () => {
 
   return (
     <Box
+      display={{ base: "none", sm: "none", md: "block" }}
       ml="20px"
       h="38px"
       w="500px"

--- a/layouts/Page.tsx
+++ b/layouts/Page.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import Link from "next/link";
-import React, { ReactElement, useEffect, useState } from "react";
-import { useMediaQuery } from "@chakra-ui/react";
+import React, { ReactElement } from "react";
 import Meta from "../components/Meta";
 import FeedbackPopover from "../components/FeedbackPopover";
 import Autocomplete from "../components/Autocomplete";
@@ -11,83 +10,74 @@ type Props = {
   sidebar?: ReactElement;
 };
 
-export const Page: React.FC<Props> = ({ children, pageType, sidebar }) => {
-  const [displaySearch, setDisplaySearch] = useState(false);
-  const [isMobile] = useMediaQuery("(max-width: 768px)");
+export const Page: React.FC<Props> = ({ children, pageType, sidebar }) => (
+  <>
+    <Meta />
+    <Head>
+      <title>Knock Docs</title>
+    </Head>
+    <div className="h-screen flex flex-col antialiased">
+      <header className="border-b px-5 h-16 bg-gray-50 flex items-center">
+        <div>
+          <Link href="/">
+            <a className="flex justify-center items-center">
+              <img
+                src="/icons/knock-wordmark.svg"
+                alt="Knock"
+                className="w-16 lg:w-20"
+              />
+              <span className="text-gray-500 ml-1 lg:text-lg mt-1 lg:mt-2">
+                {pageType}
+              </span>
+            </a>
+          </Link>
+        </div>
 
-  useEffect(() => {
-    setDisplaySearch(!isMobile);
-  }, []);
+        <Autocomplete />
 
-  return (
-    <>
-      <Meta />
-      <Head>
-        <title>Knock Docs</title>
-      </Head>
-      <div className="h-screen flex flex-col antialiased">
-        <header className="border-b px-5 h-16 bg-gray-50 flex items-center">
-          <div>
-            <Link href="/">
-              <a className="flex justify-center items-center">
+        <div className="ml-auto flex items-center space-x-2">
+          <FeedbackPopover />
+
+          <Link href="https://dashboard.knock.app">
+            <a className="text-sm text-brand hover:text-brand-dark font-semibold hidden md:block">
+              Go to dashboard &rarr;
+            </a>
+          </Link>
+        </div>
+      </header>
+      <div className="flex overflow-y-hidden h-full">
+        {sidebar}
+
+        <main className="w-full h-full overflow-y-auto">
+          <section className="p-5 lg:p-8 min-h-full">{children}</section>
+          <footer className="border-t p-5 lg:p-8">
+            <section className="mx-auto  w-full max-w-5xl flex flex-col lg:flex-row items-center justify-center">
+              <div className="text-center lg:text-left">
                 <img
                   src="/icons/knock-wordmark.svg"
                   alt="Knock"
-                  className="w-16 lg:w-20"
+                  className="w-16 mx-auto lg:mx-0"
                 />
-                <span className="text-gray-500 ml-1 lg:text-lg mt-1 lg:mt-2">
-                  {pageType}
+                <span className="text-sm text-gray-500 leading-tight">
+                  Notifications infrastructure for developers.
                 </span>
-              </a>
-            </Link>
-          </div>
-
-          {displaySearch && <Autocomplete />}
-
-          <div className="ml-auto flex items-center space-x-2">
-            <FeedbackPopover />
-
-            <Link href="https://dashboard.knock.app">
-              <a className="text-sm text-brand hover:text-brand-dark font-semibold hidden md:block">
-                Go to dashboard &rarr;
-              </a>
-            </Link>
-          </div>
-        </header>
-        <div className="flex overflow-y-hidden h-full">
-          {sidebar}
-
-          <main className="w-full h-full overflow-y-auto">
-            <section className="p-5 lg:p-8 min-h-full">{children}</section>
-            <footer className="border-t p-5 lg:p-8">
-              <section className="mx-auto  w-full max-w-5xl flex flex-col lg:flex-row items-center justify-center">
-                <div className="text-center lg:text-left">
-                  <img
-                    src="/icons/knock-wordmark.svg"
-                    alt="Knock"
-                    className="w-16 mx-auto lg:mx-0"
-                  />
-                  <span className="text-sm text-gray-500 leading-tight">
-                    Notifications infrastructure for developers.
-                  </span>
-                </div>
-                <div className="lg:ml-auto mt-3">
-                  <nav className="ml-auto">
-                    <ul className="flex text-sm text-gray-700">
-                      <li className="mr-5">
-                        <a href="https://knock.app">Visit website</a>
-                      </li>
-                      <li>
-                        <a href="mailto:support@knock.app">Contact us</a>
-                      </li>
-                    </ul>
-                  </nav>
-                </div>
-              </section>
-            </footer>
-          </main>
-        </div>
+              </div>
+              <div className="lg:ml-auto mt-3">
+                <nav className="ml-auto">
+                  <ul className="flex text-sm text-gray-700">
+                    <li className="mr-5">
+                      <a href="https://knock.app">Visit website</a>
+                    </li>
+                    <li>
+                      <a href="mailto:support@knock.app">Contact us</a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+            </section>
+          </footer>
+        </main>
       </div>
-    </>
-  );
-};
+    </div>
+  </>
+);


### PR DESCRIPTION
### Description
Fix rendering of header in mobile.

The issue here is that the page was being generated from the server as it search was enabled and then was not handled correctly on the client.

This PR disables the search rendering when rendering fro the server and then does the check on the client to turn it on based on device width.

### Tasks
[KNO-1425](https://linear.app/knock/issue/KNO-1425/api-doc-search-mobile-behavior)

### Screenshots
<img width="1432" alt="Screen Shot 2022-05-27 at 15 10 24" src="https://user-images.githubusercontent.com/982261/170768682-9901a42d-8479-46c1-a25f-5b38d674c265.png">
(this is the real mobile device debugger, not the simulator)
