### PR TITLE
feat(KNO-4647) Update management api reference

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -34,7 +34,7 @@ You can use the Knock management API to:
 - Create, update, and manage your Knock workflows and the notification templates within those workflows.
 - Create and manage the [translations](/send-and-manage-data/translations) used by your notification templates.
 - Create, update and manage your [email layouts](/integrations/email/layouts).
-- Commit and promote changes between your Knock environments, and list commits for a given environment.
+- Commit and promote changes between your Knock environments, and list commits in a given environment.
 
 </ContentColumn>
 <ExampleColumn>
@@ -1976,21 +1976,211 @@ A translation object
 
 To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow, a layout, a translation or an event action mapping, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
 
+You can also retrieve all commits in a given environment, or show the details of one single commit based on the target commit id.
+
 </ContentColumn>
 <ExampleColumn>
 
 <Endpoints>
+  <Endpoint name="commits-list" method="GET" path="/commits" withLink />
+  <Endpoint name="commits-get" method="GET" path="/commits/:id" withLink />
   <Endpoint name="commits-commit" method="PUT" path="/commits" withLink />
   <Endpoint
-    name="commits-promote"
+    name="commits-promote-all"
     method="PUT"
     path="/commits/promote"
+    withLink
+  />
+    <Endpoint
+    name="commits-promote-one"
+    method="PUT"
+    path="/commits/:id/promote"
     withLink
   />
 </Endpoints>
 
 </ExampleColumn>
 </Section>
