### PR TITLE
chore(kno-4899): clarify security requirements for in-app feed docs

### DIFF
--- a/content/in-app-ui/ios/reference.mdx
+++ b/content/in-app-ui/ios/reference.mdx
@@ -28,11 +28,15 @@ The top-level Knock class. Create an authenticated Knock client instance for int
     type="string (optional)"
     description={
       <>
-        A signed user token, required when{" "}
-        <a href="/in-app-ui/security-and-authentication">
-          enhanced security mode
-        </a>{" "}
-        is enabled on the environment.
+        A JWT that identifies the authenticated user, signed with the private
+        key provided in the Knock dashboard. Required to secure your production
+        environment.{" "}
+        <a
+          href="https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security-enabled"
+          target="_blank"
+        >
+          Learn more.
+        </a>
       </>
     }
   />

--- a/content/in-app-ui/ios/reference.mdx
+++ b/content/in-app-ui/ios/reference.mdx
@@ -26,7 +26,15 @@ The top-level Knock class. Create an authenticated Knock client instance for int
   <Attribute
     name="userToken"
     type="string (optional)"
-    description="A signed user token, required when [enhanced security mode](/in-app-ui/security-and-authentication) is enabled on the environment."
+    description={
+      <>
+        A signed user token, required when{" "}
+        <a href="/in-app-ui/security-and-authentication">
+          enhanced security mode
+        </a>{" "}
+        is enabled on the environment.
+      </>
+    }
   />
   <Attribute
     name="hostname"

--- a/content/in-app-ui/ios/reference.mdx
+++ b/content/in-app-ui/ios/reference.mdx
@@ -26,7 +26,7 @@ The top-level Knock class. Create an authenticated Knock client instance for int
   <Attribute
     name="userToken"
     type="string (optional)"
-    description="A signed user token, required when enhanced security mode is enabled on the environment."
+    description="A signed user token, required when [enhanced security mode](/in-app-ui/security-and-authentication) is enabled on the environment."
   />
   <Attribute
     name="hostname"

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -45,7 +45,7 @@ npm install @knocklabs/react-notification-feed
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      &nbsp;<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
+      {" "}<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
       For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -38,6 +38,21 @@ npm install @knocklabs/react-notification-feed
 
 ## Rendering a notification feed
 
+<Callout emoji="🔐"
+  text={
+    <>
+      <span className="font-bold">Secure your feed: </span> By default, Knock
+      feeds are accessible to anyone who has the feed ID. This makes it
+      easy to get started in development. To secure your feed for production,
+      enable enhanced security mode in your Knock dashboard and pass a signed
+      `userToken` as a prop to the `KnockFeedProvider` component.
+
+      For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
+      for client-side applications.
+    </>
+  }
+/>
+
 ### Using the `KnockFeedProvider`
 
 ```jsx
@@ -52,6 +67,9 @@ const YourApp = () => {
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
       feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={currentUser.id}
+      // In production, you must pass a signed userToken
+      // and enable enhanced security mode in your Knock dashboard
+      // userToken={currentUser.knockUserToken}
     >
       <NotificationFeed />
     </KnockFeedProvider>

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -50,7 +50,8 @@ npm install @knocklabs/react-notification-feed
       For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
       for client-side applications.
     </>
-  }
+
+}
 />
 
 ### Using the `KnockFeedProvider`

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -45,7 +45,7 @@ npm install @knocklabs/react-notification-feed
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      <code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
+      &nbsp;<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
       For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -45,9 +45,9 @@ npm install @knocklabs/react-notification-feed
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      `userToken` as a prop to the `KnockFeedProvider` component.
+      <code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
-      For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
+      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.
     </>
 

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -50,7 +50,7 @@ To add a real-time notifications feed to your product, you can use the out-of-th
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      &nbsp;<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
+      {" "}<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
       For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -50,7 +50,7 @@ To add a real-time notifications feed to your product, you can use the out-of-th
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      <code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
+      &nbsp;<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
       For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -55,7 +55,8 @@ To add a real-time notifications feed to your product, you can use the out-of-th
       For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
       for client-side applications.
     </>
-  }
+
+}
 />
 
 ```jsx

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -50,9 +50,9 @@ To add a real-time notifications feed to your product, you can use the out-of-th
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
-      `userToken` as a prop to the `KnockFeedProvider` component.
+      <code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
-      For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
+      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
       for client-side applications.
     </>
 

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -43,6 +43,21 @@ npm install @knocklabs/react-notification-feed
 
 To add a real-time notifications feed to your product, you can use the out-of-the-box components that the `@knocklabs/react-notification-feed` library offers.
 
+<Callout emoji="🔐"
+  text={
+    <>
+      <span className="font-bold">Secure your feed: </span> By default, Knock
+      feeds are accessible to anyone who has the feed ID. This makes it
+      easy to get started in development. To secure your feed for production,
+      enable enhanced security mode in your Knock dashboard and pass a signed
+      `userToken` as a prop to the `KnockFeedProvider` component.
+
+      For more information, visit [the security & authentication guide](/in-app-ui/security-and-authentication)
+      for client-side applications.
+    </>
+  }
+/>
+
 ```jsx
 import { useState, useRef } from "react";
 import {
@@ -63,6 +78,9 @@ const YourAppLayout = () => {
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
       feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={currentUser.id}
+      // In production, you must pass a signed userToken
+      // and enable enhanced security mode in your Knock dashboard
+      // userToken={currentUser.knockUserToken}
     >
       <>
         <NotificationIconButton


### PR DESCRIPTION
### Description

Some customers have been confused about how to secure the notification feed. This adds relevant context to our in-app feed docs, linking back to the guide on securing the feeds.

KNO-4899

