### PR TITLE
chore(react-feeds): add new docs for onOpen and badgeCountType

### DIFF
--- a/pages/in-app-ui/react/feed.mdx
+++ b/pages/in-app-ui/react/feed.mdx
@@ -115,6 +115,33 @@ import {
 />;
 ```
 
+### Using `read` instead of `seen` for the badge count
+
+```jsx
+import { NotificationIconButton } from "@knocklabs/react-notification-feed";
+
+<NotificationIconButton onClick={...} badgeCountType="unread" />;
+```
+
+### Marking messages as read on the popover opening
+
+```jsx
+import { NotificationFeedPopover } from "@knocklabs/react-notification-feed";
+
+const onOpen = ({ store, feedClient }) => {
+  const unreadItems = store.items.filter((item) => !item.read_at);
+
+  if (unreadItems.length > 0) {
+    feedClient.markAsRead(unreadItems);
+  }
+};
+
+<NotificationFeedPopover
+  onOpen={onOpen}
+  {...}
+/>;
+```
+
 ### Using dark mode
 
 The feed supports an optional `colorMode` prop, that defaults to `light` but can be set as `dark` for dark mode support.

--- a/pages/in-app-ui/react/inbox.mdx
+++ b/pages/in-app-ui/react/inbox.mdx
@@ -38,7 +38,7 @@ const NotificationInbox = () => {
       feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={user.id}
     >
-      <NotificationFeed isVisible />
+      <NotificationFeed />
     </KnockFeedProvider>
   );
 };

--- a/pages/in-app-ui/react/reference.mdx
+++ b/pages/in-app-ui/react/reference.mdx
@@ -147,6 +147,11 @@ Accepts the same base props as `NotificationFeed`, and overrides with the follow
     description="The function to be invoked when the popover is closed."
   />
   <Attribute
+    name="onOpen"
+    type="function"
+    description="A function that's invoked whenever the feed popover is opened, useful for updating any items in view and marking them as read, seen, or archived."
+  />
+  <Attribute
     name="buttonRef*"
     type="RefObject<HTMLElement>"
     description="A ref of the button to position the popover adjacent to."
@@ -206,6 +211,11 @@ Renders a notification bell icon, with a badge showing the number of unseen item
     name="onClick*"
     type="function"
     description="The function to be invoked when the IconButton is clicked"
+  />
+  <Attribute
+    name="badgeCountType"
+    type="enum"
+    description="One of `unseen` | `unread` | `all` to determine which count to display"
   />
 </Attributes>
 


### PR DESCRIPTION
### Description

Supporting work for adding new `onOpen` and `badgeCountType` props for the feed.

### Tasks
[KNO-1479](https://linear.app/knock/issue/KNO-1479)

