### PR TITLE
fix: include feedClient instructions in custom feed example code

### DIFF
--- a/pages/in-app-ui/react/custom-notifications-ui.mdx
+++ b/pages/in-app-ui/react/custom-notifications-ui.mdx
@@ -62,8 +62,15 @@ In our notifications page, we'll use the store exposed by the `KnockFeedProvider
 
 ```jsx
 const NotificationsList = () => {
-  const { useFeedStore } = useKnockFeed();
+  const { feedClient, useFeedStore } = useKnockFeed();
   const items = useFeedStore((state) => state.items);
+
+  useEffect(() => {
+    // Once the feedClient is available, calling .fetch() will
+    // populate the feed. In the background, a websocket is
+    // opened that will receive new messages in real time.
+    feedClient.fetch();
+  }, [feedClient]);
 
   return (
     <div className="notifications">


### PR DESCRIPTION
### Description
Teikametrics used this sample code, but wondered why the feed wouldn't populate. It's because the feedClient needs to be called with `feedClient.fetch()`.

See [this thread](https://knocklabs.slack.com/archives/C0407L4PUTU/p1686334259461669)

### Tasks
N/A
