### PR TITLE
fix: docs layout when anchor link or query params are in the url

### DIFF
--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -7,11 +7,11 @@ import Breadcrumbs from "../components/Breadcrumbs";
 import sidebarContent from "../data/sidebar";
 import DocsSidebar from "../components/DocsSidebar";
 import Meta from "../components/Meta";
-import { getSidebarInfo } from "../lib/content";
+import { getSidebarInfo, slugToPaths } from "../lib/content";
 
 const DocsLayout = ({ frontMatter, children }) => {
-  const { asPath } = useRouter();
-  const paths = useMemo(() => asPath.substring(1).split("/"), [asPath]);
+  const router = useRouter();
+  const paths = slugToPaths(router.query.slug);
 
   useEffect(() => {
     const content = document.querySelector(".main-content");
@@ -21,7 +21,7 @@ const DocsLayout = ({ frontMatter, children }) => {
     if (content) {
       content.scrollTop = 0;
     }
-  }, [asPath]);
+  }, [paths]);
 
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getSidebarInfo(paths, sidebarContent),

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,5 +1,16 @@
 import { SidebarPage, SidebarSection } from "../data/types";
 
+// Converts a Next.js router slug to a paths array
+export const slugToPaths = (slug: string | string[] | undefined): string[] => {
+  if (!slug) {
+    return [];
+  } else if (typeof slug == "string") {
+    return [slug];
+  } else {
+    return slug;
+  }
+};
+
 // Returns the breadcrumbs and adjacent pages in the sidebar given a path
 export const getSidebarInfo = (
   paths: string[],


### PR DESCRIPTION
### Description
`asPath` includes anchor links and query params, so this PR updates the docs layout to use `router.query.slug` as the input to getSidebarInfo

### Tasks
[KNO-4595](https://linear.app/knock/issue/KNO-4595/%5Bdocs%5D-breadcrumbs-dont-work-with-anchor-links)

### Screenshots
![Screenshot 2023-11-07 at 10 35 12 AM](https://github.com/knocklabs/docs/assets/12838032/8d17de9c-c897-4b2b-ae61-6bd8037c88ef)
