### PR TITLE
chore: note workflow categories are case sensitive

### DIFF
--- a/pages/concepts/preferences.mdx
+++ b/pages/concepts/preferences.mdx
@@ -70,7 +70,9 @@ Workflow preferences are a great way to give your recipients a way to opt out of
 
 There are cases when you'll want to enable your recipients to set a preference for a category of workflows, for example, all of your workflows related to `direct` notifications. In these cases, rather than having to surface a preference control for each of those notification types, you can use `categories` to set the preference for multiple workflows at once.
 
-To set a category for a given workflow, go to that workflow's page in the dashboard, click the "..." menu, and select "Manage workflow". From there you'll be able to add categories. (Note: A workflow can belong to multiple categories. In the instance that it does, and conflicting preferences are set across those categories, the workflow's preference will default to false.)
+To set a category for a given workflow, go to that workflow's page in the dashboard, click the "..." menu, and select "Manage workflow". From there you'll be able to add categories. **Note:** workflow categories are **case sensitive**.
+
+A workflow can belong to multiple categories. In the instance that it does, and conflicting preferences are set across those categories, the workflow's preference will default to false.
 
 Here's an example of a given recipient's preferences for a set of workflow categories.
 

--- a/pages/concepts/workflows.mdx
+++ b/pages/concepts/workflows.mdx
@@ -66,6 +66,15 @@ Knock workflows can be managed either via the Knock Dashboard or programmaticall
 
 Each workflow can have one or more categories associated with it. Categories are useful for grouping related types of workflows together and offer a way to [apply a set of recipient preferences](/concepts/preferences#workflow-category-preferences) across many workflows.
 
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <span className="font-bold">Note:</span> workflow categories are <strong>case sensitive</strong>.
+    </>
+  }
+/>
+
 ### Version control for workflows
 
 All changes to workflows, including changes made to the templates inside of a workflow, are version controlled. Changes must be made in the development environment and are then "committed" and then "promoted" between environments for that version to be live within an environment. This allows you to confidently make changes to workflows, without affecting any running in production.


### PR DESCRIPTION
### Description
Note workflow categories are case sensitive.

### Tasks
[KNO-4447](https://linear.app/knock/issue/KNO-4447/[docs]-add-note-that-workflow-categories-are-case-sensitive)

### Screenshots

<img width="1440" alt="CleanShot 2023-10-06 at 12 01 36@2x" src="https://github.com/knocklabs/docs/assets/4471723/7a25513b-7ecf-4ef0-bf68-24930b59bc2e">

<img width="1438" alt="CleanShot 2023-10-06 at 12 01 18@2x" src="https://github.com/knocklabs/docs/assets/4471723/e3463c26-d21b-4e7e-a817-26f0c05ed937">

