### PR TITLE
fix: update "provide feedback" section of RN docs + how to contact the team

### DIFF
--- a/content/in-app-ui/ios/overview.mdx
+++ b/content/in-app-ui/ios/overview.mdx
@@ -26,7 +26,7 @@ Our Swift SDK is worked on full-time by the Knock Swift team.
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/knock-swift/issues/new)
-- Use the "Feedback" button at the top of this page
+- Use the "Help" dropdown at the top of this page to contact support.
 
 ### Contributing
 

--- a/content/in-app-ui/javascript/overview.mdx
+++ b/content/in-app-ui/javascript/overview.mdx
@@ -27,7 +27,7 @@ Ask questions and find answers on those following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/knock-client-js/issues/new)
-- Use the "Feedback" button at the top of this page
+- Use the "Help" dropdown at the top of this page to contact support.
 
 ### Contributing
 

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -33,8 +33,7 @@ Ask questions and find answers on the following platforms:
 
 ### Provide feedback
 
-- [Open an issue](https://github.com/knocklabs/javascript/issues/new)
-- Use the "Feedback" button at the top of this page
+- Use the "Help" dropdown at the top of this page to contact support.
 
 ### Contributing
 

--- a/content/in-app-ui/react/overview.mdx
+++ b/content/in-app-ui/react/overview.mdx
@@ -39,7 +39,7 @@ Ask questions and find answers on those following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/react-notification-feed/issues/new)
-- Use the "Feedback" button at the top of this page
+- Use the "Help" dropdown at the top of this page to contact support.
 
 ### Contributing
 


### PR DESCRIPTION
### Description
Currently, the[ "Provide Feedback"](https://docs.knock.app/in-app-ui/react-native/overview#provide-feedback) section of the React Native docs points users to a private repository, resulting in a 404. This PR removes that link for now and will be added back once that becomes open source.

Additionally, I've updated instructions on how to contact the team as the "Feedback" button is no longer available. Instead, I direct users to use the help dropdown to contact support.
