### PR TITLE
fix(kno-3571): clean up translation docs

### DIFF
--- a/pages/cli/index.mdx
+++ b/pages/cli/index.mdx
@@ -408,10 +408,12 @@ knock translation list
 </ExampleColumn>
 </Section>
 
-<Section title="knock translation pull <locale> [flags]" slug="translation-pull" headingClassName="font-mono">
+<Section title="knock translation pull <translation_reference or locale> [flags]" slug="translation-pull" headingClassName="font-mono">
 <ContentColumn>
 
-Pulls one or more translation files from Knock into the local, working directory. When `<locale>` is specified, only that locale's translations are pulled.
+Pulls one or more translation files from Knock into the local, working directory. The `<translation_reference>` is `namespace.locale`, i.e. `admin.en`. If a translation has no namespace, use the locale alone, i.e. `en`.
+
+When `<locale>` is specified with the `--all` flag, all translations for that locale are pulled.
 
 ### Flags
 
@@ -432,7 +434,10 @@ Pulls one or more translation files from Knock into the local, working directory
           false.
         </p>
         <p>
-          When used, all contents in the target directory will be erased and
+          When used with a locale, will only pull the translations for that locale.
+        </p>
+        <p>
+          Note: all contents in the target directory will be erased and
           replaced with all translations from the specified environment.
         </p>
       </>
@@ -448,17 +453,28 @@ Pulls one or more translation files from Knock into the local, working directory
 </ContentColumn>
 <ExampleColumn>
 
-```bash Basic usage
-knock translation pull
+```bash Pull a single translation without a namespace
+knock translation pull en
+```
+```bash Pull a single translation with a namespace
+knock translation pull admin.en
+```
+```bash Pull all translations for a locale
+knock translation pull en --all
+```
+```bash Pull all translations
+knock translation pull --all
 ```
 
 </ExampleColumn>
 </Section>
 
-<Section title="knock translation push <locale> [flags]" slug="translation-push" headingClassName="font-mono">
+<Section title="knock translation push <translation_reference or locale> [flags]" slug="translation-push" headingClassName="font-mono">
 <ContentColumn>
 
-Pushes local translation files back to Knock and upserts them. When `<locale>` is given, only the translation files in that locale's directory are pushed to Knock. Can only be pushed to the development environment.
+Pushes local translation files back to Knock and upserts them. The <translation_reference> is `namespace.locale`, i.e. `admin.en`. If a translation has no namespace, use the locale alone, i.e. `en`.
+
+When `<locale>` is given with the `--all` flag, all translations in that locale's directory are pushed to Knock. Can only be pushed to the development environment.
 
 ### Flags
 
@@ -483,16 +499,20 @@ Pushes local translation files back to Knock and upserts them. When `<locale>` i
 </ContentColumn>
 <ExampleColumn>
 
-```bash Basic usage
-knock translation push
+```bash Push a single translation without a namespace
+knock translation push en
 ```
 
-```bash Push all translation files
-knock translation push --all
+```bash Push a single translation with a namespace
+knock translation push tasks.en
 ```
 
 ```bash Push all translation files for the en locale
 knock translation push en --all
+```
+
+```bash Push all translation files
+knock translation push --all
 ```
 
 </ExampleColumn>

--- a/pages/mapi/index.mdx
+++ b/pages/mapi/index.mdx
@@ -862,7 +862,7 @@ An upserted workflow
 ```json Response
 // Success
 {
-  "workfow": {
+  "workflow": {
     "active": false,
     "created_at": "2023-02-02T02:52:36.054397Z",
     "environment": "development",
@@ -942,7 +942,7 @@ A validated workflow object, if valid. Note: some read-only fields will be empty
 ```json Response
 // Valid
 {
-  "workfow": {
+  "workflow": {
     "active": null,
     "created_at": null,
     "environment": "development",
@@ -1056,8 +1056,6 @@ Note: This immediately enables or disables a workflow in a given environment wit
 
 [Translations](/send-and-manage-data/translations) support localization in Knock. They hold the translated content for a given locale, which you can reference in your message templates with the `t` Liquid function filter.
 
-You can retrieve, update, or create a workflow as well as list all workflows in a given [environment](/send-and-manage-data/environments). Workflows are identified by its unique workflow key.
-
 You can retrieve, update, and create translations as well as listing all in a given [environment](/send-and-manage-data/environments). Translations are identified by their locale code + an optional namespace.
 
 </ContentColumn>
@@ -1147,7 +1145,7 @@ You can retrieve, update, and create translations as well as listing all in a gi
 <Section title="List all translations" slug="translations-list">
 <ContentColumn>
 
-Returns a paginated list of translations available in a given environment. The workflows are returned in alpha-sorted order by its locale code.
+Returns a paginated list of translations available in a given environment. The translations are returned in alpha-sorted order by locale code.
 
 ### Endpoint
 
@@ -1227,7 +1225,7 @@ A paginated list of translations
 <Section title="Get translations" slug="translations-get">
 <ContentColumn>
 
-Returns a paginated list of translations available in a given environment. The workflows are returned in alpha-sorted order by its locale code.
+Returns a paginated list of translations available in a given environment. The translations are returned in alpha-sorted order by locale code.
 
 ### Endpoint
 
@@ -1309,6 +1307,11 @@ Note: this endpoint only operates on translations in the “development” envir
 ### Query parameters
 
 <Attributes>
+  <Attribute
+    name="namespace"
+    type="string"
+    description="An optional namespace that identifies the translation."
+  />
   <Attribute
     name="commit"
     type="boolean"
@@ -1409,7 +1412,7 @@ A translation object
 <Section title="Commits" slug="commits-overview">
 <ContentColumn>
 
-To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow or a layout, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
+To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow, a layout, a translation or an event action mapping, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
 
 </ContentColumn>
 <ExampleColumn>


### PR DESCRIPTION
### Description
Cleans up the docs and adds additional instructions for how to target translations in pull and push. I hope these are clear but happy for suggestions on how to make it more obvious how to use these.

### Tasks
[KNO-3571](https://linear.app/knock/issue/KNO-3571/check-through-docs)