### PR TITLE
chore: improve gaps in CLI documentation

### DIFF
--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -542,6 +542,8 @@ knock layout get default --environment=production
 
 Pulls the contents of one or all email layouts from Knock into your local filesystem. Using `<layout_key>` you can pull a single email layout, specified by the key or use the `--all` flag to pull all email layouts from Knock at once.
 
+See how layout files are structured in your system [here](/integrations/email/layouts#layout-files-structure).
+
 ### Flags
 
 <Attributes>

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -205,6 +205,8 @@ You can pull and download workflows with its message templates from Knock to a l
 
 Note: if pulling the target workflow for the first time or all workflowws, Knock CLI will ask to confirm before writing to the local filesystem.
 
+See how workflow files are structured in your system [here](/concepts/workflows#workflow-files-structure).
+
 ### Flags
 
 <Attributes>

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -263,7 +263,7 @@ translations_directory
    └── tasks.en-GB.json
 ```
 
-If you're migrating your local translation files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using [`knock translation push --all`](/cli#translation-push).
+If you're migrating your local translation files into Knock, you can arrange them using the file structure above and then push them into Knock with a single command using [`knock translation push --all`](/cli#translation-push). Each `<locale>.json` file should follow the structure defined [here](/mapi#translations-object).
 
 You can learn more about automating translation management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -247,7 +247,7 @@ In addition to working with translations in the Knock dashboard, you can program
 
 If you manage your own translation files within your application, you can automate the creation and management of Knock translations so that they always reflect the state of the translation files you keep in your application code.
 
-The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
 
 ### Translation files structure
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -254,7 +254,7 @@ The Knock CLI can also be used to commit changes and promote them to production,
 When translations are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
 
 ```txt Local translation files structure
-translations_directory
+translations_directory/
 ├── en/
 │  ├── en.json
 │  └── admin.en.json

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -243,11 +243,11 @@ The message template will first try to find a translation that corresponds with 
 
 ## Automate translation management with the Knock CLI
 
-In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/cli).
+In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/developer-tools/knock-cli).
 
 If you manage your own translation files within your application, you can automate the creation and management of Knock translations so that they always reflect the state of the translation files you keep in your application code.
 
-The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as part of your CI/CD workflow.
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
 
 ### Translation files structure
 
@@ -255,15 +255,15 @@ When translations are pulled from Knock, they are stored in directories named by
 
 ```txt Local translation files structure
 translations_directory
-|- en/
-   |- en.json
-   |- admin.en.json
-|- en-GB/
-   |- en-GB.json
-   |- tasks.en-GB.json
+├── en/
+│  ├── en.json
+│  └── admin.en.json
+└── en-GB/
+   ├── en-GB.json
+   └── tasks.en-GB.json
 ```
 
-If you're migrating your local translation files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using knock `workflow push --all`.
+If you're migrating your local translation files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using [`knock translation push --all`](/cli#translation-push).
 
 You can learn more about automating translation management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -140,10 +140,10 @@ The Knock CLI can also be used to commit changes and promote them to production,
 
 ### Workflow files structure
 
-When workflows are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
+When workflows are pulled from Knock, they are stored in directories named by their workflow key. In addition to a `workflow.json` file that describes all of a given workflow's steps, each workflow directory also contains individual folders for each of the [channel steps](/designing-workflows/channel-step) in the workflow that hold additional content and formatting data.
 
 ```txt Local workflow files structure
-workflows_directory
+workflows_directory/
 └── workflow-name/
     ├── email_1/
     │   ├── visual_blocks/

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -130,6 +130,34 @@ Workflows can have preferences associated, either via individual workflow prefer
 
 [Read more about preferences](/concepts/preferences#workflow-preferences)
 
+## Automate workflow management with the Knock CLI
+
+In addition to working with workflows in the Knock dashboard, you can programmatically create and update workflows using the [Knock CLI](/developer-tools/knock-cli).
+
+If you manage your own workflow files within your application, you can automate the creation and management of Knock workflows so that they always reflect the state of the workflow files you keep in your application code.
+
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock workflow management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
+
+### Workflow files structure
+
+When workflows are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
+
+```txt Local workflow files structure
+workflows_directory
+└── workflow-name/
+    ├── email_1/
+    │   ├── visual_blocks/
+    │   │   └── 1.content.md
+    │   └── visual_blocks.json
+    ├── in_app_feed_1/
+    │   └── markdown_body.md
+    └── workflow.json
+```
+
+If you're migrating your local workflow files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using [`knock workflow push --all`](/cli#workflow-push).
+
+You can learn more about automating workflow management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
+
 ## Frequently asked questions
 
 #### Is there a limit to the number of workflows I can have in Knock?

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -154,7 +154,7 @@ workflows_directory
     └── workflow.json
 ```
 
