### PR TITLE
fix: update getting started section under supported email providers

### DIFF
--- a/content/integrations/email/aws-ses.mdx
+++ b/content/integrations/email/aws-ses.mdx
@@ -24,7 +24,7 @@ You'll need to take the following steps in AWS before you can configure your SES
 1. **Verify a "From" address within AWS.** You'll need to do this before sending emails via SES through Knock.
 2. **Choose and configure an AWS Authentication Scheme.** To integrate with SES from the Knock dashboard, you can use cess Management (IAM) User Access Keys, or to improve security delegate a role to Knock [using External ID-based authentication.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
 
-Once you've completed both of those steps, you'll be able to configure an AWS SES channel in the Knock dashboard under the "Channels" page.
+Once you've completed both of those steps, you'll be able to configure an AWS SES channel in the Knock dashboard under the {"Integrations > Channels"} section.
 
 ### 1. Verify a "From" address within AWS SES
 

--- a/content/integrations/email/mailersend.mdx
+++ b/content/integrations/email/mailersend.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Mailersend channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Mailersend channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 

--- a/content/integrations/email/mailgun.mdx
+++ b/content/integrations/email/mailgun.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Mailgun channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Mailgun channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 

--- a/content/integrations/email/mailjet.mdx
+++ b/content/integrations/email/mailjet.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Mailjet channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Mailjet channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 

--- a/content/integrations/email/mandrill.mdx
+++ b/content/integrations/email/mandrill.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Mandrill channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Mandrill channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 

--- a/content/integrations/email/postmark.mdx
+++ b/content/integrations/email/postmark.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Postmark channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Postmark channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 

--- a/content/integrations/email/sendgrid.mdx
+++ b/content/integrations/email/sendgrid.mdx
@@ -21,9 +21,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ### Connect SendGrid to Knock
 
-Head to the “Channels” page in the Knock dashboard and click “Create channel” to create a new SendGrid channel in your account.
-
-Once the channel is created, click into it to configure SendGrid for each of your Knock environments.
+You can create a new SendGrid channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 Here are a few things to note as you configure your SendGrid provider:
 

--- a/content/integrations/email/sparkpost.mdx
+++ b/content/integrations/email/sparkpost.mdx
@@ -19,7 +19,7 @@ In this guide you'll learn how to get started sending transactional email notifi
 
 ## Getting started
 
-You can create a new Sparkpost channel in the dashboard under the "Channels" section. From there, you'll need to configure the channel for each environment you have.
+You can create a new Sparkpost channel in the dashboard under the {"Integrations > Channels"} section. From there, you'll need to configure the channel for each environment you have.
 
 ## Provider configuration
 


### PR DESCRIPTION
### Description

Updating the "Getting Started" section for the different supported providers under integrations > email to all point users to "Integrations > Channels" from the dashboard.

Note that Mailtrap had already been updated.

