### PR TITLE
Chore: Add callout regarding transferring email templates

### DIFF
--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -236,3 +236,23 @@ Keep in mind that to override any of the base component style properties listed 
   margin-bottom: 0;
 }
 ```
+
+<br></br>
+
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <span className="font-bold">Reminder: </span>The email layout contains the{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>head</code>{" "}
+      and{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>body</code>{" "}
+      tags. If you are transferring an email template from an outside source,
+      you may need to make adjustments to remove the{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>head</code>{" "}
+      and{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>body</code>{" "}
+      tags from your email template file within Knock.
+    </>
+  }
+/>

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -244,14 +244,22 @@ Keep in mind that to override any of the base component style properties listed 
   text={
     <>
       <span className="font-bold">Reminder: </span>The email layout contains the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;head&gt;</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;head&gt;
+      </code>{" "}
       and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;body&gt;</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;body&gt;
+      </code>{" "}
       tags. If you are transferring an email template from an outside source,
       you may need to make adjustments to remove the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;head&gt;</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;head&gt;
+      </code>{" "}
       and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;body&gt;</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;body&gt;
+      </code>{" "}
       tags from your email template file within Knock.
     </>
   }

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -244,14 +244,14 @@ Keep in mind that to override any of the base component style properties listed 
   text={
     <>
       <span className="font-bold">Reminder: </span>The email layout contains the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>head</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;head&gt;</code>{" "}
       and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>body</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;body&gt;</code>{" "}
       tags. If you are transferring an email template from an outside source,
       you may need to make adjustments to remove the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>head</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;head&gt;</code>{" "}
       and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>body</code>{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>&lt;body&gt;</code>{" "}
       tags from your email template file within Knock.
     </>
   }

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -184,8 +184,8 @@ Regardless of the layout you've chosen for a given email step, you'll be able to
   emoji="🌠"
   text={
     <>
-      <span className="font-bold">Note: </span>Since the email layout contains
-      the{" "}
+      <span className="font-bold">Note: </span>Since each Knock email layout
+      contains{" "}
       <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
         &lt;head&gt;
       </code>{" "}
@@ -193,8 +193,9 @@ Regardless of the layout you've chosen for a given email step, you'll be able to
       <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
         &lt;body&gt;
       </code>{" "}
-      tags, if you are transferring an email template from an outside source,
-      you may need to make adjustments to remove the{" "}
+      tags, these tags should not be included in your workflow's email template.
+      If you are transferring email content from an outside source, you may need
+      to make adjustments to remove any{" "}
       <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
         &lt;head&gt;
       </code>{" "}
@@ -202,7 +203,7 @@ Regardless of the layout you've chosen for a given email step, you'll be able to
       <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
         &lt;body&gt;
       </code>{" "}
-      tags from your email template file within Knock.
+      tags prior to saving your email template within a Knock workflow.
     </>
   }
 />

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -180,6 +180,33 @@ If you're looking to use a blank or empty email layout you should use the follow
 
 Regardless of the layout you've chosen for a given email step, you'll be able to use the [visual template editor](/send-notifications/designing-workflows/template-editor#visual-editing-with-drag-and-drop-components) to compose the `content` of your email template.
 
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Note: </span>Since the email layout contains
+      the{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;head&gt;
+      </code>{" "}
+      and{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;body&gt;
+      </code>{" "}
+      tags, if you are transferring an email template from an outside source,
+      you may need to make adjustments to remove the{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;head&gt;
+      </code>{" "}
+      and{" "}
+      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
+        &lt;body&gt;
+      </code>{" "}
+      tags from your email template file within Knock.
+    </>
+  }
+/>
+
 When you use the visual template editor to insert components such as buttons and dividers into your email, Knock auto-generates CSS using a set of base component styles. You can find these styles in the section below, where we also cover updating these styles to match your design system.
 
 <Callout
@@ -236,31 +263,3 @@ Keep in mind that to override any of the base component style properties listed 
   margin-bottom: 0;
 }
 ```
-
-<br></br>
-
-<Callout
-  emoji="🚨"
-  text={
-    <>
-      <span className="font-bold">Reminder: </span>The email layout contains the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
-        &lt;head&gt;
-      </code>{" "}
-      and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
-        &lt;body&gt;
-      </code>{" "}
-      tags. If you are transferring an email template from an outside source,
-      you may need to make adjustments to remove the{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
-        &lt;head&gt;
-      </code>{" "}
-      and{" "}
-      <code style={{ fontWeight: 600, backgroundColor: "inherit" }}>
-        &lt;body&gt;
-      </code>{" "}
-      tags from your email template file within Knock.
-    </>
-  }
-/>


### PR DESCRIPTION
### Description

Adds a callout in the email layout documentation to remind users that `<head>` and `<body>` are included in the **layout** and should not be added to the **template** when transferring a template from an outside provider. Adding this to the documentation as this has come up twice in the last month when helping customers. 