### PR TITLE
feat(kno-1949): add docs for pre-content for emails

### DIFF
--- a/pages/integrations/email/layouts.mdx
+++ b/pages/integrations/email/layouts.mdx
@@ -116,7 +116,7 @@ To do this your email layout would look like this:
 
 And then within the pre-content override of your email template you'd insert your `previewText` variable:
 
-``` A precontent field value
+``` markdown Pre-content field value
 {% assign previewText = "Hello and welcome to Knock" %}
 ```
 


### PR DESCRIPTION
### Description
Adds docs for the `pre-content` attribute for email templates.
This docs are based on: https://www.notion.so/knockapp/Sample-doc-Email-template-evaluation-00937b3e1f1c48c6b4a583a6af817cda

### Tasks
[KNO-1949](https://linear.app/knock/issue/KNO-1949/[docs]-add-pre-content-attribute-docs)
