### PR TITLE
fix: decrease <aside> height to prevent footer overlap

### DIFF
--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -104,7 +104,7 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
   return (
     <aside
       className="fixed top-30 pl-5 w-64 overflow-y-auto"
-      style={{ height: "calc(100vh - 95px)" }}
+      style={{ height: "calc(100vh - 200px)" }}
     >
       <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">
         On this page


### PR DESCRIPTION
### Description
At screen widths >= to 1280px, the `<aside>` component which renders the "On This Page" sidebar has a height which overlaps the footer. This means that the "Visit website" and "Contact us" links are unusable, because the rollover is not detected.

This PR increases the height calc from 95px to 200px (thus decreasing overall component height) to leave enough clearance for the links to remain clickable.