### PR TITLE
chore: add payload example for Segment Track events

### DIFF
--- a/content/integrations/extensions/segment.mdx
+++ b/content/integrations/extensions/segment.mdx
@@ -46,7 +46,7 @@ Knock uses the Segment HTTP Source to send events to your Segment account. Each 
 
 ## Events sent to Segment
 
-When connected, Knock will forward the following track events to Segment.
+When connected, Knock will forward the following `track` events to Segment.
 
 <Table
   headers={["Event", "Description"]}
@@ -94,3 +94,36 @@ When connected, Knock will forward the following track events to Segment.
     ],
   ]}
 />
+
+Knock uses the Segment [Track spec](https://segment.com/docs/connections/spec/track/) for the event data we pass to Segment. You can find an example payload of what you can expect from Knock events coming into Segment below.
+
+```An example Segment Track event payload
+{
+  "context": {
+    "library": {
+      "name": "unknown",
+      "version": "unknown"
+    }
+  },
+  "event": "Notification Seen",
+  "integrations": {},
+  "messageID": "2XoNHQx7lPp0zsCtZh3BGgCJxxx",
+  "messageId": "api-2ZjG9Ho7EeqVV9uqkdlSRYbDxxx",
+  "originalTimestamp": "2023-12-18T19:31:58.653982Z",
+  "properties": {
+    "channelId": "26d3f6ad-eebc-4ce4-9125-bb856dad8xxx",
+    "channelType": "in_app_feed",
+    "environment": "Production",
+    "messageId": "2XoNHQx7lPp0zsCtZh3BGgCJxxx",
+    "provider": "in_app_feed_knock",
+    "stepRef": "YJAxjVC-ya69fBhoSFxxx",
+    "workflowKey": "account-invite-accepted"
+  },
+  "receivedAt": "2023-12-18T19:32:01.326Z",
+  "sentAt": null,
+  "timestamp": "2023-12-18T19:31:58.653Z",
+  "type": "track",
+  "userId": "70171a84-7e52-46d7-8866-5b4ab88cxxx",
+  "writeKey": "REDACTED"
+}
+```

--- a/content/integrations/extensions/segment.mdx
+++ b/content/integrations/extensions/segment.mdx
@@ -95,6 +95,8 @@ When connected, Knock will forward the following `track` events to Segment.
   ]}
 />
 
+## Event schema
+
 Knock uses the Segment [Track spec](https://segment.com/docs/connections/spec/track/) for the event data we pass to Segment. You can find an example payload of what you can expect from Knock events coming into Segment below.
 
 ```An example Segment Track event payload


### PR DESCRIPTION
This PR makes 2 small clarifications to our Segment Extension documentation:

1. Add backticks to `track` to clarify that it is a Segment `event` type
2. Add an example event payload so that customers can see what Knock is sending to Segment

**Question:** Should we be using `<a target="_blank">` for external links, or should we be leaving these in pure MD even though it will direct users away from our site? I noticed that we are not currently preventing navigation away from the Knock docs with the link to Segment at the top of this particular page ([line 9](https://github.com/knocklabs/docs/blob/38d6a33fbae01bbb8ab95ea2657d8a2b3112cf06/content/integrations/extensions/segment.mdx#L9))

<img width="392" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/33908fcd-8792-4a3a-b5e3-6226915741ac">
