### PR TITLE
chore: add limitation to doc text

### DIFF
--- a/content/designing-workflows/branch-function.mdx
+++ b/content/designing-workflows/branch-function.mdx
@@ -16,7 +16,7 @@ section: Designing workflows
 
 The branch function allows you to execute discrete branches of logic within your workflows using our powerful [conditions builder](/concepts/conditions) to specify the criteria for when a branch should execute.
 
-You can think about the branch function in Knock as an `if/else` step, with the ability to add multiple `else if` clauses. Each branch has access to the full [workflow run scope](/concepts/conditions#condition-types) to evaluate conditions.
+You can think about the branch function in Knock as an `if/else` step, with the ability to add multiple `else if` clauses. Each branch has access to the full [workflow run scope](/concepts/conditions#condition-types) to evaluate conditions. Knock will execute the first branch whose conditions evaluate to `true`.
 
 ![Branching by a recipient plan type](/images/branch-step.png)
 


### PR DESCRIPTION
### Description

There is a branch limitation spelled out in the UI text 'Knock will execute the first branch whose conditions evaluate to true' that should also appear in the actual text of the docs.


### Screenshots
Before
<img width="708" alt="Screenshot 2023-12-20 at 7 56 21 AM" src="https://github.com/knocklabs/docs/assets/7818951/a79623ef-1f8e-4b7b-a179-d217963b8f0b">

After
<img width="711" alt="Screenshot 2023-12-20 at 7 55 57 AM" src="https://github.com/knocklabs/docs/assets/7818951/9b7facb7-77e9-43ad-8019-808510594365">
