### PR TITLE
chore(kno-2819): remove Knock Tracking beta callouts

### DIFF
--- a/pages/send-and-manage-data/messages.md
+++ b/pages/send-and-manage-data/messages.md
@@ -5,8 +5,6 @@ tags: ["messages", "workflows"]
 section: Send & manage data
 ---
 
-import Callout from "../../components/Callout";
-
 ## An overview
 
 A Message in Knock represents a notification delivered to a [User](/send-and-manage-data/users) or an [Object](/send-and-manage-data/objects) on a particular channel. This is the core Knock data entity that your recipients will interact with when receiving notifications.
@@ -32,19 +30,6 @@ Knock captures changes in message status as events that can be sent to [outbound
 To learn more, see our [message statuses guide](/send-notifications/message-statuses).
 
 ## Link and open tracking
-
-<Callout
-  emoji="🚧"
-  text={
-    <>
-      <span className="font-bold">Knock tracking is currently in beta.</span> If you'd like early access please{" "}
-      <a href="mailto:support@knock.app?subject=Knock tracking">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
 
 Knock provides opt-in, provider agnostic tracking capabilities for your notifications. With link tracking, Knock will capture link-click actions by your recipients as a message event. With open tracking, Knock will embed tracking pixels in email channel messages to help gauge when recipients are opening and reading your email notifications.
 

--- a/pages/send-notifications/tracking.mdx
+++ b/pages/send-notifications/tracking.mdx
@@ -5,8 +5,6 @@ tags: ["link tracking", "open tracking", "open rates", "link clicks"]
 section: Send notifications
 ---
 
-import Callout from "../../components/Callout";
-
 ## Overview
 
 Knock provides opt-in, provider-agnostic tracking capabilities for your notifications. These are:
@@ -19,19 +17,6 @@ Many of the providers Knock integrates with offer their own versions of open and
 With Knock tracking, you get the same features with cross-channel tracking events surfaced as first-class entities in a single place: your Knock account.
 
 ### Availability
-
-<Callout
-  emoji="🚧"
-  text={
-    <>
-      <span className="font-bold">Knock tracking is currently in beta.</span> If you'd like early access please{" "}
-      <a href="mailto:support@knock.app?subject=Knock tracking">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
 
 <table>
   <thead>


### PR DESCRIPTION
### Description

Remove all callouts marking Knock Tracking as a beta feature.

### Tasks

[KNO-2819](https://linear.app/knock/issue/KNO-2819/remove-knock-tracking-beta-notes-in-docs)