+
+<Section title="Commit definition" slug="commits-object">
+<ContentColumn>
+
+### Attributes
+
+<Attributes>
+  <Attribute
+    name="id"
+    type="string"
+    description="The unique id for this commit."
+  />
+  <Attribute
+    name="resource"
+    type="CommitResource"
+    description="The resource object associated with the commit."
+  />
+  <Attribute
+    name="author"
+    type="CommitAuthor"
+    description="The author responsible for the commit."
+  />
+  <Attribute
+    name="commit_message"
+    type="string"
+    description="The optional message about the commit."
+  />
+  <Attribute
+    name="environment"
+    type="string"
+    description="The environment where the commit was made."
+  />
+  <Attribute
+    name="created_at"
+    type="timestamp"
+    description="A timestamp of when the commit was created."
+  />
+</Attributes>
+
+### CommitResource Attributes
+
+<Attributes>
+  <Attribute
+    name="type"
+    type="string"
+    description="The type of the resource object."
+  />
+    <Attribute
+    name="identifier"
+    type="string"
+    description="The Unique identifier for the resource."
+  />
+</Attributes>
+
+### CommitAuthor Attributes
+
+<Attributes>
+  <Attribute
+    name="name"
+    type="string"
+    description="The name of the commit author."
+  />
+    <Attribute
+    name="email"
+    type="string"
+    description="The email address of the author."
+  />
+</Attributes>
+
+</ContentColumn>
+<ExampleColumn>
+
+```json Commit object
+{
+      "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
+      "resource": {
+        "identifier": "default",
+        "type": "email_layout"
+      },
+      "author": {
+        "email": "John@gmail.com",
+        "name": "John Doe"
+      },
+      "commit_message": "Initial email layout",
+      "environment": "development",
+      "created_at": "2023-09-22T18:57:21.704602Z"
+}
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="List all commits" slug="commits-list">
+<ContentColumn>
+
+Returns a paginated list of commits in a given environment. The commits are ordered from most recent.
+
+### Endpoint
+
+<Endpoint method="GET" path="/commits" />
+
+### Query parameters
+
+<Attributes>
+  <Attribute
+    name="environment"
+    type="string"
+    description="A slug of the environment from which to query commits."
+  />  
+  <Attribute
+    name="[no-]promoted"
+    type="string"
+    description="Whether to show only promoted or unpromoted changes between the given environment and the subsequent environment."
+    />
+    <Attribute
+    name="after"
+    type="string"
+    description="The cursor to retrieve items after."
+  />
+  <Attribute
+    name="before"
+    type="string"
+    description="The cursor to retrieve items before."
+  />
+  <Attribute
+    name="limit"
+    type="number"
+    description="The total number to retrieve per page (defaults to 50, maximum of 100)."
+  />
+</Attributes>
+
+### Returns
+
+A paginated list of commits
+
+</ContentColumn>
+<ExampleColumn>
+
+```json Response
+{
+  "entries": [
+   {
+      "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
+      "resource": {
+        "identifier": "default",
+        "type": "email_layout"
+      },
+      "author": {
+        "email": "John@gmail.com",
+        "name": "John Doe"
+      },
+      "commit_message": "Initial email layout",
+      "environment": "development",
+      "created_at": "2023-09-22T18:57:21.704602Z"
+   },
+ {
+      "id": "e4a22631-e05e-4d40-b323-4dc327c0670e",
+      "resource": {
+        "identifier": "new-comment",
+        "type": "workflow"
+      },
+      "author": {
+        "email": "franklin@gmail.com",
+        "name": "Franklin Sierra"
+      },
+      "environment": "development",
+      "created_at": "2023-11-13T19:28:25.090196Z"
+}
+  ],
+  "page_info": {
+    "after": null,
+    "before": null,
+    "page_size": 50
+  }
+}
+```
+
+</ExampleColumn>
+</Section>
+
 
 <Section title="Commit all changes" slug="commits-commit">
 <ContentColumn>

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -1976,7 +1976,7 @@ A translation object
 
 To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow, a layout, a translation or an event action mapping, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
 
-You can also retrieve all commits in a given environment, or show the details of one single commit based on the target commit id.
+You can retrieve all commits in a given environment, or show the details of one single commit based on the target commit id.
 
 </ContentColumn>
 <ExampleColumn>
@@ -2043,30 +2043,30 @@ You can also retrieve all commits in a given environment, or show the details of
 ### CommitResource Attributes
 
 <Attributes>
-  <Attribute
-    name="type"
-    type="string"
-    description="The type of the resource object."
-  />
     <Attribute
     name="identifier"
     type="string"
     description="The Unique identifier for the resource."
+  />
+    <Attribute
+    name="type"
+    type="string"
+    description="The type of the resource object."
   />
 </Attributes>
 
 ### CommitAuthor Attributes
 
 <Attributes>
-  <Attribute
-    name="name"
-    type="string"
-    description="The name of the commit author."
-  />
     <Attribute
     name="email"
     type="string"
     description="The email address of the author."
+  />
+    <Attribute
+    name="name"
+    type="string"
+    description="The name of the commit author."
   />
 </Attributes>
 
@@ -2075,18 +2075,18 @@ You can also retrieve all commits in a given environment, or show the details of
 
 ```json Commit object
 {
-      "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
-      "resource": {
-        "identifier": "default",
-        "type": "email_layout"
-      },
-      "author": {
-        "email": "John@gmail.com",
-        "name": "John Doe"
-      },
-      "commit_message": "Initial email layout",
-      "environment": "development",
-      "created_at": "2023-09-22T18:57:21.704602Z"
+   "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
+   "resource": {
+      "identifier": "default",
+      "type": "email_layout"
+   },
+   "author": {
+      "email": "John@gmail.com",
+      "name": "John Doe"
+   },
+   "commit_message": "Initial email layout",
+   "environment": "development",
+   "created_at": "2023-09-22T18:57:21.704602Z"
 }
 ```
 
@@ -2096,7 +2096,7 @@ You can also retrieve all commits in a given environment, or show the details of
 <Section title="List all commits" slug="commits-list">
 <ContentColumn>
 
-Returns a paginated list of commits in a given environment. The commits are ordered from most recent.
+Returns a paginated list of commits in a given environment. The commits are ordered from most recent first.
 
 ### Endpoint
 
@@ -2141,46 +2141,91 @@ A paginated list of commits
 
 ```json Response
 {
-  "entries": [
-   {
-      "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
-      "resource": {
-        "identifier": "default",
-        "type": "email_layout"
+   "entries": [
+      {
+         "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
+         "resource": {
+            "identifier": "default",
+            "type": "email_layout"
+         },
+         "author": {
+            "email": "John@gmail.com",
+            "name": "John Doe"
+         },
+         "commit_message": "Initial email layout",
+         "environment": "development",
+         "created_at": "2023-09-22T18:57:21.704602Z"
       },
-      "author": {
-        "email": "John@gmail.com",
-        "name": "John Doe"
-      },
-      "commit_message": "Initial email layout",
-      "environment": "development",
-      "created_at": "2023-09-22T18:57:21.704602Z"
-   },
- {
-      "id": "e4a22631-e05e-4d40-b323-4dc327c0670e",
-      "resource": {
-        "identifier": "new-comment",
-        "type": "workflow"
-      },
-      "author": {
-        "email": "franklin@gmail.com",
-        "name": "Franklin Sierra"
-      },
-      "environment": "development",
-      "created_at": "2023-11-13T19:28:25.090196Z"
-}
-  ],
-  "page_info": {
-    "after": null,
-    "before": null,
-    "page_size": 50
-  }
+      {
+         "id": "e4a22631-e05e-4d40-b323-4dc327c0670e",
+         "resource": {
+            "identifier": "new-comment",
+            "type": "workflow"
+         },
+         "author": {
+            "email": "franklin@gmail.com",
+            "name": "Franklin Sierra"
+         },
+         "environment": "development",
+         "created_at": "2023-11-13T19:28:25.090196Z"
+      }
+   ],
+   "page_info": { 
+      "after": null,
+      "before": null,
+      "page_size": 50
+   }
 }
 ```
 
 </ExampleColumn>
 </Section>
 
+<Section title="Get commit" slug="commits-get">
+<ContentColumn>
+
+Retrieve a single commit by its id.
+
+### Endpoint
+
+<Endpoint method="GET" path="/commits/:id"/>
+
+### Path parameters
+
+<Attributes>
+   <Attribute
+    name="id"
+    type="string"
+    description="The id of the commit."
+  />
+</Attributes>
+
+### Returns
+
+A complete commit.
+
+</ContentColumn>
+<ExampleColumn>
+
+```json Response
+{
+   "id": "ce3e5457-34f2-4f53-94a2-2f316528d83f",
+   "resource" :{
+      "identifier": "default",
+      "type": "email_layout"
+   },
+   "author": {
+      "email": "John@gmail.com",
+      "name": "John Doe"
+   },
+   "commit_message": "Initial email layout",
+   "environment": "development",
+   "created_at": "2023-09-22T18:57:21.704602Z"
+}
+```
+
+</ExampleColumn>
+</Section>
 
 <Section title="Commit all changes" slug="commits-commit">
 <ContentColumn>
@@ -2217,7 +2262,7 @@ Commit all changes across all resources in the development environment.
 </ExampleColumn>
 </Section>
 
-<Section title="Promote all changes" slug="commits-promote">
+<Section title="Promote all changes" slug="commits-promote-all">
 <ContentColumn>
 
 Promote all changes across all resources to the target environment from its preceding environment.
@@ -2253,6 +2298,52 @@ Promote all changes across all resources to the target environment from its prec
 ```json Response
 {
   "result": "success"
+}
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="Promote one change" slug="commits-promote-one">
+<ContentColumn>
+
+Promotes one change to the subsequent environment.
+
+### Endpoint
+
+<Endpoint method="PUT" path="/commits/:id/promote" />
+
+### Query parameters
+
+<Attributes>
+  <Attribute
+    name="id"
+    type="string"
+    description={<p>The target commit id to promote to the subsequent environment.</p>}
+/>
+</Attributes>
+
+### Returns
+
+A promoted commit.
+
+</ContentColumn>
+<ExampleColumn>
+
+```json Response
+{
+   "commit": {
+      "id": "e4a22631-e05e-4d40-b323-4dc327c0670e",
+      "resource": {
+         "identifier": "new-comment",
+         "type": "workflow"
+      },
+      "author": {
+         "email": "franklin@gmail.com",
+         "name": "Franklin Sierra"
+      },
+      "environment": "development"
+   }
 }
 ```
 

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -17,7 +17,7 @@ tags: ["api", "sdks", "api key", "keys", "errors"]
     <>
       <strong>Note:</strong> the Knock management API only provides access to
       the resources managed in <strong>the Knock dashboard</strong>, such as
-      workflows, templates, and translations.
+      workflows, templates, translations and commits.
       <br />
       <br />
       All other concepts within the Knock notification engine are accessed through
@@ -27,13 +27,14 @@ tags: ["api", "sdks", "api key", "keys", "errors"]
   }
 />
 
