### PR TITLE
chore: fix kotlin link, use entries not items for feed

### DIFF
--- a/pages/in-app-ui/overview.mdx
+++ b/pages/in-app-ui/overview.mdx
@@ -24,6 +24,6 @@ We have the following SDKs available to use to build in-app experiences:
 - [JS (Non-React Web)](/in-app-ui/javascript/overview)
 - [React Native](/in-app-ui/react-native/overview)
 - [Swift (iOS / macOS)](/in-app-ui/ios/overview)
-- [Kotlin (Android)](/in-app-ui/kotlin/overview)
+- [Kotlin (Android)](/in-app-ui/android/overview)
 
 Under each you'll find guides and references to help you get started.

--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -1663,7 +1663,7 @@ as such return information that is required on the client to do so**
 
 <Attributes>
   <Attribute
-    name="items"
+    name="entries"
     type="FeedItem[]"
     description="An ordered list of feed items (most recent first)"
   />
@@ -1693,7 +1693,7 @@ as such return information that is required on the client to do so**
 
 ```json Response
 {
-  "items": [
+  "entries": [
     {
       "__typename": "FeedItem",
       "__cursor": "g3QAAAABZAACaWRtAAAAGzFzTXRJc1J2WnRZZjg2YU9ma00yUENwQzZYYw==",


### PR DESCRIPTION
### Description

* Link 404'd
* Feeds **should** be `entries` and not `items`
