### PR TITLE
updates to channel data docs

### DIFF
--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -1528,7 +1528,19 @@ Sets channel data for the user and the channel specified.
   <Attribute
     name="data"
     type="object"
-    description="The data to set for this channel, shape of the payload varies depending on the channel"
+    description=
+    {
+    <p>
+      The data to set for the specified <code>channel_id</code>. The shape of the payload varies depending on the channel. You can learn more about channel data schemas
+      {" "}<a
+        href="/send-notifications/setting-channel-data#provider-data-requirements"
+        className="text-brand underline"
+      >
+        here
+      </a>
+      .
+    </p>
+  }
   />
 </Attributes>
 
@@ -1675,7 +1687,18 @@ Sets channel data for the object and the channel specified.
   <Attribute
     name="data"
     type="object"
-    description="The data to set for this channel, shape of the payload varies depending on the channel"
+    description={
+    <p>
+      The data to set for the specified <code>channel_id</code>. The shape of the payload varies depending on the channel. You can learn more about channel data schemas
+      {" "}<a
+        href="/send-notifications/setting-channel-data#provider-data-requirements"
+        className="text-brand underline"
+      >
+        here
+      </a>
+      .
+    </p>
+  }
   />
 </Attributes>
 

--- a/pages/send-notifications/setting-channel-data.mdx
+++ b/pages/send-notifications/setting-channel-data.mdx
@@ -138,13 +138,23 @@ Channel data requirements for each push provider are listed below. Typically thi
 | ----------- | ----------------- | -------------------------------- |
 | connections | SlackConnection[] | One or more connections to Slack |
 
-A `SlackConnection` has the following schema:
+A `SlackConnection` can have one of two schemas, depending on whether you're using standard Slack OAuth scopes or an incoming webhook. 
+We cover Slack app scopes in detail in our [Slack scopes guide](/integrations/chat/slack/slack-apps-and-scopes). 
+
+If you're using standard Slack OAuth with access token scopes, your `SlackConnection` schema looks like this. You'll use 
+either a `channel_id` or `user_id` depending on whether you're storing connection data to message a channel or user in Slack. 
 
 | Property             | Type   | Description                                                                 |
 | -------------------- | ------ | --------------------------------------------------------------------------- |
 | access_token         | string | A bot access token                                                          |
 | channel_id           | string | A Slack channel ID                                                          |
 | user_id              | string | A Slack user ID                                                             |
+
+
+If you're using a Slack app with the `incoming-webhook` scope your `SlackConnection` schema is quite simple.    
+
+| Property             | Type   | Description                                                                 |
+| -------------------- | ------ | --------------------------------------------------------------------------- |
 | incoming_webhook.url | string | The Slack incoming webhook URL (to be used instead of the properties above) |
 
 #### Discord


### PR DESCRIPTION
- updates to api ref on channel data and setting channel data docs. I'm trying to make it easier to find way to provider-specific channel data and then clarify on slack schema a bit more. 
- @cjbell im wondering if it makes sense to update our slack channel data code snippet to use access token example instead of incoming webhook? is that an update you could push to this PR?