### PR TITLE
Add webhook channel docs back in

### DIFF
--- a/pages/integrations/webhook/overview.mdx
+++ b/pages/integrations/webhook/overview.mdx
@@ -10,6 +10,7 @@ import Callout from "../../../components/Callout"
 
 Learn more about how to use Knock webhook channels to send to custom destinations, build reusable fetch steps, and to power customer-facing webhooks within your own product.
 
+## Features and use cases
 You can use the Knock webhook channel type to build a custom channel that sends a webhook request to a configured endpoint. This endpoint can be static, or can be dynamically built using liquid variables during workflow run time. The Knock webhook channel supports PUT, POST, and GET requests, making it a flexible tool to use for a number of different use cases. 
 
 You might use the Knock webhook channel to...


### PR DESCRIPTION
When I shipped guide docs I forgot to pull latest main back in, which means I took the webhook channel docs out. 🤦  This fixes that. 