### PR TITLE
fix(kno-1464): remove cursor from webhook payload example

### DIFF
--- a/pages/send-and-manage-data/outbound-webhooks.mdx
+++ b/pages/send-and-manage-data/outbound-webhooks.mdx
@@ -67,7 +67,6 @@ A webhook payload for the message events will always include the message sent an
   "created_at": "2022-05-31T17:12:59.958652Z",
   "data": {
     // The message for which this event is being reported
-    "__cursor": null,
     "__typename": "Message",
     "archived_at": null,
     "channel_id": "f5674f8b-81bb-49b1-9d52-e29d754b8a1b",


### PR DESCRIPTION
### Description
The cursor shouldn't be included in a single message payload, that's for paginating messages.

### Tasks
[KNO-1464](https://linear.app/knock/issue/KNO-1464/%5Bswitchboard%5D-do-not-include-cursor-on-payloads-if-not-necessary)