### PR TITLE
feat(KNO-2968): Add cmd + k keyboard support

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -117,7 +117,7 @@ const Autocomplete = () => {
     [],
   );
 
-  useHotkeys("/", (e) => {
+  useHotkeys("/, cmd+k", (e) => {
     // adding small timeout so event doesn't get to the focused input resulting
     // in "/" being displayed on the input
     e.preventDefault();


### PR DESCRIPTION
### Description
Currently we only allow `/`  as a shortcut for docs search, this PR adds `cmd + k`  as well

### Tasks
[KNO-2969](https://linear.app/knock/issue/KNO-2968/[docs]-add-cmd-k-keyboard-support-for-focussing-on-search)
