### PR TITLE
add callout for combined prefs

### DIFF
--- a/content/concepts/preferences.mdx
+++ b/content/concepts/preferences.mdx
@@ -126,8 +126,19 @@ Take an example of an app that wants to give per-channel preferences to its reci
   }
 }
 ```
+<br />
 
-**Remember:** in cases where a preference is set both for a workflow and for its parent category, Knock will only send a notification if all preference combinations that exist on the recipient evaluate to `true`. This means that in the case above, if the `new-mention` workflow belongs to the `collaboration` category, the recipient will not receive email notifications about new mentions, even though the preference is currently set to `true`.
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Remember:</span> in cases where a preference 
+      is set both for a workflow and for its parent category, Knock will only send 
+      a notification if all preference combinations that exist on the recipient evaluate 
+      to <code>true</code>. This means that in the case above, if the <code>new-mention</code> workflow belongs to the <code>collaboration</code> category, the recipient will not receive email notifications about new mentions, even though the preference is currently set to <code>true</code>.
+    </>
+  }
+/>
 
 ## Preference sets
 

--- a/content/concepts/preferences.mdx
+++ b/content/concepts/preferences.mdx
@@ -126,16 +126,21 @@ Take an example of an app that wants to give per-channel preferences to its reci
   }
 }
 ```
+
 <br />
 
 <Callout
   emoji="🌠"
   text={
     <>
-      <span className="font-bold">Remember:</span> in cases where a preference 
-      is set both for a workflow and for its parent category, Knock will only send 
-      a notification if all preference combinations that exist on the recipient evaluate 
-      to <code>true</code>. This means that in the case above, if the <code>new-mention</code> workflow belongs to the <code>collaboration</code> category, the recipient will not receive email notifications about new mentions, even though the preference is currently set to <code>true</code>.
+      <span className="font-bold">Remember:</span> in cases where a preference
+      is set both for a workflow and for its parent category, Knock will only
+      send a notification if all preference combinations that exist on the
+      recipient evaluate to <code>true</code>. This means that in the case
+      above, if the <code>new-mention</code> workflow belongs to the{" "}
+      <code>collaboration</code> category, the recipient will not receive email
+      notifications about new mentions, even though the preference is currently
+      set to <code>true</code>.
     </>
   }
 />


### PR DESCRIPTION
### Description

I updated the `Remember:...` section of text below [this code sample](https://docs.knock.app/concepts/preferences#combining-preferences) to be a callout. This change aligns it with the other uses of callouts the on concepts pages and better highlights an important caveat for the customer. 

### Screenshots
Before
<img width="698" alt="Screenshot 2023-12-14 at 3 29 00 PM" src="https://github.com/knocklabs/docs/assets/7818951/b236b052-9aa6-4690-a13b-dfccc180c999">
After
<img width="774" alt="Screenshot 2023-12-14 at 3 29 22 PM" src="https://github.com/knocklabs/docs/assets/7818951/69f54e2c-bad5-4b0b-afa8-bdbb93c4c910">

