### PR TITLE
chore(kno-2929): remove template variant references from docs

### DIFF
--- a/pages/designing-workflows/template-editor.mdx
+++ b/pages/designing-workflows/template-editor.mdx
@@ -112,23 +112,18 @@ To learn more about the variables, Liquid keywords, and other helper functions a
 
 The Knock template editor includes a visual editor you can use to compose your template with drag and drop components.
 
-
 <Callout
   emoji="🛣"
   text={
     <>
-      <span className="font-bold">Note: </span>The visual template editor is currently only available for email templates. 
+      <span className="font-bold">Note: </span>The visual template editor is currently only available for email templates.
     </>
   }
 />
 
-When you're in the visual template editor you'll see a **Components** panel on the right with a number of components for use in your template. 
+When you're in the visual template editor you'll see a **Components** panel on the right with a number of components for use in your template.
 
 Once you add a new component to the document, the Components pane will automatically switch to **Inspect** mode, where you can edit various attributes of the newly added component. While in inspect mode, you can remove the component by clicking the `x` icon in the top-right corner of the component or access additional menu items from the Inspect pane header.
-
-<video width="100%" class="mb-12" autoPlay loop muted playsInline>
-  <source src="/videos/visual-template-editor.mp4" type="video/mp4" />
-</video>
 
 As a reminder, **you still have full access to the variables data as well as liquid tags** when editing any of the text content fields of any components. The visual template editor makes it easier to introduce elements into your notification template while still giving you the full flexibility and power of code.
 
@@ -141,13 +136,16 @@ A few other component features to note:
 If you ever want to take complete control of the notification template and just work in HTML and CSS, you can enter the code editor via the "Enter code editor" button found at the bottom of the editor. When opting out of the visual template editor, any components used in the template document will be translated into the equivalent HTML for you to take over.
 
 ### Updating component styles
+
 When using the visual template editor, a handful of CSS styles are auto-generated and included in the email layout to provide base styles for certain components. If you want to globally configure these component styles to match your design system, you can do so by updating your email layout to override the base styles we generate for components. You can learn more about updating base component styles in email layouts [here](/integrations/email/layouts#updating-base-component-styles).
 
 <Callout
   emoji="🚨"
   text={
     <>
-      <span className="font-bold">Reminder: </span>The visual template editor will only render component styles when you are in preview mode. Your layout (and its styles) is not rendered in editor mode.
+      <span className="font-bold">Reminder: </span>The visual template editor
+      will only render component styles when you are in preview mode. Your
+      layout (and its styles) is not rendered in editor mode.
     </>
   }
 />
@@ -161,35 +159,3 @@ Your notification preview is populated with the data available in the lefthand v
 To test your notification, click "Save" and navigate back to the workflow canvas by clicking the back arrow in the top-left corner. You can run actual notification tests by clicking "Run a test" in the top-right corner. Just choose your actor and recipient, provide and trigger call data that you'd like included in your test, and click "Run test".
 
 All test runner notifications are tracked under "Messages" and have a source of "Test runner" to distinguish them from notifications you've triggered via the Knock API.
-
-## Using template variants
-
-Template variants are useful when you want to manage multiple templates within a single channel step, where the template used at workflow runtime is defined via a condition (for example: `recipient.locale` is equal to `es`). 
-
-The primary use case for template variants is localization, but you can also use your own custom template variant conditions to power other use cases (such as creating variants of a given template for certain `tenants`).
-
-<Callout
-  emoji="✨"
-  text={
-    <>
-      <span className="font-bold">Growth plan feature.</span> Template variants are a beta feature available on the Growth plan. 
-      <br />
-      <br /> If you're interested in trying this functionality, please shoot us a
-      note at <a href="mailto:support@knock.app">support@knock.app</a>.
-    </>
-  }
-/>
-
-### Powering localization with template variants
-
-Before you start creating your locale-specific template variants, you need to make sure that you're passing a `locale` key on your identify calls to Knock. We use the `locale` property on your [Knock users schema](/send-and-manage-data/users) to evaluate which template variant we should send to a given recipient. Once your users have a `locale` property in place, you're ready to start creating locale-specific template variants. 
-
-When you get into the template editor, you'll notice that the first is always called "Default". This template will be sent to any recipients without a `locale` or with a `locale` that doesn't map to any of the template variants you've created. 
-
-To add a new template variant for a specific locale, click the plus button next to the "Default" tab. You'll be prompted to select a locale for your new variant. Once your variant is created, you can start writing your template in the language that corresponds to that locale.
-
-If a variant already has visual elements you'd like to duplicate, you can select "Duplicate variant" from the three-dot menu in the tab header. Keep in mind you'll still have to alter the text to what you'd like it to be, but the entire message contents will be copied to the variant locale you select.
-
-### Powering custom template variants
-
-In addition to locale-specific variants, you can create your own custom variants that will evaluate against any condition logic you'd like. This feature is currently in development but if you're interested in participating in the beta please send us a note at <a href="mailto:support@knock.app">support@knock.app</a>.

--- a/pages/integrations/email/attachments.mdx
+++ b/pages/integrations/email/attachments.mdx
@@ -9,7 +9,7 @@ import MultiLangCodeBlock from "../../../components/MultiLangCodeBlock";
 
 ## How attachments work in Knock
 
-1. Set an attachment key in your email template to tell Knock how to resolve attachments you send in the data payload of your trigger call. To set an attachment key, click the "..." menu in the top right corner of the email template editor.
+1. Set an attachment key in your email template to tell Knock how to resolve attachments you send in the data payload of your trigger call. To set an attachment key, click the "Manage template settings" menu in the top right corner of the email template editor and set it under the "Attachment key" field.
 2. Include one or more attachment objects in the `data` payload of your trigger call. Each attachment object should have the content of the file to be attached as a base64 encoded value.
 3. Knock automatically adds any attachments included in the attachment key of your trigger call to the emails sent by your email provider 🎉.
 

--- a/pages/integrations/push/overview.mdx
+++ b/pages/integrations/push/overview.mdx
@@ -29,7 +29,7 @@ Channel groups are currently enabled on an on-demand basis. If you'd like it ena
 
 ## Push overrides
 
-For push-specific sending needs, a set of overrides can be set per template. The overrides provided are merged into the push payload sent to the underlying provider and can be used to set badge counts, custom sound files, and any other provider-specific settings.
+For push-specific sending needs, a set of overrides can be set per template from the "Manage template settings" button on the push message template page. The overrides provided are merged into the push payload sent to the underlying provider and can be used to set badge counts, custom sound files, and any other provider-specific settings.
 
 ## Supported providers
 


### PR DESCRIPTION
### Description
Remove references to template variants from the docs and update portions that reference old UI.
You can see the video I removed here: https://docs.knock.app/designing-workflows/template-editor#visual-editing-with-drag-and-drop-components

I didn't think it was super necessary? And it showcases the old UI. We can remake if necessary but I think it's probably good to not have too many videos/screenshots that get stale in our docs if we can help it, and this is pretty self-explanatory.

### Tasks
[KNO-2929](https://linear.app/knock/issue/KNO-2929/rewind-template-loc-in-docs)