### PR TITLE
fix(kno-3027): broken slack links

### DIFF
--- a/pages/integrations/chat/slack/how-knock-slacks.mdx
+++ b/pages/integrations/chat/slack/how-knock-slacks.mdx
@@ -16,7 +16,7 @@ In this guide we'll provide an overview of how Knock sends notifications to Slac
 
 Here's a list of terms and concepts we'll be referencing throughout our Slack guides.
 
-- **Slack app.** The Slack app you configure within the Slack API platform. This is sometimes referred to as a Slack bot but we'll be using the term "Slack app" throughout this documentation. This is what your customers install into their own Slack workspace during the [Slack OAuth flow](/slack/building-oauth-flow) you start from within your product.
+- **Slack app.** The Slack app you configure within the Slack API platform. This is sometimes referred to as a Slack bot but we'll be using the term "Slack app" throughout this documentation. This is what your customers install into their own Slack workspace during the [Slack OAuth flow](/integrations/chat/slack/building-oauth-flow) you start from within your product.
 - **Knock channel.** The channel you configure _within_ the Knock dashboard. You'll use the `id` of this channel when you store `channel data` on your `users` or `objects` in Knock.
 - **Slack channel.** A channel in your customer's Slack workspace that you want to notify. "Channel" is an overloaded term between Knock and Slack, so we'll always refer to channels that live within Slack as "Slack channels". Note that this can refer to a public channel, a private channel, or even a user DM channel.
 - **Channel data.** The connection data received from the Slack OAuth handshake, either an incoming webhook URL or an access token. You store this data on `users` and/or `objects` in Knock so we know where to send a Slack notification for a given recipient.

--- a/pages/integrations/chat/slack/slack-apps-and-scopes.mdx
+++ b/pages/integrations/chat/slack/slack-apps-and-scopes.mdx
@@ -49,7 +49,7 @@ Take the Linear example below. Under “Team notification” I can see a record 
 
 ![An example of multiple Slack OAuth points in Linear](/images/linear-slack-start-oauth-flow.png)
 
-We get into more detail how to support these use cases using Knock in [our Slack examples page](/slack/slack-examples).
+We get into more detail how to support these use cases using Knock in [our Slack examples page](/integrations/chat/slack/slack-examples).
 
 ### Advanced use cases: access tokens and all other scopes
 

--- a/pages/integrations/chat/slack/slack-interactivity.mdx
+++ b/pages/integrations/chat/slack/slack-interactivity.mdx
@@ -20,7 +20,7 @@ If you're brand new to building Slack interactive notifications, this [Slack gui
 
 ## Designing interactive Slack notification templates
 
-To build an interactive Slack message, whether it contains a button, a dropdown, or some other input, you'll be using Slack's block kit UI framework. We cover how to build block-based Slack notifications within Knock in [our guide on designing Slack templates](/slack/designing-slack-templates).
+To build an interactive Slack message, whether it contains a button, a dropdown, or some other input, you'll be using Slack's block kit UI framework. We cover how to build block-based Slack notifications within Knock in [our guide on designing Slack templates](/integrations/chat/slack/designing-slack-templates).
 
 ## Handling interaction payloads from Slack
 


### PR DESCRIPTION
### Description
A customer noticed these broken links. This fixes that.


### Tasks
[KNO-3027](https://linear.app/knock/issue/KNO-3027)

