### PR TITLE
fix: change named to default import

### DIFF
--- a/content/in-app-ui/react/preferences.mdx
+++ b/content/in-app-ui/react/preferences.mdx
@@ -67,7 +67,7 @@ The nice thing about this approach is we don't need to store any notification pr
 
 ```jsx
 import React, { useEffect, useState } from "react";
-import { Knock } from "@knocklabs/client";
+import Knock from "@knocklabs/client";
 
 import { useCurrentUser } from "./hooks";
 


### PR DESCRIPTION
### Description

Updates this code sample to use `Knock` as a default export instead of a named export. Checked these places:
https://github.com/knocklabs/knock-client-js/blob/main/src/index.ts
https://github.com/knocklabs/knock-node-example-app/blob/main/app/users/components/NotificationPreferencesModal.tsx


### Screenshots

Before
<img width="656" alt="Screenshot 2023-12-15 at 8 50 12 AM" src="https://github.com/knocklabs/docs/assets/7818951/e15d77bc-4d72-4edd-a893-6de6de81c354">

After
<img width="650" alt="Screenshot 2023-12-15 at 8 51 01 AM" src="https://github.com/knocklabs/docs/assets/7818951/37bdd457-7e64-4f64-a311-106a3dede93f">

