### PR TITLE
fix: add default action_url behavior

### DIFF
--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Building notification feeds with React"
 description: How to build notification feeds powered by Knock and React.
-tags: ["inbox", "feeds", "toasts"]
+tags: ["inbox", "feeds", "toasts", "action_url"]
 section: Building in-app UI
 ---
 
@@ -81,6 +81,10 @@ const YourAppLayout = () => {
 ```
 
 ## Common recipes
+
+### Setting an `action_url` on the notification cell
+
+You can pass a value in the Action URL field of your notification template and the `KnockFeedProvider` will attach a redirect handler if `action_url` is not empty.
 
 ### Adding an `onClick` handler to the notification cell
 


### PR DESCRIPTION
### Description

Adds a recipe describing the default behavior of the `action_url` on the `KnockFeedProvider`. I put it first since its the most common scenario.


### Screenshots


<img width="749" alt="Screenshot 2023-12-15 at 2 59 59 PM" src="https://github.com/knocklabs/docs/assets/7818951/bb55d094-5471-43ac-aecc-ebfe7fd98192">

