### PR TITLE
fix: datadog docs to not mention analytics

### DIFF
--- a/pages/integrations/extensions/datadog.mdx
+++ b/pages/integrations/extensions/datadog.mdx
@@ -14,8 +14,8 @@ import dashboardJson from "./datadog_dashboard.json"
 You can use the Knock + Datadog integration to stream workflow, channel, and message metrics from your Knock account to your Datadog account. With this you can:
 
 - Set up custom Datadog monitors and dashboards to track your Knock workflows & channels
-- Get up-to-the-minute data on messages being sent, opened, and archived
-- Monitor event ingestion from event platforms like [Segment](/integrations/sources/segment) and [Rudderstack](/integrations/sources/rudderstack)
+- Get up-to-the-minute data on workflows triggered and messages delivered
+- Monitor events ingested and actions triggered from event platforms like [Segment](/integrations/sources/segment) and [Rudderstack](/integrations/sources/rudderstack)
 
 ## What this integration does
 


### PR DESCRIPTION
### Description

[VidYard noted](https://knocklabs.slack.com/archives/C05A5SH8VFE/p1685732706032539) some inconsistencies between the paragraphs & the table showing the metrics published. This fixes that.

