### PR TITLE
chore(messages): add metadata for external_id to messages

### DIFF
--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -461,6 +461,9 @@ A paginated list of Message records
       },
       "data": {
         "foo": "bar"
+      },
+      "metadata": {
+        "external_id": "external_id_from_provider"
       }
     }
   ],
@@ -2074,6 +2077,9 @@ A message is a notification delivered on a particular channel to a user.
   },
   "data": {
     "foo": "bar"
+  },
+  "metadata": {
+    "external_id": "external_id_from_provider"
   }
 }
 ```
@@ -2166,6 +2172,9 @@ A paginated list of Message records
       },
       "data": {
         "foo": "bar"
+      },
+      "metadata": {
+        "external_id": "external_id_from_provider"
       }
     }
   ],
@@ -2901,6 +2910,9 @@ A paginated list of Message records
       },
       "data": {
         "foo": "bar"
+      },
+      "metadata": {
+        "external_id": "external_id_from_provider"
       }
     }
   ],

--- a/pages/send-and-manage-data/outbound-webhooks.mdx
+++ b/pages/send-and-manage-data/outbound-webhooks.mdx
@@ -62,7 +62,7 @@ This is the list of events that Knock can use to trigger a webhook:
 
 A webhook payload for the message events will always include the message sent and the type of event that triggered the payload. This is an example of what will be sent to your webhook endpoint:
 
-```json
+```json A sample event payload
 {
   "__typename": "Event",
   "created_at": "2022-05-31T17:12:59.958652Z",
@@ -74,18 +74,22 @@ A webhook payload for the message events will always include the message sent an
     "data": null,
     "id": "29wHMT3jeGfPE02PHezR8go0cK1",
     "inserted_at": "2022-05-31T17:12:59.933761Z",
+    "metadata": {
+      // The `id` of the delivered message that the delivery provider may return
+      "external_id": "external_id_from_provider"
+    },
     "read_at": null,
     "recipient": "fd3d0708-ebee-456b-a324-1312a30edd0c",
     "seen_at": null,
     "source": {
+      // The source workflow that triggered this message
       "__typename": "NotificationSource",
       "key": "new-comment",
       "version_id": "f5917d67-8a2f-487d-a544-83cacbdb1cfb"
     },
     "status": "delivered", // The current status of the message sent
     "tenant": null,
-    "updated_at": "2022-05-31T17:12:59.942374Z",
-    "workflow": "new-comment"
+    "updated_at": "2022-05-31T17:12:59.942374Z"
   },
   "type": "message.sent" // The type of event that triggered the webhook
 }


### PR DESCRIPTION
### Description

Adds `metadata.external_id` to the message object

### Tasks
[KNO-2602](https://linear.app/knock/issue/KNO-2602)