-If you're migrating your local workflow files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using [`knock workflow push --all`](/cli#workflow-push).
+If you're migrating your local workflow files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock workflow push --all`](/cli#workflow-push). Each `workflow.json` file should follow the structure defined [here](/mapi#workflows-object).
 
 You can learn more about automating workflow management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -136,7 +136,7 @@ In addition to working with workflows in the Knock dashboard, you can programmat
 
 If you manage your own workflow files within your application, you can automate the creation and management of Knock workflows so that they always reflect the state of the workflow files you keep in your application code.
 
-The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock workflow management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock workflow management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
 
 ### Workflow files structure
 

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -1,0 +1,129 @@
+---
+title: Adding Knock to your CI/CD pipeline
+description: Learn how to add Knock to your deployment pipeline with our command line interface.
+tags:
+  [
+    "CI/CD",
+    "cicd",
+    "integration",
+    "deployment",
+    "automation",
+    "testing",
+    "commit",
+    "staging",
+  ]
+section: Developer Tools
+---
+
+With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment.
+
+This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli#installation) on your local machine.
+
+## Local development
+
+With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by providing a `key` rather than using the `--all` flag.
+
+Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+
+<Callout
+  emoji="🛑"
+  text={
+    <>
+      <span className="font-bold">Note:</span> As with working directly in your
+      dashboard, any uncommitted changes that are made to a Knock resource and
+      pushed to Knock can be overwritten by another user who is working on the
+      same resource. It’s important to <code>commit</code> any changes that you
+      want to persist while working in the Development environment.
+    </>
+  }
+/>
+
+## Pushing to your remote repository and deploying to staging
+
+When you’re ready to commit your locally-developed feature (including any updates to your Knock resources) to a remote git repository and kick off a test build in your staging environment, you can use the Knock CLI to automate the promotion of changes to your Knock resources across Knock environments. An example implementation might be done with a GitHub Action that promotes all of your committed updates from the Knock Development environment to your Staging environment, so that your application’s staging deployment will have access to all of your notifications changes.
+
+<Callout
+  emoji="👀"
+  text={
+    <>
+      When using the <code>knock commit promote</code>{" "}
+      <a href="/cli#commit-promote">command</a> with the <code>--to</code> flag,
+      the CLI will automatically locate any promotion-eligible changes that
+      exist in the environment one "level" lower in your list of Knock
+      environments in order to promote them to the designated environment. To
+      view the current order of all your configured environments, navigate to{" "}
+      <span className="font-bold">Settings &gt; Environments</span> in your
+      Knock dashboard.
+    </>
+  }
+/>
+
+This sample GitHub Action `.yml` file shows how you might promote all committed changes from your Development environment to your Staging environment:
+
+```yml
+name: Knock Workflow Promotion to Staging
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+jobs:
+  promote_workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.9.0" # Set Node.js version to ^16.14.0
+
+      - name: Install Knock CLI
+        run: npm install -g @knocklabs/cli
+
+      - name: Promote Workflow to Staging
+        env:
+          KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+        run: knock commit promote --to=staging --service-token=$KNOCK_SERVICE_TOKEN
+```
+
+<br />
+
+## Deploying to production
+
+Once a pull request has been approved and is ready to be merged into your `main` branch, you can once again include the Knock CLI in your CI/CD pipeline to promote your relevant Knock resources to your Production environment.
+
+This sample GitHub Action `.yml` file shows how you might promote all changes from your Staging environment to your Production environment:
+
+```yml
+name: Knock Workflow Promotion to Production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  promote_workflow:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.9.0" # Set Node.js version to ^16.14.0
+
+      - name: Install Knock CLI
+        run: npm install -g @knocklabs/cli
+
+      - name: Promote Workflow to Production
+        env:
+          KNOCK_SERVICE_TOKEN: ${{ secrets.KNOCK_SERVICE_TOKEN }} # Ensure you've set KNOCK_SERVICE_TOKEN in your GitHub secrets
+        run: knock commit promote --to=production --service-token=$KNOCK_SERVICE_TOKEN
+```

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -7,7 +7,7 @@ section: Developer tools
 The Knock CLI helps you build, test, and manage your Knock notification system, right from the terminal. You can use the CLI to:
 
 - Pull Knock workflows down to your local machine and work with your notification logic and templates in your code editor.
