### PR TITLE
feat(webhooks): docs on secrets

### DIFF
--- a/pages/send-and-manage-data/outbound-webhooks.mdx
+++ b/pages/send-and-manage-data/outbound-webhooks.mdx
@@ -96,6 +96,7 @@ The request header will also contain the following:
 
 - `x-knock-event`: the field and the value found in the `"type"` key of the payload
 - `x-knock-environment-id`: the environment the webhook belongs to
+- `x-knock-signature`: the encoded result of a timestamp, payload, and shared secret key so you can verify that the contents of the webhook are from Knock and not a result of a [Man in the middle attack](https://en.wikipedia.org/wiki/Man-in-the-middle_attack). Learn more about [verifying signatures below](/send-and-manage-data/outbound-webhooks#verifying-the-signature).
 
 <Callout
   emoji="🌠"
@@ -129,7 +130,79 @@ When you click "Create webhook" you'll be prompted to add the endpoint from the 
 
 Once you create the webhook, it will be activated and you will begin receiving requests to your endpoint. To stop receiving requests, you can [delete the webhook](/send-and-manage-data/webhooks#deleting-a-webhook).
 
-## Using data from a webhook payload
+## Recieving a webhook payload
+
+### Verifying the signature
+
+We recommend that upon receiving the webhook request you verify the signature before using the contents of the payload. We follow the Stripe specification to add a layer of security to our webhook requests.
+
+The signature is generated with a HMAC using the SHA256 algorithm and, prior to being encoded, is comprised of the timestamp and the stringified JSON payload of the request. We encode `"timestamp in numerical form"."stringified payload"` as the signature of the request.
+
+The `x-knock-signature` header is a string comprised of the timestamp used in the encoding and the encoded value above. It will look like this: `t=timestamp,s=encoded-signature`
+
+To test that the payload sent has not been compromised, you can recreate the signature using the shared secret key found on the Webhook page and compare to the one sent in the header.
+
+1. Split the `x-knock-signature` on the comma (",") and extract the values of timestamp and signature.
+2. Construct the value of the signature by concatenating:
+
+   - The timestamp (as a string)
+   - The character .
+   - The stringified JSON payload
+
+3. Generate the signature with an HMAC and SHA256 algorithm using the secret key from your webhook's dashboard
+4. Compare your generated signature with the one extracted in step one; they should match exactly. If the timestamp is more than five minutes old compared to the current time, you may decide you want to reject the payload for additional security.
+
+Here's an example to follow:
+
+```javascript Validating a webhook payload with your secret key
+// This example uses Express to receive webhooks
+const express = require("express");
+
+const app = express();
+
+// Find your webhook's secret key on its page in your Knock dashboard
+const webhookSecret = "some-secret";
+
+// Match the raw body to content type application/json
+app.post(
+  "/webhook",
+  express.raw({ type: "application/json" }),
+  (request, response) => {
+    const sig = request.headers["x-knock-signature"];
+
+    // Extract the timestamp and signature from the header and remove the identifiers
+    const timestamp = sig.split(",")[0].substring(2);
+    const originalSignature = sig.split(",")[1].substring(2);
+    // Construct the value to be encoded
+    const value = `${timestamp}.${request.body}`;
+
+    // Generate the signature with a HMAC using the SHA256 algorithm
+    const reconstructedSignature = crypto
+      .createHmac("sha256", webhookSecret)
+      .update(value)
+      .digest("base64");
+
+    // Compare the signature from the header with your reconstructed signature to validate
+    const isValid = crypto.timingSafeEqual(originalSignature, reconstructedSignature);
+
+    // For additional security, validate that the timestamp is within your
+    // tolerance for proximity to the current time (example shown within 5 minutes)
+    const date = new Date(timestamp);
+    const now = new Date.now();
+    const isWithinFiveMinutes = now - date < 60000;
+
+    if (isValid && isWithinFiveMinutes) {
+      response.json({ received: true });
+    } else {
+      response.status(400).send("Webhook Error, invalid signature");
+    }
+  },
+);
+
+app.listen(4242, () => console.log("Running on port 4242"));
+```
+
+### Using the data
 
 Once you receive a webhook request and return a `2xx` status code, you can make additional requests to the Knock API to gather more information about the message event. For example, if you'd like to log the message's content when an event type comes through as `message.undelivered`, you can use the message ID to send a request to [get message content](/reference#get-message-content) when that condition is met.
 


### PR DESCRIPTION
### Description
Add documentation for how to verify the payload of a webhook request with a javascript example.

### Tasks
[KNO-1392](https://linear.app/knock/issue/KNO-1392/enable-secrets)
