### PR TITLE
chore: add docs for new markAllAsSeen / Read / Archived behavior

### DIFF
--- a/pages/in-app-ui/javascript/reference.mdx
+++ b/pages/in-app-ui/javascript/reference.mdx
@@ -268,9 +268,17 @@ Unbinds an existing event handler previously bound with `on`. Use this method to
 
 ### `getState`
 
-Programatically access the current `FeedStoreState`.
+Programmatically access the current `FeedStoreState`.
 
 **Returns**: `FeedStoreState`.
+
+### `markAllAsSeen`
+
+Marks all of the items in the store optimistically as seen and performs a server-side request to mark **all items on the feed in the current scope** as seen. Broadcasts a `items:all_seen` event.
+
+**Please note**: this operation is deferred and may take some time to process all items in the feed.
+
+**Returns**: `Promise<ApiResponse>`
 
 ### `markAsSeen`
 
@@ -301,6 +309,14 @@ Removes the `seen` status on the item or items given. Will perform the operation
     description="A single `FeedItem` or a list of `FeedItem` to perform the update on."
   />
 </Attributes>
+
+**Returns**: `Promise<ApiResponse>`
+
+### `markAllAsRead`
+
+Marks all of the items in the store optimistically as read and performs a server-side request to mark **all items on the feed in the current scope** as read. Broadcasts a `items:all_read` event.
+
+**Please note**: this operation is deferred and may take some time to process all items in the feed.
 
 **Returns**: `Promise<ApiResponse>`
 
@@ -336,9 +352,17 @@ Removes the `read` status on the item or items given. Will perform the operation
 
 **Returns**: `Promise<ApiResponse>`
 
+### `markAllAsArchived`
+
+Marks all of the items in the store optimistically as archived and performs a server-side request to mark **all items on the feed in the current scope** as archived. Broadcasts a `items:all_archived` event.
+
+**Please note**: this operation is deferred and may take some time to process all items in the feed.
+
+**Returns**: `Promise<ApiResponse>`
+
 ### `markAsArchived`
 
-Sets the `archived` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`.
+Sets the `archived` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts a `items:archived` event.
 
 **Params**:
 


### PR DESCRIPTION
### Description

Adds new reference docs for new `markAllAs` methods on the feed

### Tasks
[KNO-2406](https://linear.app/knock/issue/KNO-2406)

