### PR TITLE
chore: add CI/CD CLI guide

### DIFF
--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -12,7 +12,7 @@ tags:
     "commit",
     "staging",
   ]
-section: Guides
+section: Developer Tools
 ---
 
 With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment.

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -7,7 +7,7 @@ section: Developer tools
 The Knock CLI helps you build, test, and manage your Knock notification system, right from the terminal. You can use the CLI to:
 
 - Pull Knock workflows down to your local machine and work with your notification logic and templates in your code editor.
-- Integrate Knock into your CI/CD pipeline and automatically promote changes between Knock environments on release.
+- [Integrate Knock into your CI/CD pipeline](/guides/cicd-with-the-knock-cli) and automatically promote changes between Knock environments on release.
 - Map your translation files into Knock to localize your notifications.
 
 ## Installing the CLI

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -7,7 +7,7 @@ section: Developer tools
 The Knock CLI helps you build, test, and manage your Knock notification system, right from the terminal. You can use the CLI to:
 
 - Pull Knock workflows down to your local machine and work with your notification logic and templates in your code editor.
-- [Integrate Knock into your CI/CD pipeline](/guides/cicd-with-the-knock-cli) and automatically promote changes between Knock environments on release.
+- [Integrate Knock into your CI/CD pipeline](/developer-tools/integrating-into-cicd) and automatically promote changes between Knock environments on release.
 - Map your translation files into Knock to localize your notifications.
 
 ## Installing the CLI

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -73,21 +73,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '20.9.0' # Set Node.js version to ^16.14.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.9.0" # Set Node.js version to ^16.14.0
 
-    - name: Install Knock CLI
-      run: npm install -g @knocklabs/cli
+      - name: Install Knock CLI
+        run: npm install -g @knocklabs/cli
 
