### PR TITLE
fix: typo in subscriptions section title

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4416,7 +4416,7 @@ A subscription represents the relationship between a recipient (the subscriber) 
 </ExampleColumn>
 </Section>
 
-<Section title="List subscriptons" slug="list-subscriptions">
+<Section title="List subscriptions" slug="list-subscriptions">
 <ContentColumn>
 
 Lists all subscriptions for an object (the subscribers) or all of the current subscriptions for the object, depending on the `mode` given. Defaults to returning subscriber information.


### PR DESCRIPTION
### Description
Typo here: https://docs.knock.app/reference#list-subscriptions%23list-subscriptions
