### PR TITLE
Chore: Update GitHub links on JS SDK page

### DIFF
--- a/content/in-app-ui/javascript/overview.mdx
+++ b/content/in-app-ui/javascript/overview.mdx
@@ -11,7 +11,7 @@ The `@knocklabs/client` library is a low-level JavaScript SDK for interacting wi
 **Quick links**
 
 - [`@knocklabs/client` on npm](https://www.npmjs.com/package/@knocklabs/client)
-- [Package on Github](https://github.com/knocklabs/knock-client-js)
+- [Package on Github](https://github.com/knocklabs/javascript/tree/main/packages/client)
 - [Full reference guide](/in-app-ui/javascript/reference)
 
 ## Need help?
@@ -31,4 +31,4 @@ Ask questions and find answers on those following platforms:
 
 ### Contributing
 
-All contributors are welcome, from casual to regular. Feel free to open a [pull request](https://github.com/knocklabs/knock-client-js/pulls/new).
+All contributors are welcome, from casual to regular. Feel free to open a [pull request](https://github.com/knocklabs/javascript/pulls).


### PR DESCRIPTION
### Description

The GitHub links on the "Building in-app UI in Javascript" page in the docs were still pointing to https://github.com/knocklabs/knock-client-js which has been archived and moved to the new JS monorepo. This PR Is to update those links to point to the new location. 