### PR TITLE
fix: update dark mode instructions to pass prop directly to KnockFeedProvider

### DIFF
--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -161,9 +161,9 @@ const onOpen = ({ store, feedClient }) => {
 The feed supports an optional `colorMode` prop, that defaults to `light` but can be set as `dark` for dark mode support.
 
 ```jsx
-import { NotificationFeed } from "@knocklabs/react-notification-feed";
+import { KnockFeedProvider } from "@knocklabs/react-notification-feed";
 
-<NotificationFeed colorMode="dark" />;
+<KnockFeedProvider colorMode="dark" />;
 ```
 
 ### Adding inline actions


### PR DESCRIPTION
### Description

We currently document the ability to change the default value of `colorMode` for a given notification feed from `light` to `dark` by passing a `colorMode` prop to the `NotificationFeed` component. However, this setting is pulled from `KnockFeedProvider` by both `NotificationFeed` ([here](https://github.com/knocklabs/react-notification-feed/blob/f7eadca7726222d219ac1394764db2d6f5b0ff47/src/components/NotificationFeed/NotificationFeed.tsx#L77C51-L77C65)) and `NotificationFeedPopover` ([here](https://github.com/knocklabs/react-notification-feed/blob/f7eadca7726222d219ac1394764db2d6f5b0ff47/src/components/NotificationFeedPopover/NotificationFeedPopover.tsx#L40)) with the `useKnockFeed()` method. The `colorMode` prop is not valid for either of these components.

This PR simply changes the component name to `KnockFeedProvider`. Providing `colorMode` as a prop to this component will set the child feed component(s) to `dark` mode.
