### PR TITLE
chore(kno-4062): segment on triggering workflows via events

### DIFF
--- a/pages/concepts/workflows.mdx
+++ b/pages/concepts/workflows.mdx
@@ -93,7 +93,7 @@ Workflows defined in Knock are executed via trigger, which starts a workflow run
 In Knock, workflows can be triggered in three different ways:
 
 - **API call**: workflows can be [triggered directly via an API call](/send-notifications/triggering-workflows) to our workflow trigger endpoint. This is the most common form of integration and means that Knock is integrated into your backend codebase, usually alongside your application logic.
-- **Events**: using different [event sources](/concepts/), you can connect Knock to CDPs such as Segment and Rudderstack and map the events those systems produce to workflows that should be triggered.
+- **Events**: using different [event sources](/integrations/sources/overview/), you can connect Knock to CDPs such as Segment and Rudderstack and map the events those systems produce to workflows that should be triggered.
 - **Schedules**: [workflows can be scheduled](/concepts/schedules) to be run for one or more recipients, in a recipient's local timezone on a one-off, or recurring basis.
 
 ### Canceling a workflow run

--- a/pages/send-notifications/triggering-workflows.mdx
+++ b/pages/send-notifications/triggering-workflows.mdx
@@ -209,3 +209,11 @@ You may also wish to fan out a workflow trigger to all [subscribers of an object
 Schedules allow you to express complex repeating schedules for your workflow triggers, so that you can trigger workflows on a one-off or a recurring basis for one or more recipients. You can think of a schedule as a managed, recipient-timezone-aware cron job that Knock will run on your behalf.
 
 [Learn more about schedules](/send-and-manage-data/schedules)
+
+## Triggering workflows via source events
+
+When you connect source to Knock from a customer data platform like [Segment](/integrations/sources/segment), you'll be able to use the events Knock receives to trigger workflows. You can create and manage event triggers for your workflows in the "Sources" section (under "Developers" in the sidebar) or directly from the workflow builder when you click the "Trigger" step.
+
+From the Trigger step sidebar, if you have events connected to Knock you'll see the option to switch the trigger type to "Event" from the dropdown menu. Once here, you can select an event that when received will trigger this workflow. You can also map the critical fields needed to run a workflow to the fields that will be in the incoming event payload.
+
+[Learn more about sources](/integrations/sources/overview)


### PR DESCRIPTION
### Description
Adding a small section on triggering workflows via events. I think this is useful to include - not sure if we should add it somewhere else as well or if this has the right level of detail.

Also small fix for a broken link.

### Tasks
[KNO-4062](https://linear.app/knock/issue/KNO-4062/docs)