### PR TITLE
fix: update mistyped field to resolve JSX error

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -3809,7 +3809,7 @@ Returns a paginated list of messages for an object. Will return newest messages 
     description="Limits the results to only items related to any of the provided categories"
   />
   <Attribute
-    type="JSON string (optional)"
+    name="JSON string (optional)"
     type="object (optional)"
     description="Limits the results to only items that were generated with the given data"
   />


### PR DESCRIPTION
A `name` field on an attribute in the API reference is mis-labeled as a `type`, resulting in a JSX error for two fields with the same name. This PR resolves the typo.
