### PR TITLE
fix(kno-2868): explain multiline env vars

### DIFF
--- a/pages/in-app-ui/security-and-authentication.mdx
+++ b/pages/in-app-ui/security-and-authentication.mdx
@@ -5,8 +5,6 @@ section: Building in-app UI
 tags: ["jwt", "signing keys", "missing_user_token", "user token"]
 ---
 
-import Callout from "../../components/Callout";
-
 Authentication ensures your users can securely access the Knock API from your client
 applications, without you exposing your secret API key and allowing blanket
 access.


### PR DESCRIPTION
### Description

Some customers have had trouble working with our multi-line private keys and environment variables. This takes a few different forms, but showing an example in the docs seems like a good way to help customers clear this hurdle.

### Tasks
[KNO-2868](https://linear.app/knock/issue/KNO-2868)

### Screenshots
<img width="1214" alt="image" src="https://user-images.githubusercontent.com/45031/214110395-789d960f-026c-41eb-ae7d-4a8f8bac5d39.png">