-The Knock management API provides you with a programmatic way to interact with the resources you create and manage in your Knock dashboard, including workflows, templates, layouts, and translations. It's separate from the [Knock API](/reference) and only provides access to a limited subset of resources.
+The Knock management API provides you with a programmatic way to interact with the resources you create and manage in your Knock dashboard, including workflows, templates, layouts, translations and commits. It's separate from the [Knock API](/reference) and only provides access to a limited subset of resources.
 
 You can use the Knock management API to:
 
 - Create, update, and manage your Knock workflows and the notification templates within those workflows.
 - Create and manage the [translations](/send-and-manage-data/translations) used by your notification templates.
-- Commit and promote changes between your Knock environments.
+- Create, update and manage your [email layouts](/integrations/email/layouts).
+- Commit and promote changes between your Knock environments, and list commits for a given environment.
 
 </ContentColumn>
 <ExampleColumn>

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -2319,7 +2319,7 @@ Promotes one change to the subsequent environment.
   <Attribute
     name="id"
     type="string"
-    description={<p>The target commit id to promote to the subsequent environment.</p>}
+    description="The target commit id to promote to the subsequent environment."
 />
 </Attributes>
 

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -2111,7 +2111,7 @@ Returns a paginated list of commits in a given environment. The commits are orde
     description="A slug of the environment from which to query commits."
   />  
   <Attribute
