### PR TITLE
fix(KNO-4217): Fix variables links

### DIFF
--- a/pages/designing-workflows/template-editor/overview.mdx
+++ b/pages/designing-workflows/template-editor/overview.mdx
@@ -45,7 +45,7 @@ We'll cover:
 
 To inject a variable into your notification template, enclose it with double curly braces: `{{ a_variable }}`.
 
-You can use curly braces to reference a number of different variable types in your templates. We've included a few common types below. You can find the [full list of supported variables here](/designing-workflows/references/variables).
+You can use curly braces to reference a number of different variable types in your templates. We've included a few common types below. You can find the [full list of supported variables here](/designing-workflows/template-editor/variables).
 
 **Date payload variables.** All variables sent in the `data` payload of your workflow trigger call. These don't require a prefixed namespace to reference, so if you send through `{ "a_variable": "something" }` in your data payload you can reference this as `{{ a_variable }}` in your template.
 
@@ -60,7 +60,7 @@ Thanks,
 The team @ Knock
 ```
 
-[Full list of Knock variables available →](/designing-workflows/references/variables)
+[Full list of Knock variables available →](/designing-workflows/template-editor/variables)
 
 ## Adding control flow and iteration to your template
 


### PR DESCRIPTION
### Description
These links were calling to `/designing-workflows/references/variables`, file that does not exists.
The correct file for this is:  `/designing-workflows/template-editor/variables`

### Tasks
[KNO-4127]([KNO-4217 : \[Docs\] Fix designing workflows variables link](https://linear.app/knock/issue/KNO-4217/[docs]-fix-designing-workflows-variables-link))

