### PR TITLE
remove beta callout

### DIFF
--- a/pages/integrations/sources/hightouch.mdx
+++ b/pages/integrations/sources/hightouch.mdx
@@ -11,20 +11,6 @@ import Callout from "../../../components/Callout";
 
 Knock integrates with [Hightouch](https://hightouch.com) as a downstream destination to sync customer and event data from your data warehouse.
 
-<Callout
-  emoji="🚧"
-  text={
-    <>
-      Our Hightouch integration is currently in beta. If you'd like early
-      access, or this is blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Hightouch integration">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
 ## Use cases
 
 You can use our Hightouch integration to:


### PR DESCRIPTION
I think we should remove this beta callout since users aren't blocked from using the hightouch integration by requesting access to the beta