### PR TITLE
crosslink segment docs

### DIFF
--- a/pages/integrations/extensions/segment.mdx
+++ b/pages/integrations/extensions/segment.mdx
@@ -1,5 +1,5 @@
 ---
-title: Connecting Knock to your Segment account
+title: How to send Knock data to Segment
 description: Learn more about how to connect Knock with your Segment account.
 layout: integrations
 tags: ["segment", "extensions"]
@@ -9,9 +9,11 @@ section: Integrations > Extensions
 import Table from "../../../components/Table";
 import Callout from "../../../components/Callout"
 
-You can use our Segment extension to send Knock's normalized notification data into [Segment](https://segment.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
+This guide covers how to use our Segment extension to send Knock's normalized notification data into [Segment](https://segment.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
 
 Once the extension is enabled, Knock automatically passes a stream of track events to Segment (e.g. "Notification delivered", "Notification seen", "Notification read") which you can then use in your downstream tools.
+
+Knock also provides a separate integration for using Segment as a [Knock source](/integrations/sources/overview) to bring track and identify event data from Segment into Knock to power your notifications. You can learn more in our [Segment source docs](/integrations/sources/segment).
 
 <Callout
   emoji="✨"

--- a/pages/integrations/sources/segment.mdx
+++ b/pages/integrations/sources/segment.mdx
@@ -1,5 +1,5 @@
 ---
-title: How to integrate Segment to Knock
+title: How to use Segment events to power Knock
 description: Learn how to connect your Segment events to Knock to power your product notifications.
 section: Integrations > Sources
 layout: integrations
@@ -9,30 +9,18 @@ import Callout from "../../../components/Callout";
 import Image from "next/image";
 import eventPayload from "../../../data/code/sources/eventPayload";
 
-## Video walkthrough
 
-<div style={{ position: "relative", paddingBottom: "56.25%", height: 0 }}>
-  <iframe
-    src="https://www.loom.com/embed/42721f4bed1a4180821acd9530155cc7"
-    frameBorder="0"
-    allowFullscreen
-    style={{
-      position: "absolute",
-      top: 0,
-      left: 0,
-      width: "100%",
-      height: "100%",
-    }}
-  ></iframe>
-</div>
+This guide covers using Segment as a [Knock source](/integrations/sources/overview) to bring track and identify event data from Segment into Knock to power your notifications. 
+
+Knock also provides a separate [Segment extension](/integrations/extensions/segment) for sending Knock notification data into Segment for use in your downstream tools.
 
 ## Getting started
 
-Knock is a **Segment Destination**, which means you can use events coming through Segment to power actions in Knock, such as triggering a workflow.
+When using Segment as a Knock source, you also need to configure Knock as a **Destination** within Segment. This means you can use events coming through Segment to power actions in Knock, such as triggering a workflow.
 
-You can start routing your Segment events to Knock by creating a source of type "Segment" in the dashboard. From here, you'll be taken to the environment configuration page for the source which will give you unique URLs for each environment you have configured in Knock.
+You can start routing your Segment events to Knock by creating a source of type "Segment" in the Knock dashboard. From here, you'll be taken to the environment configuration page for the source which will give you unique URLs for each environment you have configured in Knock.
 
-## Configuring Segment
+## Configure a Knock destination in Segment
 
 <Callout
   emoji="✨"
@@ -40,7 +28,7 @@ You can start routing your Segment events to Knock by creating a source of type 
     <>
       <span className="font-bold">Use webhooks to connect to Knock.</span> Knock
       does not have a first-party integration with Segment, so you will not find
-      us in the list of destinations. Instead, you'll configure the connection
+      us in Segment's destination catalog. Instead, you'll configure the connection
       to Knock via a webhook destination as described below.
     </>
   }
@@ -108,10 +96,27 @@ Event action configurations are stored in the commit history, just like workflow
 
 Actions are automatically enabled when you create them. If you want to stop an event from triggering an action, you can go to the action page and toggle its status to "Inactive". Keep in mind that this will disable that action for the current environment only. When you're ready to trigger the action again, you can set it back to "Active".
 
-## Enabling Identify Events
+## Enabling Identify events
 
 When Segment sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `id`, `email`, `phone`, `avatar`, `name`, and any other custom properties over.
 
 To enable handling of identify events, open the settings for the source in the environment. You can then enable or disable handling identify events accordingly.
 
 ![A screenshot of how to toggle Knock handling Segment identify calls](/images/sources/segment-identify.png)
+
+## Video walkthrough
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0 }}>
+  <iframe
+    src="https://www.loom.com/embed/42721f4bed1a4180821acd9530155cc7"
+    frameBorder="0"
+    allowFullscreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
+</div>


### PR DESCRIPTION
- add cross references b/w source and extension pages. 
- also renamed to try to make it clearer as to what each page is about