### PR TITLE
feat(KNO-2234): update AWS SES docs with knock_recipient_id

### DIFF
--- a/pages/integrations/email/aws-ses.mdx
+++ b/pages/integrations/email/aws-ses.mdx
@@ -168,26 +168,27 @@ Knock sends the following attributes along with your emails (all as `Tags`):
 - `Sender`: always set to `knock.app`
 - `knock_message_id`: the ID of the message this email is associated with
 - `knock_workflow`: the key of the workflow this message was generated from
-- `knock_recipient_id`: the ID from your recipient
+- `knock_recipient_id`: the ID of your recipient
 
 <Callout
   emoji="🔦"
   text={
     <>
-      <span className="font-bold">Important:</span> Keep in mind that AWS SES
-      doesn't allow the use of non-ASCII characters on tags and must have 255
-      characters or fewer. You can still use recipients with these characters,
-      but at the moment of sending an email we will remove them for the
-      <span className="font-bold"> knock_recipient_id</span> tag and only use the
-      first 255 characters.
+      Keep in mind that AWS SES tags can be up to 256 characters long of only
+      ASCII letters (a-z, A-Z), numbers (0-9), underscores (_), or dashes (-).
+      If your <span className="font-bold">knock_recipient_id</span> does not
+      meet these requirements, Knock will truncate{" "}
+      <span className="font-bold">knock_recipient_id</span> to 256 characters
+      and remove any prohibited characters.
       <br />
+      Check out the{" "}
       <a
         href="https://docs.aws.amazon.com/ses/latest/APIReference/API_MessageTag.html"
         target="_blank"
       >
-        Here
-      </a>
-      &nbsp;you can find more information about tag's restrictions
+        AWS Docs
+      </a>{" "}
+      for more information.
     </>
   }
 />


### PR DESCRIPTION
### Description
Update the docs so the users know we pass "recipient_id" on the metadata will no non-ASCII characters on it and with a limitation of 255 characters.

### Tasks
[KNO-2234](https://linear.app/knock/issue/KNO-2234/[docs]-update-aws-ses-docs-with-non-ascii-characters-on-recipient-id)

### Screenshots
![Image 12-10-22 at 13 12](https://user-images.githubusercontent.com/67347884/195394678-1be32e41-df7e-4f43-95bb-8fa35199d4fc.jpg)
