### PR TITLE
chore: update react docs to reference @knocklabs/react

### DIFF
--- a/content/designing-workflows/channel-step.mdx
+++ b/content/designing-workflows/channel-step.mdx
@@ -29,7 +29,7 @@ The Knock [Feed API](/reference#feeds) gives developers a way to deliver in-app 
 
 There are a few ways to power in-app notifications in your product using Knock:
 
-- **Use our [React notification feed component](https://github.com/knocklabs/react-notification-feed).** The Knock notification feed component provides real-time updates, pagination, badge behavior, filtering, and more. It's a great way to quickly add an in-app feed to your product if you use React.
+- **Use our [React SDK](https://github.com/knocklabs/javascript/tree/main/packages/react).** The Knock notification feed component provides real-time updates, pagination, badge behavior, filtering, and more. It's a great way to quickly add an in-app feed to your product if you use React.
 - **Leverage our [client-side JS SDK](https://github.com/knocklabs/knock-client-js).** This is a good approach if you need to use a component library outside of React JS but are still in the JS ecosystem.
 - **Integrate with our [API directly](/reference#feeds).** If you're not working within the JS ecosystem in your client, you can integrate directly with the Knock Feed API to power your in-app notifications.
 

--- a/content/guides/customizing-react-in-app-feed-components.mdx
+++ b/content/guides/customizing-react-in-app-feed-components.mdx
@@ -14,7 +14,7 @@ In some applications, you may want to override the styles provided in the React 
 
 If you're importing the CSS styles associated with the components, then it's possible to use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) to override the majority of the properties used within the stylesheet, such as colors, font sizes, ad more.
 
-The CSS variables that are used within the components are all prefixed with `--rnf-`. The complete set of overrides is here, for reference, or available in the [theme.css file](https://raw.githubusercontent.com/knocklabs/react-notification-feed/main/src/theme.css).
+The CSS variables that are used within the components are all prefixed with `--rnf-`. The complete set of overrides is here, for reference, or available in the [theme.css file](https://raw.githubusercontent.com/knocklabs/javascript/main/packages/react/src/theme.css).
 
 ```css
 :root {
@@ -94,7 +94,7 @@ Then we'd import like:
 
 ```javascript
 // Default styles
-import "@knocklabs/react-notification-feed/dist/index.css";
+import "@knocklabs/react/dist/index.css";
 
 // Overrides
 import "~/styles/feed-overrides.css";
@@ -106,10 +106,10 @@ If you need more fine-grained control over the CSS provided by the components, i
 
 All of the notification feed components have classes prefixed with `rnf-`. You can see the existing CSS styles here, which are written using CSS modules to be isolated per component.
 
-- [NotificationFeed](https://github.com/knocklabs/react-notification-feed/blob/main/src/components/NotificationFeed/styles.css)
-- [NotificationFeedPopover](https://github.com/knocklabs/react-notification-feed/blob/main/src/components/NotificationFeedPopover/styles.css)
-- [NotificationCell](https://github.com/knocklabs/react-notification-feed/blob/main/src/components/NotificationCell/styles.css)
-- [EmptyFeed](https://github.com/knocklabs/react-notification-feed/blob/main/src/components/EmptyFeed/styles.css)
+- [NotificationFeed](https://github.com/knocklabs/javascript/blob/main/packages/react/src/modules/feed/components/NotificationFeed/styles.css)
+- [NotificationFeedPopover](https://github.com/knocklabs/javascript/blob/main/packages/react/src/modules/feed/components/NotificationFeedPopover/styles.css)
+- [NotificationCell](https://github.com/knocklabs/javascript/blob/main/packages/react/src/modules/feed/components/NotificationCell/styles.css)
+- [EmptyFeed](https://github.com/knocklabs/javascript/blob/main/packages/react/src/modules/feed/components/EmptyFeed/styles.css)
 
 ### Partially overriding the feed CSS
 
@@ -129,7 +129,7 @@ And when we import those styles, we'll want to ensure our overrides are imported
 
 ```javascript
 // Default styles
-import "@knocklabs/react-notification-feed/dist/index.css";
+import "@knocklabs/react/dist/index.css";
 
 // Overrides
 import "~/styles/feed-overrides.css";
@@ -179,7 +179,7 @@ The React component library ships with hooks that you can use to setup and manag
 First of all, we need to use the `useAuthenticatedKnockClient` hook to create a Knock client instance, authenticated for the user that's provided.
 
 ```jsx Setting up a Knock client
-import { useAuthenticatedKnockClient } from "@knocklabs/react-notification-feed";
+import { useAuthenticatedKnockClient } from "@knocklabs/react";
 
 const NotificationFeed = ({ user }) => {
   const knockClient = useAuthenticatedKnockClient(
@@ -197,7 +197,7 @@ Next up, we then set up our feed instance using the `useNotifications` hook. Thi
 import {
   useAuthenticatedKnockClient,
   useNotifications,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 
 const NotificationFeed = ({ user }) => {
   const knockClient = useAuthenticatedKnockClient(
@@ -216,7 +216,7 @@ Now we have our Feed instance, then we need to have a way to access the state of
 import {
   useAuthenticatedKnockClient,
   useNotifications,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 import create from "zustand";
 import { useEffect } from "react";
 
@@ -242,24 +242,24 @@ With our component set up, we have all the building blocks we need to build our 
 
 The `KnockFeedProvider` can also be used to set up the feed instance and build custom UI, which is what the pre-built components use under the hood.
 
-The first step is to set up a wrapper component that will render your Feed with the `KnockFeedProvider`:
+The first step is to set up a wrapper component that will render your Feed with the `KnockProvider` and `KnockFeedProvider`:
 
 ```jsx Setting up our feed provider
-import { KnockFeedProvider } from "@knocklabs/react-notification-feed";
+import { KnockProvider, KnockFeedProvider } from "@knocklabs/react";
 
 const NotificationFeed = ({ user }) => (
-  <KnockFeedProvider
-    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-    feedId={process.env.KNOCK_FEED_CHANNEL_ID}
-    userId={user.id}
-  ></KnockFeedProvider>
+  <KnockProvider apiKey={process.env.KNOCK_PUBLIC_API_KEY} userId={user.id}>
+    <KnockFeedProvider
+      feedId={process.env.KNOCK_FEED_CHANNEL_ID}
+    ></KnockFeedProvider>
+  </KnockProvider>
 );
 ```
 
 Now that our provider is set up, we're going to split out a subcomponent that will be used to render the actual contents of the feed. The reason we have this as a separate component is so we can access the context that the `KnockFeedProvider` exposes.
 
 ```jsx Implementing our feed component
-import { useKnockFeed } from "@knocklabs/react-notification-feed";
+import { useKnockFeed } from "@knocklabs/react";
 
 const Feed = () => {
   const { useFeedStore } = useKnockFeed();
@@ -275,16 +275,14 @@ Note here we're using the `useFeedStore` hook that the `useKnockFeed` hook retur
 And finally, to put it all together:
 
 ```jsx Our working custom feed
-import { KnockFeedProvider } from "@knocklabs/react-notification-feed";
+import { KnockFeedProvider } from "@knocklabs/react";
 import Feed from "~/components/Feed";
 
 const NotificationFeed = ({ user }) => (
-  <KnockFeedProvider
-    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-    feedId={process.env.KNOCK_FEED_CHANNEL_ID}
-    userId={user.id}
-  >
-    <Feed />
-  </KnockFeedProvider>
+  <KnockProvider apiKey={process.env.KNOCK_PUBLIC_API_KEY} userId={user.id}>
+    <KnockFeedProvider feedId={process.env.KNOCK_FEED_CHANNEL_ID}>
+      <Feed />
+    </KnockFeedProvider>
+  </KnockProvider>
 );
 ```

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -33,7 +33,7 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 ## Installing dependencies
 
 ```bash Installing dependencies
-npm install @knocklabs/react-notification-feed
+npm install @knocklabs/react-native
 ```
 
 ## Rendering a notification feed

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -5,13 +5,13 @@ tags: ["inbox", "feeds", "toasts", "action_url"]
 section: Building in-app UI
 ---
 
-Our `@knocklabs/react-notification-feed` library comes pre-built with a real-time feed component that you can drop into your application. In this guide, you'll find common recipes to help you work with the Knock feed component.
+Our `@knocklabs/react` library comes pre-built with a real-time feed component that you can drop into your application. In this guide, you'll find common recipes to help you work with the Knock feed component.
 
 [See a live demo](https://knock-in-app-notifications-react.vercel.app/)
 
 **Quick links**:
 
-- [`@knocklabs/react-notification-feed` library reference](/in-app-ui/react/reference)
+- [`@knocklabs/react` library reference](/in-app-ui/react/reference)
 - [`@knocklabs/client` library reference](/in-app-ui/javascript/reference)
 
 ## Getting started
@@ -36,12 +36,12 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 ## Installing dependencies
 
 ```bash Installing dependencies
-npm install @knocklabs/react-notification-feed
+npm install @knocklabs/react
 ```
 
 ## Rendering a notification feed
 
-To add a real-time notifications feed to your product, you can use the out-of-the-box components that the `@knocklabs/react-notification-feed` library offers.
+To add a real-time notifications feed to your product, you can use the out-of-the-box components that the `@knocklabs/react` library offers.
 
 <Callout emoji="🔐"
   text={
@@ -62,39 +62,41 @@ To add a real-time notifications feed to your product, you can use the out-of-th
 ```jsx
 import { useState, useRef } from "react";
 import {
+  KnockProvider,
   KnockFeedProvider,
   NotificationIconButton,
   NotificationFeedPopover,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 
 // Required CSS import, unless you're overriding the styling
-import "@knocklabs/react-notification-feed/dist/index.css";
+import "@knocklabs/react/dist/index.css";
 
 const YourAppLayout = () => {
   const [isVisible, setIsVisible] = useState(false);
   const notifButtonRef = useRef(null);
 
   return (
-    <KnockFeedProvider
+    <KnockProvider
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-      feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={currentUser.id}
       // In production, you must pass a signed userToken
       // and enable enhanced security mode in your Knock dashboard
       // userToken={currentUser.knockUserToken}
     >
-      <>
-        <NotificationIconButton
-          ref={notifButtonRef}
-          onClick={(e) => setIsVisible(!isVisible)}
-        />
-        <NotificationFeedPopover
-          buttonRef={notifButtonRef}
-          isVisible={isVisible}
-          onClose={() => setIsVisible(false)}
-        />
-      </>
-    </KnockFeedProvider>
+      <KnockFeedProvider feedId={process.env.KNOCK_FEED_CHANNEL_ID}>
+        <>
+          <NotificationIconButton
+            ref={notifButtonRef}
+            onClick={(e) => setIsVisible(!isVisible)}
+          />
+          <NotificationFeedPopover
+            buttonRef={notifButtonRef}
+            isVisible={isVisible}
+            onClose={() => setIsVisible(false)}
+          />
+        </>
+      </KnockFeedProvider>
+    </KnockProvider>
   );
 };
 ```
@@ -110,7 +112,7 @@ You can pass a value in the Action URL field of your notification template and t
 You can customize the click handler for the notification cell as follows:
 
 ```jsx
-import { NotificationFeed } from "@knocklabs/react-notification-feed";
+import { NotificationFeed } from "@knocklabs/react";
 
 <NotificationFeed onNotificationClick={(item) => onClose()} />;
 ```
@@ -122,7 +124,7 @@ Both the `NotificationFeed` and the `NotificationFeedPopover` take a `onNotifica
 You can customize the rendering of a notification cell in the feed by overriding the `renderItem` prop.
 
 ```jsx
-import { NotificationFeed } from "@knocklabs/react-notification-feed";
+import { NotificationFeed } from "@knocklabs/react";
 
 const MyNotificationCell = ({ item, onItemClick }) => <Outer>...</Outer>;
 
@@ -134,11 +136,7 @@ const MyNotificationCell = ({ item, onItemClick }) => <Outer>...</Outer>;
 You can customize the `Avatar` component rendered within the `NotificationCell` by passing a different `avatar` component into the `NotificationCell` in the `renderItem` function passed to the feed:
 
 ```jsx
-import {
-  NotificationFeed,
-  NotificationCell,
-  Avatar,
-} from "@knocklabs/react-notification-feed";
+import { NotificationFeed, NotificationCell, Avatar } from "@knocklabs/react";
 
 <NotificationFeed
   renderItem={({ item, ...props }) => (
@@ -155,7 +153,7 @@ import {
 ### Using `read` instead of `seen` for the badge count
 
 ```jsx
-import { NotificationIconButton } from "@knocklabs/react-notification-feed";
+import { NotificationIconButton } from "@knocklabs/react";
 
 <NotificationIconButton onClick={...} badgeCountType="unread" />;
 ```
@@ -163,7 +161,7 @@ import { NotificationIconButton } from "@knocklabs/react-notification-feed";
 ### Marking messages as read on the popover opening
 
 ```jsx
-import { NotificationFeedPopover } from "@knocklabs/react-notification-feed";
+import { NotificationFeedPopover } from "@knocklabs/react";
 
 const onOpen = ({ store, feedClient }) => {
   const unreadItems = store.items.filter((item) => !item.read_at);
@@ -184,7 +182,7 @@ const onOpen = ({ store, feedClient }) => {
 The feed supports an optional `colorMode` prop, that defaults to `light` but can be set as `dark` for dark mode support.
 
 ```jsx
-import { KnockFeedProvider } from "@knocklabs/react-notification-feed";
+import { KnockFeedProvider } from "@knocklabs/react";
 
 <KnockFeedProvider colorMode="dark" />;
 ```
@@ -203,7 +201,7 @@ import {
   Button,
   NotificationFeed,
   NotificationCell,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 
 <NotificationFeed
   renderItem={({ item, ...props }) => (
@@ -233,7 +231,7 @@ import {
   Button,
   NotificationFeed,
   NotificationCell,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 
 <NotificationFeed
   renderItem={({ item, ...props }) => (
@@ -276,24 +274,23 @@ You can see a demo of this behavior here:
 
 The complete theme that controls the look and feel of the feed components can be customized for theme in a few different ways:
 
-1. **Customizing the CSS variables**. The feed is written using CSS variables, which you can override to better match the look and feel of your product. The best way to see the possible CSS variables in use is to look at the [theme.css source code](https://github.com/knocklabs/react-notification-feed/blob/main/src/theme.css).
+1. **Customizing the CSS variables**. The feed is written using CSS variables, which you can override to better match the look and feel of your product. The best way to see the possible CSS variables in use is to look at the [theme.css source code](https://github.com/knocklabs/javascript/blob/main/packages/react/src/theme.css).
 
-2. **Bringing your own CSS**. It's possible to override the Knock CSS entirely to customize the look and feel of the feed. All of the feed classes are unique and start with `rnf-`. You can see the classes in use by looking at the [source code of the components](https://github.com/knocklabs/react-notification-feed/blob/main/src/).
+2. **Bringing your own CSS**. It's possible to override the Knock CSS entirely to customize the look and feel of the feed. All of the feed classes are unique and start with `rnf-`. You can see the classes in use by looking at the [source code of the components](https://github.com/knocklabs/javascript/tree/main/packages/react/src).
 
 ### Setting custom translations
 
-You can set custom translations for the components inside the feed by passing the `i18n` property to the `KnockFeedProvider` component. You can provide a partial or full set of translations to be used [following the expected `I18nContent` type](/in-app-ui/react/reference#i18ncontent).
+You can set custom translations for the components inside the feed by passing the `i18n` property to the `KnockProvider` component. You can provide a partial or full set of translations to be used [following the expected `I18nContent` type](/in-app-ui/react/reference#i18ncontent).
 
 **Note**: the default locale used in the components will be `en`. No other translations are provided out-of-the-box.
 
 ```jsx
-import { KnockFeedProvider } from "@knocklabs/react-notification-feed";
+import { KnockProvider } from "@knocklabs/react";
 
 const YourAppLayout = () => {
   return (
-    <KnockFeedProvider
+    <KnockProvider
       apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-      feedId={process.env.KNOCK_FEED_CHANNEL_ID}
       userId={currentUser.id}
       i18n={{
         translations: {

--- a/content/in-app-ui/react/reference.mdx
+++ b/content/in-app-ui/react/reference.mdx
@@ -325,7 +325,7 @@ The `KnockFeedProvider` exposes a `useKnockFeed` hook for all child components.
 **Example**:
 
 ```jsx
-import { useKnockFeed } from "@knocklabs/react-notification-feed";
+import { useKnockFeed } from "@knocklabs/react";
 
 const App = ({ authenticatedUser }) => (
   <KnockFeedProvider
@@ -360,7 +360,7 @@ Creates an authenticated Knock client.
 **Example**:
 
 ```jsx
-import { useAuthenticatedKnockClient } from "@knocklabs/react-notification-feed";
+import { useAuthenticatedKnockClient } from "@knocklabs/react";
 
 const MyComponent = () => {
   const knock = useAuthenticatedKnockClient(
@@ -385,7 +385,7 @@ Creates a `Feed` instance for the provided `Knock` client which creates a statef
 import {
   useAuthenticatedKnockClient,
   useNotifications,
-} from "@knocklabs/react-notification-feed";
+} from "@knocklabs/react";
 import create from "zustand";
 
 const MyComponent = () => {


### PR DESCRIPTION
### Description

Updates some additional code examples that were using the react-notification-feed package or old version of the KnockFeedProvider