### PR TITLE
fix: breadcrumbs for integrations page. add prev/next pages

### DIFF
--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,5 +1,16 @@
 import { SidebarPage, SidebarSection } from "../data/types";
 
+// Converts a Next.js router slug to a paths array
+export const slugToPaths = (slug: string | string[] | undefined): string[] => {
+  if (!slug) {
+    return [];
+  } else if (typeof slug == "string") {
+    return [slug];
+  } else {
+    return slug;
+  }
+};
+
 // Returns the breadcrumbs and adjacent pages in the sidebar given a path
 export const getSidebarInfo = (
   paths: string[],


### PR DESCRIPTION
### Description
Updates the integrations layout to use `getSidebarInfo`. Adds extra logic to merge the first two path segments for most pages so that the paths input to getSidebarInfo matches the slugs in the sidebar content.

### Tasks
[KNO-4596](https://linear.app/knock/issue/KNO-4596/%5Bdocs%5D-breadcrumbs-missing-from-integrations)

### Screenshots
![Screenshot 2023-11-07 at 11 04 00 AM](https://github.com/knocklabs/docs/assets/12838032/c4c4720d-e52c-4f8f-bf80-efeb4a87bb28)