### PR TITLE
feat(kno-2198): specify has_tenant filter defaults to 'false'

### DIFF
--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -4,13 +4,18 @@ const Attributes = ({ children }) => (
   </div>
 );
 
-const Attribute = ({ name, type, description }) => (
+const Attribute = ({ name, type, defaultValue, description }) => (
   <div className="attribute border-b dark:border-b-gray-800 py-2">
     <span>
       <span className="font-mono text-xs">{name}</span>
       <span className="font-semibold text-gray-500 dark:text-gray-300 text-xs ml-2 py-0.5 px-1 border border-gray-100 bg-gray-50 dark:bg-transparent dark:border-transparent">
         {type}
       </span>
+      {defaultValue && (
+        <span className="font-semibold text-gray-500 dark:text-gray-300 text-xs ml-2 py-0.5 px-1 border border-gray-100 bg-gray-50 dark:bg-transparent dark:border-transparent">
+          default: {defaultValue}
+        </span>
+      )}
     </span>
     <span className="block text-sm mt-0 text-gray-600 dark:text-gray-300">
       {description}

--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -393,7 +393,8 @@ Retrieve a paginated list of messages for a user. Will return most recent messag
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"
@@ -1915,7 +1916,8 @@ along with a user token to make this request**
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"
@@ -1940,6 +1942,7 @@ along with a user token to make this request**
   <Attribute
     name="has_tenant"
     type="boolean (optional)"
+    defaultValue="false"
     description="Scope the feed to display items with or without any tenancy"
   />
   <Attribute
@@ -1950,7 +1953,8 @@ along with a user token to make this request**
   <Attribute
     name="archived"
     type="string (optional)"
-    description="One of `include`, `exclude`, `only` (defaults to `exclude`)"
+    defaultValue="exclude"
+    description="One of `include`, `exclude`, `only`"
   />
 </Attributes>
 
@@ -2094,7 +2098,8 @@ Returns a paginated list of messages.
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"
@@ -2227,7 +2232,8 @@ Returns a paginated list of events for a message.
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"
@@ -2297,7 +2303,8 @@ Returns a paginated list of activities associated with the message. Note: for no
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"
@@ -2829,7 +2836,8 @@ Returns a paginated list of messages for an object. Will return newest messages 
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    defaultValue="50"
+    description="The total number to retrieve per page"
   />
   <Attribute
     name="after"


### PR DESCRIPTION
### Description

Also makes a small update for highlighting default values for request parameters.

### Tasks

[KNO-2198](https://linear.app/knock/issue/KNO-2198/[switchboard]-add-has-tenant-boolean-filter-to-user-feeds-api-socket)
