### PR TITLE
Fix canonical links for all docs

### DIFF
--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -45,7 +45,7 @@ export default function Meta(props) {
     return {
       title: props.title ?? DEFAULT_META.title,
       description: props.description ?? DEFAULT_META.description,
-      canonical: `${SITE_ORIGIN}${router.asPath.split('?')[0]}`,
+      canonical: `${SITE_ORIGIN}${router.asPath.split("?")[0]}`,
       openGraph: {
         type: "website",
         images: [

--- a/components/Meta.tsx
+++ b/components/Meta.tsx
@@ -45,7 +45,7 @@ export default function Meta(props) {
     return {
       title: props.title ?? DEFAULT_META.title,
       description: props.description ?? DEFAULT_META.description,
-      canonical: `${SITE_ORIGIN}${router.pathname}`,
+      canonical: `${SITE_ORIGIN}${router.asPath.split('?')[0]}`,
       openGraph: {
         type: "website",
         images: [


### PR DESCRIPTION
Fixes an issue where canonical links are current [slug] because of 'pathname' being used. 