### PR TITLE
fix: update styling for Segment event types and names

### DIFF
--- a/content/integrations/extensions/segment.mdx
+++ b/content/integrations/extensions/segment.mdx
@@ -8,9 +8,9 @@ section: Integrations > Extensions
 
 This guide covers how to use our Segment extension to send Knock's normalized notification data into [Segment](https://segment.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
 
-Once the extension is enabled, Knock automatically passes a stream of track events to Segment (e.g. "Notification delivered", "Notification seen", "Notification read") which you can then use in your downstream tools.
+Once the extension is enabled, Knock automatically passes a stream of `track` events to Segment (e.g. `Notification delivered`, `Notification seen`, `Notification read`) which you can then use in your downstream tools.
 
-Knock also provides a separate integration for using Segment as a [Knock source](/integrations/sources/overview) to bring track and identify event data from Segment into Knock to power your notifications. You can learn more in our [Segment source docs](/integrations/sources/segment).
+Knock also provides a separate integration for using Segment as a [Knock source](/integrations/sources/overview) to bring `track` and `identify` event data from Segment into Knock to power your notifications. You can learn more in our [Segment source docs](/integrations/sources/segment).
 
 <Callout
   emoji="✨"


### PR DESCRIPTION
This PR updates the Segment extension page to be consistent with `code` styling for all of Segment's event types and names.
