### PR TITLE
fix(kno-4377): custom throttle keys must be shorter than 64 characters long

### DIFF
--- a/pages/designing-workflows/throttle-function.mdx
+++ b/pages/designing-workflows/throttle-function.mdx
@@ -73,6 +73,8 @@ A throttle function always runs per recipient. If you do not provide a throttle 
   }
 />
 
+Custom throttle keys must be shorter than 64 characters long after being JSON and URL encoded.
+
 ## Frequently asked questions
 
 #### Can I use a dynamic throttle window?


### PR DESCRIPTION
### Description

Explain limits on custom throttle keys.  See also:

* https://github.com/knocklabs/control/pull/2468
* https://github.com/knocklabs/switchboard/pull/1532


### Tasks
[KNO-4377](https://linear.app/knock/issue/KNO-4377)

