### PR TITLE
chore: update `/messages/:id/:status` endpoint descriptions to clarify functionality

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -3178,7 +3178,7 @@ A paginated list of `MessageDeliveryLog`.
 <Section title="Updating a message status" slug="update-message-status">
 <ContentColumn>
 
-Marks the given message as the `status`, recording an event in the process.
+Marks the given message with the provided `status`, recording an event in the process.
 
 ### Endpoint
 
@@ -3209,7 +3209,7 @@ A Message.
 <Section title="Undoing a message status change" slug="undo-message-status">
 <ContentColumn>
 
-Un-marks the given message as the `status`, recording an event in the process.
+Un-marks the given `status` on a message, recording an event in the process.
 
 ### Endpoint
 


### PR DESCRIPTION
I find the existing English-language descriptions for the `/messages/:id/:status` endpoint (both `PUT` and `DELETE` methods) to be confusing. This PR attempts to clarify functionality by tweaking the descriptions.
