### PR TITLE
update feed id references for in app docs

### DIFF
--- a/pages/in-app-ui/react/custom-notifications-ui.mdx
+++ b/pages/in-app-ui/react/custom-notifications-ui.mdx
@@ -4,6 +4,8 @@ description: How to build custom notifications UI powered by Knock and React.
 section: Building in-app UI
 ---
 
+import Callout from "../../../components/Callout";
+
 Using our `@knocklabs/react-notification-feed` and `@knocklabs/client` libraries, you can create fully custom notification UIs that are backed by the Knock Feed API and Websockets to receive and process real-time notifications in your web application.
 
 In this guide, we'll take a look at creating a completely custom notifications page in our application.
@@ -14,6 +16,17 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 
 - A public API key for the Knock environment (set as `KNOCK_PUBLIC_API_KEY`)
 - The channel ID for the in-app feed (set as `KNOCK_FEED_CHANNEL_ID`)
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Find your channel ID.</span> To find the channel ID for your in-app channel(s),
+      go to "Integrations > Channels" in the Knock
+      dashboard, navigate to the channel page of your in-app channel, and copy the channel ID.
+    </>
+  }
+/>
 
 ## Installing dependencies
 

--- a/pages/in-app-ui/react/feed.mdx
+++ b/pages/in-app-ui/react/feed.mdx
@@ -5,6 +5,8 @@ tags: ["inbox", "feeds", "toasts"]
 section: Building in-app UI
 ---
 
+import Callout from "../../../components/Callout";
+
 Our `@knocklabs/react-notification-feed` library comes pre-built with a real-time feed component that you can drop into your application. In this guide, you'll find common recipes to help you work with the Knock feed component.
 
 [See a live demo](https://knock-in-app-notifications-react.vercel.app/)
@@ -20,6 +22,17 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 
 - A public API key for the Knock environment (set as `KNOCK_PUBLIC_API_KEY`)
 - The channel ID for the in-app feed (set as `KNOCK_FEED_CHANNEL_ID`)
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Find your channel ID.</span> To find the channel ID for your in-app channel(s),
+      go to "Integrations > Channels" in the Knock
+      dashboard, navigate to the channel page of your in-app channel, and copy the channel ID.
+    </>
+  }
+/>
 
 ## Installing dependencies
 
@@ -49,7 +62,7 @@ const YourAppLayout = () => {
   return (
     <KnockFeedProvider
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-      feedId={process.env.KNOCK_FEED_ID}
+      feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={currentUser.id}
     >
       <>

--- a/pages/in-app-ui/react/inbox.mdx
+++ b/pages/in-app-ui/react/inbox.mdx
@@ -4,6 +4,8 @@ description: How to build notification inboxes powered by Knock and React.
 section: Building in-app UI
 ---
 
+import Callout from "../../../components/Callout";
+
 Our `@knocklabs/react-notification-feed` library can be used to build full-page inbox experiences, too. In this guide we'll show you how to have a basic inbox ready for your users in a few minutes.
 
 ## Getting started
@@ -12,6 +14,17 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 
 - A public API key for the Knock environment (set as `KNOCK_PUBLIC_API_KEY`)
 - The channel ID for the in-app feed (set as `KNOCK_FEED_CHANNEL_ID`)
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Find your channel ID.</span> To find the channel ID for your in-app channel(s),
+      go to "Integrations > Channels" in the Knock
+      dashboard, navigate to the channel page of your in-app channel, and copy the channel ID.
+    </>
+  }
+/>
 
 ## Installing dependencies
 

--- a/pages/in-app-ui/react/reference.mdx
+++ b/pages/in-app-ui/react/reference.mdx
@@ -317,7 +317,7 @@ const MyComponent = () => {
     user.knockToken,
   );
 
-  const notificationFeed = useNotifications(knock, process.env.KNOCK_FEED_ID);
+  const notificationFeed = useNotifications(knock, process.env.KNOCK_FEED_CHANNEL_ID);
 
   const useNotificationStore = create(notificationFeed.store);
   const { metadata } = useNotificationStore();

--- a/pages/in-app-ui/react/toasts.mdx
+++ b/pages/in-app-ui/react/toasts.mdx
@@ -4,6 +4,8 @@ description: How to build notification toasts powered by Knock and React.
 section: Building in-app UI
 ---
 
+import Callout from "../../../components/Callout";
+
 While there are no out-of-the-box components in the `@knocklabs/react-notification-feed` library, it's easy to build toasts on top of the primitives exposed. In this guide, we'll show you just how to do that using the `react-hot-toasts` library as our "toaster".
 
 [See a live demo](https://knock-in-app-notifications-react.vercel.app/)
@@ -14,6 +16,17 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 
 - A public API key for the Knock environment (set as `KNOCK_PUBLIC_API_KEY`)
 - The channel ID for the in-app feed (set as `KNOCK_FEED_CHANNEL_ID`)
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Find your channel ID.</span> To find the channel ID for your in-app channel(s),
+      go to "Integrations > Channels" in the Knock
+      dashboard, navigate to the channel page of your in-app channel, and copy the channel ID.
+    </>
+  }
+/>
 
 ## Installing dependencies
 

--- a/pages/in-app-ui/security-and-authentication.mdx
+++ b/pages/in-app-ui/security-and-authentication.mdx
@@ -18,7 +18,7 @@ The following calls require authentication (when called from the client):
 
 - Fetching a user's notification feed
 - Marking a message as read, seen, or archived
-- Getting or setting a users preferences
+- Getting or setting a user's preferences
 
 ## Authentication (in development environments)
 

--- a/pages/send-and-manage-data/tenants.mdx
+++ b/pages/send-and-manage-data/tenants.mdx
@@ -48,7 +48,7 @@ to the tenant:
 import Knock from "@knocklabs/client";
 const knockClient = new Knock(process.env.KNOCK_PUBLIC_API_KEY);
 
-const feedClient = knockClient.feeds.initialize(process.env.KNOCK_FEED_ID, {
+const feedClient = knockClient.feeds.initialize(process.env.KNOCK_FEED_CHANNEL_ID, {
   // Scope all requests to the current workspace
   tenant: currentWorkspace.id,
 });
@@ -56,7 +56,7 @@ const feedClient = knockClient.feeds.initialize(process.env.KNOCK_FEED_ID, {
 // Or if you're using the React SDK:
 <KnockFeedProvider
   apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-  feedId={process.env.KNOCK_FEED_ID}
+  feedId={process.env.KNOCK_FEED_CHANNEL_ID}
   userId={currentUser.id}
   defaultFeedOptions={{ tenant: currentWorkspace.id }}
 >


### PR DESCRIPTION
- update references from KNOCK_FEED_ID to KNOCK_FEED_CHANNEL_ID
- add callouts to help readers understand where to find their knock channel ID