### PR TITLE
feat(KNO-4321): Add  "recipient.schedule" properties in variables section

### DIFF
--- a/pages/designing-workflows/template-editor/variables.mdx
+++ b/pages/designing-workflows/template-editor/variables.mdx
@@ -39,16 +39,16 @@ When you build workflows in Knock, we auto-generate certain pieces of state (as 
 
 A serialized `User` or `Object`. The properties available are:
 
-| Variable       | Description                                                                                                                                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `__typename`   | Either `User` or `Object`                                                                                                                                     |
-| `id`           | The id of the recipient                                                                                                                                       |
-| `collection`   | The collection of the object (only set for `Object` recipients)                                                                                               |
-| `*`            | Any custom properties set                                                                                                                                     |
-| `created_at`   | A datetime field for when the recipient was created (if set)                                                                                                  |
-| `updated_at`   | A datetime field for when the recipient was last updated                                                                                                      |
-| `subscription` | An optional set of properties set on a `subscription`. Only available when a workflow is triggered via a [Subscription](/send-and-manage-data/subscriptions). |
-| `schedule`     | A serialized `Schedule` including the `id`, `last_occurrence_at`, and `next_occurrence_at` of the schedule. Only available when a workflow is triggered via a [Schedule](/concepts/schedules).                                       |
+| Variable       | Description                                                                                                                                                                                    |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `__typename`   | Either `User` or `Object`                                                                                                                                                                      |
+| `id`           | The id of the recipient                                                                                                                                                                        |
+| `collection`   | The collection of the object (only set for `Object` recipients)                                                                                                                                |
+| `*`            | Any custom properties set                                                                                                                                                                      |
+| `created_at`   | A datetime field for when the recipient was created (if set)                                                                                                                                   |
+| `updated_at`   | A datetime field for when the recipient was last updated                                                                                                                                       |
+| `subscription` | An optional set of properties set on a `subscription`. Only available when a workflow is triggered via a [Subscription](/send-and-manage-data/subscriptions).                                  |
+| `schedule`     | A serialized `Schedule` including the `id`, `last_occurrence_at`, and `next_occurrence_at` of the schedule. Only available when a workflow is triggered via a [Schedule](/concepts/schedules). |
 
 ### Activity
 


### PR DESCRIPTION
### Description
Now we expose `schedule` properties under the `recipient` variable, so this PR indicates this in the docs.

### Tasks
[KNO-4321](https://linear.app/knock/issue/KNO-4321/[docs]-adds-recipientschedule-in-variables-section)

### Screenshots
![Screen Shot 2023-09-19 at 12 58 22](https://github.com/knocklabs/docs/assets/67347884/43f472fc-ae57-411d-a386-13ad2c01e498)



