### PR TITLE
fix: clearbit tag by directly setting the path on route change

### DIFF
--- a/lib/clearbit.ts
+++ b/lib/clearbit.ts
@@ -1,0 +1,7 @@
+// Clearbit doesn't detect the correct url when using catch all routes (e.g. [...slug].tsx)
+// so we need to directly set the path on route change
+export const setClearbitPath = (path) => {
+  if (typeof window !== "undefined" && typeof window.clearbit !== "undefined") {
+    window.clearbit.push(["set", { path }]);
+  }
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import {
 } from "@byteclaw/use-event-emitter";
 
 import * as gtag from "../lib/gtag";
+import { setClearbitPath } from "../lib/clearbit";
 
 import "../styles/index.css";
 import { DocsLayout } from "../layouts/DocsLayout";
@@ -19,6 +20,7 @@ function App({ Component, pageProps }) {
   useEffect(() => {
     const handleRouteChange = (url: URL) => {
       gtag.pageview(url);
+      setClearbitPath(url);
     };
 
     router.events.on("routeChangeComplete", handleRouteChange);

--- a/types.ts
+++ b/types.ts
@@ -20,3 +20,11 @@ export interface ISidebarSection {
   title?: string;
   pages: IPage[];
 }
+
+declare global {
+  interface Window {
+    clearbit: {
+      push: (args: any[]) => void;
+    };
+  }
+}


### PR DESCRIPTION
### Description
Clearbit doesn't detect the correct url when using catch all routes (e.g. [...slug].tsx) so we need to directly set the path on route change

### Todos
- [ ] Test w/ Clearbit