-- Integrate Knock into your CI/CD pipeline and automatically promote changes between Knock environments on release.
+- [Integrate Knock into your CI/CD pipeline](/developer-tools/integrating-into-cicd) and automatically promote changes between Knock environments on release.
 - Map your translation files into Knock to localize your notifications.
 
 ## Installing the CLI

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -264,3 +264,41 @@ Keep in mind that to override any of the base component style properties listed 
   margin-bottom: 0;
 }
 ```
+
+## Automate layout management with the Knock CLI
+
+In addition to working with layouts in the Knock dashboard, you can programmatically create and update layouts using the [Knock CLI](/developer-tools/knock-cli).
+
+If you manage your own email layout files within your application, you can automate the creation and management of Knock layouts so that they always reflect the state of the layout files you keep in your application code.
+
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock email layout management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
+
+### Layout files structure
+
+When email layouts are pulled from Knock, they are stored in directories named by their layout key. 
+
+```txt Local layout files structure
+layouts_directory/
+├── default/
+│   ├── html_layout.html
+│   ├── layout.json
+│   └── text_layout.txt
+└── custom-layout/
+    ├── html_layout.html
+    ├── layout.json
+    └── text_layout.txt
+```
+
+If you're migrating your local layout files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock layout push --all`](/cli#email-layout-push). Each `layout.json` file should follow the example shown below; additional information on the Layout structure is defined [here](/mapi#email-layouts-object).
+
+```json
+{
+  "key": "custom-layout",
+  "name": "Custom Layout",
+  "html_layout@": "html_layout.html",
+  "text_layout@": "text_layout.txt",
+  "footer_links": [{ "text": "My link", "url": "https://example.com" }]
+}
+```
+
+You can learn more about automating layout management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -275,7 +275,7 @@ The Knock CLI can also be used to commit changes and promote them to production,
 
 ### Layout files structure
 
-When email layouts are pulled from Knock, they are stored in directories named by their layout key. 
+When email layouts are pulled from Knock, they are stored in directories named by their layout key.
 
 ```txt Local layout files structure
 layouts_directory/

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -271,7 +271,7 @@ In addition to working with layouts in the Knock dashboard, you can programmatic
 
 If you manage your own email layout files within your application, you can automate the creation and management of Knock layouts so that they always reflect the state of the layout files you keep in your application code.
 
-The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock email layout management as [part of your CI/CD workflow](/guides/cicd-with-the-knock-cli).
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock email layout management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
 
 ### Layout files structure
 
@@ -291,7 +291,7 @@ layouts_directory/
 
 If you're migrating your local layout files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock layout push --all`](/cli#email-layout-push). Each `layout.json` file should follow the example shown below; additional information on the Layout structure is defined [here](/mapi#email-layouts-object).
 
-```json
+```json Local layout file example JSON
 {
   "key": "custom-layout",
   "name": "Custom Layout",

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -178,6 +178,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/management-api", title: "Management API" },
       { slug: "/api-logs", title: "API logs" },
       { slug: "/outbound-webhooks", title: "Outbound webhooks" },
+      { slug: "/integrating-into-cicd", title: "Integrating into CI/CD" },
     ],
   },
   {


### PR DESCRIPTION
This PR closes some gaps in our current CLI documentation:

- It fixes some small issues with the documentation on Translations folder structure, including updating an incorrect CLI command and adding some additional context
- It adds folder structures for both Workflows and Layouts
- It adds an additional example `layout.json` file to demonstrate linking the `html` and `text` sources from within a given Layout's folder
- It adds backlinks from the CLI reference to the folder structures referenced on the above resource pages
- It also adds a link back to the new CI/CD automation guide (#385) in each of the relevant sections 