-    name="[no-]promoted"
+    name="promoted"
     type="boolean"
     description="Whether to show only promoted or unpromoted changes between the given environment and the subsequent environment."
     />

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -34,7 +34,7 @@ You can use the Knock management API to:
 - Create, update, and manage your Knock workflows and the notification templates within those workflows.
 - Create and manage the [translations](/send-and-manage-data/translations) used by your notification templates.
 - Create, update and manage your [email layouts](/integrations/email/layouts).
-- Commit and promote changes between your Knock environments, and list commits in a given environment.
+- Commit and promote changes between your Knock environments.
 
 </ContentColumn>
 <ExampleColumn>
@@ -2040,13 +2040,13 @@ You can retrieve all commits in a given environment, or show the details of one 
   />
 </Attributes>
 
-### CommitResource Attributes
+### CommitResource attributes
 
 <Attributes>
     <Attribute
     name="identifier"
     type="string"
-    description="The Unique identifier for the resource."
+    description="The unique identifier for the resource."
   />
     <Attribute
     name="type"
@@ -2055,13 +2055,13 @@ You can retrieve all commits in a given environment, or show the details of one 
   />
 </Attributes>
 
-### CommitAuthor Attributes
+### CommitAuthor attributes
 
 <Attributes>
     <Attribute
     name="email"
     type="string"
-    description="The email address of the author."
+    description="The email address of the commit author."
   />
     <Attribute
     name="name"
@@ -2112,7 +2112,7 @@ Returns a paginated list of commits in a given environment. The commits are orde
   />  
   <Attribute
     name="[no-]promoted"
-    type="string"
+    type="boolean"
     description="Whether to show only promoted or unpromoted changes between the given environment and the subsequent environment."
     />
     <Attribute
@@ -2342,7 +2342,7 @@ A promoted commit.
          "email": "franklin@gmail.com",
          "name": "Franklin Sierra"
       },
-      "environment": "development"
+      "environment": "staging"
    }
 }
 ```

--- a/layouts/MapiReferenceLayout.tsx
+++ b/layouts/MapiReferenceLayout.tsx
@@ -60,8 +60,10 @@ const sidebarData = [
       { slug: "#commits-overview", title: "Introduction" },
       { slug: "#commits-object", title: "Commit definition" },
       { slug: "#commits-list", title: "List Commits" },
+      { slug: "#commits-get", title: "Get a commit" },
       { slug: "#commits-commit", title: "Commit all changes" },
-      { slug: "#commits-promote", title: "Promote all changes" },
+      { slug: "#commits-promote-all", title: "Promote all changes" },
+      { slug: "#commits-promote-one", title: "Promote one change" },
     ],
   },
 ];

--- a/layouts/MapiReferenceLayout.tsx
+++ b/layouts/MapiReferenceLayout.tsx
@@ -58,6 +58,8 @@ const sidebarData = [
     slug: "/mapi",
     pages: [
       { slug: "#commits-overview", title: "Introduction" },
+      { slug: "#commits-object", title: "Commit definition" },
+      { slug: "#commits-list", title: "List Commits" },
       { slug: "#commits-commit", title: "Commit all changes" },
       { slug: "#commits-promote", title: "Promote all changes" },
     ],


### PR DESCRIPTION
### Description
Adds the following sections to the Management Api reference:
* Commit description
* Commits get endpoint
* Commits list endpoint
* Commits promote one endpoint

### Tasks
[KNO-4647](https://linear.app/knock/issue/KNO-4647/[docs]-update-management-api-reference)

### Screenshots

https://github.com/knocklabs/docs/assets/67347884/d6a72d19-7ed2-4d6e-b263-9d31c4dcb780




