### PR TITLE
chore: fix messages docs

### DIFF
--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -428,7 +428,7 @@ A paginated list of Message records
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "Message",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",
@@ -1663,7 +1663,7 @@ as such return information that is required on the client to do so**
 
 <Attributes>
   <Attribute
-    name="entries"
+    name="items"
     type="FeedItem[]"
     description="An ordered list of feed items (most recent first)"
   />
@@ -1693,7 +1693,7 @@ as such return information that is required on the client to do so**
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "FeedItem",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",
@@ -2039,7 +2039,7 @@ A paginated list of Message records
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "Message",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",
@@ -2152,7 +2152,7 @@ A paginated list of MessageEvent records
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "MessageEvent",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",
@@ -2225,7 +2225,7 @@ A paginated list of Activity records
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "Activity",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",
@@ -2299,8 +2299,8 @@ of message being sent (email, chat, in-app feed, sms and push).**
   "__typename": "MessageContent",
   "id": "264os2yt574e1T3jblzjbh7Qa69",
   "data": {
-    "bcc": bcc@example.com,
-    "cc": cc@example.com,
+    "bcc": "bcc@example.com",
+    "cc": "cc@example.com",
     "from": {
       "email": "info-app@example.com",
       "name": "Example App"
@@ -2311,7 +2311,7 @@ of message being sent (email, chat, in-app feed, sms and push).**
     "text_body": "example",
     "to": "user@example.com"
   },
-  "inserted_at": "2021-04-06T12:00:00Z",
+  "inserted_at": "2021-04-06T12:00:00Z"
 }
 ```
 
@@ -2774,7 +2774,7 @@ A paginated list of Message records
 
 ```json Response
 {
-  "entries": [
+  "items": [
     {
       "__typename": "Message",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",


### PR DESCRIPTION
### Description

* `entries` → `items` in the listing endpoint docs
* MessageContent example was wrong

### Tasks
[KNO-1447](https://linear.app/knock/issue/KNO-1447)

