### PR TITLE
chore: add timezone information to user concept page and API reference

### DIFF
--- a/content/concepts/users.mdx
+++ b/content/concepts/users.mdx
@@ -50,6 +50,7 @@ The following attributes are optional, depending on the channel types you decide
 | name         | The full name of the user                                                                                        |
 | avatar       | A URL for the avatar of the user                                                                                 |
 | phone_number | The [E.164](https://www.twilio.com/docs/glossary/what-e164) phone number of the user (required for SMS channels) |
+| timezone     | A valid [tz database time zone string](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (optional for [recurring schedules](/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients)) |
 
 ### Storing user properties
 

--- a/content/concepts/users.mdx
+++ b/content/concepts/users.mdx
@@ -44,12 +44,12 @@ The following attributes are required for each user you identify with Knock.
 
 The following attributes are optional, depending on the channel types you decide to use with Knock.
 
-| Property     | Description                                                                                                      |
-| ------------ | ---------------------------------------------------------------------------------------------------------------- |
-| email        | The primary email address for the user (required for email channels)                                             |
-| name         | The full name of the user                                                                                        |
-| avatar       | A URL for the avatar of the user                                                                                 |
-| phone_number | The [E.164](https://www.twilio.com/docs/glossary/what-e164) phone number of the user (required for SMS channels) |
+| Property     | Description                                                                                                                                                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| email        | The primary email address for the user (required for email channels)                                                                                                                                                        |
+| name         | The full name of the user                                                                                                                                                                                                   |
+| avatar       | A URL for the avatar of the user                                                                                                                                                                                            |
+| phone_number | The [E.164](https://www.twilio.com/docs/glossary/what-e164) phone number of the user (required for SMS channels)                                                                                                            |
 | timezone     | A valid [tz database time zone string](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) (optional for [recurring schedules](/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients)) |
 
 ### Storing user properties

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -616,10 +616,8 @@ Identifying a user will create or update a user in Knock, merging the properties
     type="string (optional)"
     description={
       <span>
-        The timezone of the user. Must be a valid 
-        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
-        . Used for 
-        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
+        The timezone of the user. Must be a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
+        . Used for <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
       </span>
     }
   />

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -620,9 +620,11 @@ Identifying a user will create or update a user in Knock, merging the properties
         <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
           tz database time zone string
         </a>
-        . Used for <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
+        . Used for{" "}
+        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
           recurring schedules
-        </a>.
+        </a>
+        .
       </span>
     }
   />

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -615,17 +615,19 @@ Identifying a user will create or update a user in Knock, merging the properties
     name="timezone"
     type="string (optional)"
     description={
-      <span>
-        The timezone of the user. Must be a valid{" "}
-        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
-          tz database time zone string
-        </a>
-        . Used for{" "}
-        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
-          recurring schedules
-        </a>
-        .
-      </span>
+      <>
+        <span>
+          The timezone of the user. Must be a valid{" "}
+          <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
+            tz database time zone string
+          </a>
+          . Used for{" "}
+          <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
+            recurring schedules
+          </a>
+          .
+        </span>
+      </>
     }
   />
   <Attribute

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -621,11 +621,9 @@ Identifying a user will create or update a user in Knock, merging the properties
           <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
             tz database time zone string
           </a>
-          . Used for{" "}
-          <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
+          . Used for <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
             recurring schedules
-          </a>
-          .
+          </a>.
         </span>
       </>
     }

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -617,9 +617,12 @@ Identifying a user will create or update a user in Knock, merging the properties
     description={
       <span>
         The timezone of the user. Must be a valid{" "}
-        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
-        . Used for{" "}
-        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
+        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">
+          tz database time zone string
+        </a>
+        . Used for <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">
+          recurring schedules
+        </a>.
       </span>
     }
   />

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -615,13 +615,12 @@ Identifying a user will create or update a user in Knock, merging the properties
     name="timezone"
     type="string (optional)"
     description={
-      <>
-        <span>The timezone of the user. Must be a valid </span>
+      <span>
+        The timezone of the user. Must be a valid 
         <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
-        <span>. Used for </span>
-        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>
-        <span>.</span>
-      </>
+        . Used for 
+        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
+      </span>
     }
   />
   <Attribute

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -616,8 +616,10 @@ Identifying a user will create or update a user in Knock, merging the properties
     type="string (optional)"
     description={
       <span>
-        The timezone of the user. Must be a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
-        . Used for <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
+        The timezone of the user. Must be a valid{" "}
+        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
+        . Used for{" "}
+        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>.
       </span>
     }
   />

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -612,6 +612,19 @@ Identifying a user will create or update a user in Knock, merging the properties
     }
   />
   <Attribute
+    name="timezone"
+    type="string (optional)"
+    description={
+      <>
+        <span>The timezone of the user. Must be a valid </span>
+        <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">tz database time zone string</a>
+        <span>. Used for </span>
+        <a href="/concepts/schedules#scheduling-workflows-with-recurring-schedules-for-recipients">recurring schedules</a>
+        <span>.</span>
+      </>
+    }
+  />
+  <Attribute
     name="*"
     type="key-value pairs"
     description="Any custom properties"
@@ -634,6 +647,7 @@ A User.
   "name": "User name",
   "email": "user@example.com",
   "locale": "en",
+  "timezone": "America/New_York",
   "foo": "bar",
   "baz": true,
   "created_at": null,


### PR DESCRIPTION
In response to user feedback about lacking documentation of the `timezone` parameter for User objects, this PR updates both the concept page for Users (/concepts/users) and the API reference for identifying a user (/reference#identify-user) in order to clarify its usage.
