### PR TITLE
chore: add Pigeon conversion instructions link to cert-based APNS setup instructions

### DIFF
--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -29,6 +29,8 @@ You can read aout how to setup a certificate connection to APNS [in the document
 1. A provider certificate (from your Apple developer account)
 2. A private key (generated in the process above)
 
+Both of these values should be converted according to the instructions [here](https://hexdocs.pm/pigeon/2.0.0-rc.1/Pigeon.APNS.html#module-generating-your-certificate-and-key-pem) prior to providing them to your Knock channel configuration.
+
 ## Using APNS with Knock
 
 In order to use APNS with Knock you'll need to synchronize your users device tokens retrieved from the APNS SDK to Knock by [setting channel data](/send-notifications/setting-channel-data) for your recipient.


### PR DESCRIPTION
This PR adds documentation from Pigeon to inform customers of a required conversion that is necessary before they supply their APNS certificate and private key to the channel configuration in their dashboard. Needs review for content accuracy.