-    - name: Promote Workflow to Staging
-      env:
-        KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
-      run: knock commit promote --to=staging --service-token=$KNOCK_SERVICE_TOKEN
+      - name: Promote Workflow to Staging
+        env:
+          KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+        run: knock commit promote --to=staging --service-token=$KNOCK_SERVICE_TOKEN
 ```
 
 <br />
@@ -111,19 +111,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '20.9.0' # Set Node.js version to ^16.14.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.9.0" # Set Node.js version to ^16.14.0
 
-    - name: Install Knock CLI
-      run: npm install -g @knocklabs/cli
+      - name: Install Knock CLI
+        run: npm install -g @knocklabs/cli
 
-    - name: Promote Workflow to Production
-      env:
-        KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
-      run: knock commit promote --to=production --service-token=$KNOCK_SERVICE_TOKEN
+      - name: Promote Workflow to Production
+        env:
+          KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+        run: knock commit promote --to=production --service-token=$KNOCK_SERVICE_TOKEN
 ```

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -21,9 +21,9 @@ This guide assumes that you have [created](/concepts/environments#create-additio
 
 ## Local development
 
-With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the **[`knock workflow pull --all`](/cli#workflow-pull)**, **[`knock layout pull --all`](/cli#email-layout-pull)**, and **[`knock translation pull --all`](/cli#translation-pull)** commands. You can also work with specific resources by name rather than using the `--all` flag.
+With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by name rather than using the `--all` flag.
 
-Once you’re ready to send your updates back to Knock’s Development environment, you can push (**[`knock workflow push --all`](/cli#workflow-push)**) and commit (**[`knock commit`](/cli#commit-all)**) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
 
 <Callout
   emoji="🛑"

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -1,32 +1,129 @@
 ---
 title: Adding Knock to your CI/CD pipeline
 description: Learn how to add Knock to your deployment pipeline with our command line interface.
-tags: ["CI/CD", "cicd", "integration", "deployment", "automation", "testing", "commit", "staging"]
+tags:
+  [
+    "CI/CD",
+    "cicd",
+    "integration",
+    "deployment",
+    "automation",
+    "testing",
+    "commit",
+    "staging",
+  ]
 section: Guides
 ---
 
-With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment. 
+With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment.
 
 This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli#installation) on your local machine.
 
 ## Local development
 
-With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by name rather than using the `--all` flag.
+With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the **[`knock workflow pull --all`](/cli#workflow-pull)**, **[`knock layout pull --all`](/cli#email-layout-pull)**, and **[`knock translation pull --all`](/cli#translation-pull)** commands. You can also work with specific resources by name rather than using the `--all` flag.
 
-Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+Once you’re ready to send your updates back to Knock’s Development environment, you can push (**[`knock workflow push --all`](/cli#workflow-push)**) and commit (**[`knock commit`](/cli#commit-all)**) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
 
 <Callout
-  emoji="👀"
+  emoji="🛑"
   text={
     <>
-      <span className="font-bold">Note:</span> As with working directly in your dashboard, 
-      any uncommitted changes that are made to a Knock resource and pushed to Knock 
-      can be overwritten by another user who is working on the same resource. 
-      It’s important to <code>commit</code> any changes that you want to persist while working 
-      in the Development environment.
+      <span className="font-bold">Note:</span> As with working directly in your
+      dashboard, any uncommitted changes that are made to a Knock resource and
+      pushed to Knock can be overwritten by another user who is working on the
+      same resource. It’s important to <code>commit</code> any changes that you
+      want to persist while working in the Development environment.
     </>
   }
 />
 
 ## Pushing to your remote repository and deploying to staging
 
+When you’re ready to commit your locally-developed feature (including any updates to your Knock resources) to a remote git repository and kick off a test build in your staging environment, you can use the Knock CLI to automate the promotion of changes to your Knock resources across Knock environments. An example implementation might be done with a GitHub Action that promotes all of your committed updates from the Knock Development environment to your Staging environment, so that your application’s staging deployment will have access to all of your notifications changes.
+
+<Callout
+  emoji="👀"
+  text={
+    <>
+      When using the <code>knock commit promote</code>{" "}
+      <a href="/cli#commit-promote">command</a> with the <code>--to</code> flag,
+      the CLI will automatically locate any promotion-eligible changes that
+      exist in the environment one "level" lower in your list of Knock
+      environments in order to promote them to the designated environment. To
+      view the current order of all your configured environments, navigate to{" "}
+      <span className="font-bold">Settings &gt; Environments</span> in your
+      Knock dashboard.
+    </>
+  }
+/>
+
+This sample GitHub Action `.yml` file shows how you might promote all committed workflow changes from your Development environment to your Staging environment:
+
+```yml
+name: Knock Workflow Promotion to Staging
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  promote_workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20.9.0' # Set Node.js version to ^16.14.0
+
+    - name: Install Knock CLI
+      run: npm install -g @knocklabs/cli
+
+    - name: Promote Workflow to Staging
+      env:
+        KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+      run: knock commit promote --to=staging --service-token=$KNOCK_SERVICE_TOKEN
+```
+
+<br />
+
+## Deploying to production
+
+Once a pull request has been approved and is ready to be merged into your `main` branch, you can once again include the Knock CLI in your CI/CD pipeline to promote your relevant Knock resources to your Production environment.
+
+This sample GitHub Action `.yml` file shows how you might promote all workflows from your Staging environment to your Production environment:
+
+```yml
+name: Knock Workflow Promotion to Production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  promote_workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20.9.0' # Set Node.js version to ^16.14.0
+
+    - name: Install Knock CLI
+      run: npm install -g @knocklabs/cli
+
+    - name: Promote Workflow to Production
+      env:
+        KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+      run: knock commit promote --to=production --service-token=$KNOCK_SERVICE_TOKEN
+```

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -1,0 +1,32 @@
+---
+title: Adding Knock to your CI/CD pipeline
+description: Learn how to add Knock to your deployment pipeline with our command line interface.
+tags: ["CI/CD", "cicd", "integration", "deployment", "automation", "testing", "commit", "staging"]
+section: Guides
+---
+
+With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment. 
+
+This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli#installation) on your local machine.
+
+## Local development
+
+With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by name rather than using the `--all` flag.
+
+Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+
+<Callout
+  emoji="👀"
+  text={
+    <>
+      <span className="font-bold">Note:</span> As with working directly in your dashboard, 
+      any uncommitted changes that are made to a Knock resource and pushed to Knock 
+      can be overwritten by another user who is working on the same resource. 
+      It’s important to <code>commit</code> any changes that you want to persist while working 
+      in the Development environment.
+    </>
+  }
+/>
+
+## Pushing to your remote repository and deploying to staging
+

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -21,7 +21,7 @@ This guide assumes that you have [created](/concepts/environments#create-additio
 
 ## Local development
 
-With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by name rather than using the `--all` flag.
+With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by providing a `key` rather than using the `--all` flag.
 
 Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
 

--- a/content/guides/cicd-with-the-knock-cli.mdx
+++ b/content/guides/cicd-with-the-knock-cli.mdx
@@ -58,7 +58,7 @@ When you’re ready to commit your locally-developed feature (including any upda
   }
 />
 
-This sample GitHub Action `.yml` file shows how you might promote all committed workflow changes from your Development environment to your Staging environment:
+This sample GitHub Action `.yml` file shows how you might promote all committed changes from your Development environment to your Staging environment:
 
 ```yml
 name: Knock Workflow Promotion to Staging
@@ -96,7 +96,7 @@ jobs:
 
 Once a pull request has been approved and is ready to be merged into your `main` branch, you can once again include the Knock CLI in your CI/CD pipeline to promote your relevant Knock resources to your Production environment.
 
-This sample GitHub Action `.yml` file shows how you might promote all workflows from your Staging environment to your Production environment:
+This sample GitHub Action `.yml` file shows how you might promote all changes from your Staging environment to your Production environment:
 
 ```yml
 name: Knock Workflow Promotion to Production

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -178,6 +178,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/management-api", title: "Management API" },
       { slug: "/api-logs", title: "API logs" },
       { slug: "/outbound-webhooks", title: "Outbound webhooks" },
+      { slug: "/integrating-into-cicd", title: "Integrating into CI/CD" },
     ],
   },
   {
@@ -217,10 +218,6 @@ const sidebarContent: SidebarSection[] = [
       {
         slug: "/customizing-react-in-app-feed-components",
         title: "Customizing the React in-app feed components",
-      },
-      {
-        slug: "/cicd-with-the-knock-cli",
-        title: "CI/CD with the Knock CLI",
       },
     ],
   },

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -218,6 +218,10 @@ const sidebarContent: SidebarSection[] = [
         slug: "/customizing-react-in-app-feed-components",
         title: "Customizing the React in-app feed components",
       },
+      {
+        slug: "/cicd-with-the-knock-cli",
+        title: "CI/CD with the Knock CLI",
+      },
     ],
   },
 ];


### PR DESCRIPTION
This PR adds a new guide on using the Knock CLI in your CI/CD pipeline. It also adds sidebar navigation for that guide, and a link from the main Knock CLI page back to this guide.
