### PR TITLE
fix: update service tokens page

### DIFF
--- a/content/developer-tools/service-tokens.mdx
+++ b/content/developer-tools/service-tokens.mdx
@@ -24,8 +24,7 @@ Service tokens always start with `knock_st_` and are different from your Knock A
 
 To use the management API or CLI, you will first need to generate a service token and use it as a means of authentication when sending requests.
 
-To generate a service token, go to the "Service tokens" tab in your account "Settings" page and click the “+ New token” button.
-
+To generate a service token, from the dashboard, go to "Settings," select the "Service tokens" tab, and click the "+ New token" button. Then, provide a name for the token and click "generate" to view and save your newly generated service token.
 Please note: once generated you **cannot see a service token again from the Knock dashboard, so be sure to copy it to a secure location**.
 
 ## Revoking a service token

--- a/content/developer-tools/service-tokens.mdx
+++ b/content/developer-tools/service-tokens.mdx
@@ -25,7 +25,15 @@ Service tokens always start with `knock_st_` and are different from your Knock A
 To use the management API or CLI, you will first need to generate a service token and use it as a means of authentication when sending requests.
 
 To generate a service token, from the dashboard, go to "Settings," select the "Service tokens" tab, and click the "+ New token" button. Then, provide a name for the token and click "generate" to view and save your newly generated service token.
-Please note: once generated you **cannot see a service token again from the Knock dashboard, so be sure to copy it to a secure location**.
+
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      Note: once generated, <strong>you cannot see a service token again from the Knock dashboard,</strong> so be sure to copy it to a secure location.
+    </>
+  }
+/>
 
 ## Revoking a service token
 

--- a/content/developer-tools/service-tokens.mdx
+++ b/content/developer-tools/service-tokens.mdx
@@ -30,7 +30,11 @@ To generate a service token, from the dashboard, go to "Settings," select the "S
   emoji="🚨"
   text={
     <>
-      Note: once generated, <strong>you cannot see a service token again from the Knock dashboard,</strong> so be sure to copy it to a secure location.
+      Note: once generated,{" "}
+      <strong>
+        you cannot see a service token again from the Knock dashboard,
+      </strong>{" "}
+      so be sure to copy it to a secure location.
     </>
   }
 />

--- a/content/developer-tools/service-tokens.mdx
+++ b/content/developer-tools/service-tokens.mdx
@@ -24,7 +24,7 @@ Service tokens always start with `knock_st_` and are different from your Knock A
 
 To use the management API or CLI, you will first need to generate a service token and use it as a means of authentication when sending requests.
 
-To generate a service token, from the dashboard, go to "Settings," select the "Service tokens" tab, and click the "+ New token" button. Then, provide a name for the token and click "generate" to view and save your newly generated service token.
+To generate a service token, from the dashboard go to "Settings," select the "Service tokens" tab, and click the "+ New token" button. Then, provide a name for the token and click "generate" to view and save your newly generated service token.
 
 <Callout
   emoji="🚨"


### PR DESCRIPTION
### Description

Updated instructions on where to go to generate a service token for better clarity. Also updated the note about only seeing a service token once upon generation to be a callout to better align with similar use cases of callouts.

### Screenshots

Before:
![Screenshot 2023-12-15 at 10 13 45 AM](https://github.com/knocklabs/docs/assets/54180641/f112604c-a463-4bc0-a29a-81ddcc9ca88c)

After:
![Screenshot 2023-12-15 at 10 13 57 AM](https://github.com/knocklabs/docs/assets/54180641/67c224b4-03c8-413d-bb7f-370793fc7a40)

