### PR TITLE
fix: missing word in mapi reference

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -236,7 +236,7 @@ Optional settings for a workflow.
   <Attribute
     name="override_preferences"
     type="boolean"
-    description="Whether to ignore recipient preferences for a given type of notification. If true, will send for every channel in the workflow even if the recipient has opted of a certain kind. Defaults to false."
+    description="Whether to ignore recipient preferences for a given type of notification. If true, will send for every channel in the workflow even if the recipient has opted out of a certain kind. Defaults to false."
   />
 </Attributes>
 


### PR DESCRIPTION
Add missing word 
