### PR TITLE
fix: remove single quotes

### DIFF
--- a/pages/in-app-ui/security-and-authentication.mdx
+++ b/pages/in-app-ui/security-and-authentication.mdx
@@ -147,7 +147,7 @@ wrap your signing key in JSON:
       
 ```javascript
 // .env.local
-KNOCK_SIGNING_KEY='{"key": "-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBA....\n-----END RSA PRIVATE KEY-----\n"}'
+KNOCK_SIGNING_KEY={"key": "-----BEGIN RSA PRIVATE KEY-----\nMIIJKgIBA....\n-----END RSA PRIVATE KEY-----\n"}
 
 /// In your app when you sign your JWT...
 const jwt = require("jsonwebtoken");


### PR DESCRIPTION
### Description
It doesn't seem that the single quotes are necessary, and in one case it confused a customer working with Vercel.


