### PR TITLE
chore(kno-4294): update set prefs docs

### DIFF
--- a/pages/reference/index.mdx
+++ b/pages/reference/index.mdx
@@ -1476,11 +1476,11 @@ Returns a `PreferenceSet`.
 <Section title="Setting user preferences" slug="set-preferences-user">
 <ContentColumn>
 
-Sets preferences within the given preference set. This is a destructive operation and
-will replace any existing preferences with the preferences given.
+Sets preferences within the given preference set. This is a destructive operation and will replace any existing preferences with the preferences given.
 
-The preference set `id` can
-be either `default` or a `tenant.id`. Learn more about per-tenant preference sets in [our preferences guide](/send-and-manage-data/preferences#preference-sets).
+If no user exists in the current environment for the given `:user_id`, Knock will create the user entry as part of this request.
+
+The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about per-tenant preference sets in [our preferences guide](/send-and-manage-data/preferences#preference-sets).
 
 ### Endpoint
 
@@ -1728,11 +1728,11 @@ Returns a `PreferenceSet`.
 <Section title="Setting object preferences" slug="set-preferences-object">
 <ContentColumn>
 
-Sets preferences within the given preference set. This is a destructive operation and
-will replace any existing preferences with the preferences given.
+Sets preferences within the given preference set. This is a destructive operation and will replace any existing preferences with the preferences given.
 
-The preference set `id` can
-be either `default` or a `tenant.id`. Learn more about per-tenant preference sets in [our preferences guide](/send-and-manage-data/preferences#preference-sets).
+If no object exists in the current environment for the given `:collection` and `:object_id`, Knock will create the object as part of this request.
+
+The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about per-tenant preference sets in [our preferences guide](/send-and-manage-data/preferences#preference-sets).
 
 ### Endpoint
 


### PR DESCRIPTION
### Description

Add note indicating that we implicitly create a missing user or object when handling set preferences API calls.

### Tasks

[KNO-4294 : \[Switchboard\] Relax user/object preference setting to allow non-existent recipients](https://linear.app/knock/issue/KNO-4294/[switchboard]-relax-userobject-preference-setting-to-allow-non)