### PR TITLE
fix(kno-2923): http -> https for all links

### DIFF
--- a/pages/getting-started/example-app.md
+++ b/pages/getting-started/example-app.md
@@ -11,7 +11,7 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
 
 Learn more about integrating Knock into your web application to power in-app notification feed and toast experiences using our [React example app](https://github.com/knocklabs/in-app-notifications-example-nextjs), written in Next.js.
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 ## Node.js example app
 

--- a/pages/in-app-ui/overview.mdx
+++ b/pages/in-app-ui/overview.mdx
@@ -8,7 +8,7 @@ In addition to delivering to out-of-app channels such as email, push, SMS, and c
 
 You can use our in-app feed channel to build stateful, in-app notifications experiences like floating feeds, inboxes, toasts and banners, and you can use our preferences API to build powerful user-facing preference controls.
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 ## Why build in-app experiences on Knock?
 

--- a/pages/in-app-ui/react/feed.mdx
+++ b/pages/in-app-ui/react/feed.mdx
@@ -7,7 +7,7 @@ section: Building in-app UI
 
 Our `@knocklabs/react-notification-feed` library comes pre-built with a real-time feed component that you can drop into your application. In this guide, you'll find common recipes to help you work with the Knock feed component.
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 **Quick links**:
 

--- a/pages/in-app-ui/react/overview.mdx
+++ b/pages/in-app-ui/react/overview.mdx
@@ -8,7 +8,7 @@ Our [`@knocklabs/react-notification-feed`](https://github.com/knocklabs/react-no
 
 The React library is built on-top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency.
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 **You can also use the library to build:**
 

--- a/pages/in-app-ui/react/toasts.mdx
+++ b/pages/in-app-ui/react/toasts.mdx
@@ -6,7 +6,7 @@ section: Building in-app UI
 
 While there are no out-of-the-box components in the `@knocklabs/react-notification-feed` library, it's easy to build toasts on top of the primitives exposed. In this guide, we'll show you just how to do that using the `react-hot-toasts` library as our "toaster".
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 ## Getting started
 

--- a/pages/integrations/in-app/overview.mdx
+++ b/pages/integrations/in-app/overview.mdx
@@ -10,7 +10,7 @@ In addition to delivering to out-of-app channels such as email, push, SMS, and c
 
 You can use our in-app feed channel to build stateful, in-app notifications experiences like floating feeds, inboxes, toasts and banners, and you can use our preferences API to build powerful user-facing preference controls. You can also use [Knock link tracking](/send-notifications/tracking) to capture link-click events right within your Knock account.
 
-[See a live demo](http://knock-in-app-notifications-react.vercel.app/)
+[See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 ## Supported providers
 


### PR DESCRIPTION
### Description
I noticed we don't use HTTP on all our links. Now we do.

### Tasks
[KNO-2923](https://linear.app/knock/issue/KNO-2923)

