### PR TITLE
chore(apns): add support for apns-push-type as a header

### DIFF
--- a/pages/integrations/push/apns.mdx
+++ b/pages/integrations/push/apns.mdx
@@ -67,11 +67,11 @@ We have full support for overriding the payload sent to APNS for adding things l
 
 See the [APNS documentation for details](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification).
 
-| Property | Type       | Description                                                                                  |
-| -------- | ---------- | -------------------------------------------------------------------------------------------- |
-| headers  | dictionary | APNS specific headers (`apns-priority`, `apns-expiration`, `apns-topic`, `apns-collapse-id`) |
-| aps      | dictionary | Overrides to send to the push payload (`sound`, `alert`, `badge`, `thread-id`)               |
-| any      | any        | Any other key values to send as part of the push message                                     |
+| Property | Type       | Description                                                                                                    |
+| -------- | ---------- | -------------------------------------------------------------------------------------------------------------- |
+| headers  | dictionary | APNS specific headers (`apns-priority`, `apns-expiration`, `apns-push-type`, `apns-topic`, `apns-collapse-id`) |
+| aps      | dictionary | Overrides to send to the push payload (`sound`, `alert`, `badge`, `thread-id`)                                 |
+| any      | any        | Any other key values to send as part of the push message                                                       |
 
 ## Channel data requirements
 


### PR DESCRIPTION
### Description

Mentions new support for `apns-push-type` as an override

### Tasks
[KNO-2738](https://linear.app/knock/issue/KNO-2738)

