### PR TITLE
chore(KNO-4749): Fix workflow preferences link

### DIFF
--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -128,7 +128,7 @@ When a workflow run is executed, associated state is loaded to be used within th
 
 Workflows can have preferences associated, either via individual workflow preferences (specified via the workflow key) or via workflow-category preferences (matched against the categories set).
 
-[Read more about preferences](http://localhost:3002/concepts/preferences#workflow-preferences)
+[Read more about preferences](/concepts/preferences#workflow-preferences)
 
 ## Frequently asked questions
 


### PR DESCRIPTION
### Description
We are redirecting to localhost instead of `docs.knock.app`

### Tasks
[KNO-4749](https://linear.app/knock/issue/KNO-4749/[docs]-fix-workflow-preferences-link)

