### PR TITLE
feat(KNO-4921): Update api reference with workflow categories

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -816,6 +816,11 @@ Retrieve a paginated list of messages for a user. Will return most recent messag
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
+    name="workflow_categories"
+    type="string[] (optional)"
+    description="Limits the results to only items related to any of the provided categories"
+  />
+  <Attribute
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
@@ -856,7 +861,8 @@ A paginated list of Message records
       "source": {
         "__typename": "WorkflowSource",
         "key": "merged-changes",
-        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de"
+        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de",
+        "categories": ["reminders"]
       },
       "data": {
         "foo": "bar"
@@ -2399,7 +2405,8 @@ as such return information that is required on the client to do so**
       "source": {
         "__typename": "WorkflowSource",
         "key": "merged-changes",
-        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de"
+        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de",
+        "categories": ["reminders"]
       },
       "tenant": null,
       "total_activities": 1,
@@ -2508,6 +2515,11 @@ along with a user token to make this request**
     name="status"
     type="string (optional)"
     description="One of `unread`,`read`, `unseen`,`seen`, `all`"
+  />
+  <Attribute
+    name="workflow_categories"
+    type="string[] (optional)"
+    description="Limits the feed to only display items related to any of the provided categories"
   />
   <Attribute
     name="archived"
@@ -2660,7 +2672,8 @@ A message is a notification delivered on a particular channel to a user.
   "source": {
     "__typename": "WorkflowSource",
     "key": "merged-changes",
-    "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de"
+    "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de",
+    "categories": ["reminders"]
   },
   "data": {
     "foo": "bar"
@@ -2726,6 +2739,11 @@ Returns a paginated list of messages.
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
+    name="workflow_categories"
+    type="string[] (optional)"
+    description="Limits the results to only items related to any of the provided categories"
+  />
+  <Attribute
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
@@ -2768,7 +2786,8 @@ A paginated list of Message records
       "source": {
         "__typename": "WorkflowSource",
         "key": "merged-changes",
-        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de"
+        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de",
+        "categories": ["reminders"]
       },
       "data": {
         "foo": "bar"
@@ -3785,6 +3804,11 @@ Returns a paginated list of messages for an object. Will return newest messages 
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
+    name="workflow_categories"
+    type="string[] (optional)"
+    description="Limits the results to only items related to any of the provided categories"
+  />
+  <Attribute
     type="JSON string (optional)"
     type="object (optional)"
     description="Limits the results to only items that were generated with the given data"
@@ -3827,7 +3851,8 @@ A paginated list of Message records
       "source": {
         "__typename": "WorkflowSource",
         "key": "merged-changes",
-        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de"
+        "version_id": "7251cd3f-0028-4d1a-9466-ee79522ba3de",
+        "categories": ["reminders"]
       },
       "data": {
         "foo": "bar"


### PR DESCRIPTION
### Description
Updates the `Api reference` section adding the new `workflow categories` param.
To be more specific, this param was added to the following endpoint sections:
* GET /users/:id/messages
* GET /messages
* GET /objects/:collection/:id/messages
* GET /users/:user_id/feeds/:feed_id

This PR also includes a change to the notification `source` in the JSON response example, so now it includes `categories`.

### Tasks

[KNO-4921](https://linear.app/knock/issue/KNO-4921/[docs]-add-workflow-categories-filter-to-messagesfeed-api-reference)
