### PR TITLE
chore: add folder structures to documentation for working with the CLI

### DIFF
--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -277,6 +277,8 @@ Note:
 - You must be directly above the target workflow directory when running the `workflow push` command, so the CLI can locate the `workflow.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
 
+See how workflow files are structured in your system [here](/concepts/workflows#workflow-files-structure).
+
 ### Flags
 
 <Attributes>
@@ -594,6 +596,8 @@ knock layout pull --all
 <ContentColumn>
 
 Pushes local email layouts back to Knock and upserts them. Using `<layout_key>` you can push a single email layout, specified by the key or use the `--all` flag to push all email layouts from Knock at once.
+
+See how layout files are structured in your system [here](/integrations/email/layouts#layout-files-structure).
 
 ### Flags
 

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -205,6 +205,8 @@ You can pull and download workflows with its message templates from Knock to a l
 
 Note: if pulling the target workflow for the first time or all workflowws, Knock CLI will ask to confirm before writing to the local filesystem.
 
+See how workflow files are structured in your system [here](/concepts/workflows#workflow-files-structure).
+
 ### Flags
 
 <Attributes>
@@ -539,6 +541,8 @@ knock layout get default --environment=production
 <ContentColumn>
 
 Pulls the contents of one or all email layouts from Knock into your local filesystem. Using `<layout_key>` you can pull a single email layout, specified by the key or use the `--all` flag to pull all email layouts from Knock at once.
+
+See how layout files are structured in your system [here](/integrations/email/layouts#layout-files-structure).
 
 ### Flags
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -243,27 +243,27 @@ The message template will first try to find a translation that corresponds with 
 
 ## Automate translation management with the Knock CLI
 
-In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/cli).
+In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/developer-tools/knock-cli).
 
 If you manage your own translation files within your application, you can automate the creation and management of Knock translations so that they always reflect the state of the translation files you keep in your application code.
 
-The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as part of your CI/CD workflow.
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock translation management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
 
 ### Translation files structure
 
 When translations are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
 
 ```txt Local translation files structure
-translations_directory
-|- en/
-   |- en.json
-   |- admin.en.json
-|- en-GB/
-   |- en-GB.json
-   |- tasks.en-GB.json
+translations_directory/
+├── en/
+│  ├── en.json
+│  └── admin.en.json
+└── en-GB/
+   ├── en-GB.json
+   └── tasks.en-GB.json
 ```
 
-If you're migrating your local translation files into Knock, you can structure them using the file structure above and then push them into Knock with a single command using knock `workflow push --all`.
+If you're migrating your local translation files into Knock, you can arrange them using the file structure above and then push them into Knock with a single command using [`knock translation push --all`](/cli#translation-push). Each `<locale>.json` file should follow the structure defined [here](/mapi#translations-object).
 
 You can learn more about automating translation management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -243,7 +243,7 @@ The message template will first try to find a translation that corresponds with 
 
 ## Automate translation management with the Knock CLI
 
-In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/developer-tools/knock-cli).
+In addition to working with translations in the Knock dashboard, you can programmatically create and update translations using the [Knock CLI](/developer-tools/knock-cli) or our [Management API](/developer-tools/management-api).
 
 If you manage your own translation files within your application, you can automate the creation and management of Knock translations so that they always reflect the state of the translation files you keep in your application code.
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -254,7 +254,7 @@ The Knock CLI can also be used to commit changes and promote them to production,
 When translations are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
 
 ```txt Local translation files structure
-translations_directory/
+translations/
 ├── en/
 │  ├── en.json
 │  └── admin.en.json

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -143,7 +143,7 @@ The Knock CLI can also be used to commit changes and promote them to production,
 When workflows are pulled from Knock, they are stored in directories named by their workflow key. In addition to a `workflow.json` file that describes all of a given workflow's steps, each workflow directory also contains individual folders for each of the [channel steps](/designing-workflows/channel-step) in the workflow that hold additional content and formatting data.
 
 ```txt Local workflow files structure
-workflows_directory/
+workflows/
 └── workflow-name/
     ├── email_1/
     │   ├── visual_blocks/

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -130,6 +130,34 @@ Workflows can have preferences associated, either via individual workflow prefer
 
 [Read more about preferences](/concepts/preferences#workflow-preferences)
 
+## Automate workflow management with the Knock CLI
+
+In addition to working with workflows in the Knock dashboard, you can programmatically create and update workflows using the [Knock CLI](/developer-tools/knock-cli).
+
+If you manage your own workflow files within your application, you can automate the creation and management of Knock workflows so that they always reflect the state of the workflow files you keep in your application code.
+
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock workflow management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
+
+### Workflow files structure
+
+When workflows are pulled from Knock, they are stored in directories named by their workflow key. In addition to a `workflow.json` file that describes all of a given workflow's steps, each workflow directory also contains individual folders for each of the [channel steps](/designing-workflows/channel-step) in the workflow that hold additional content and formatting data.
+
+```txt Local workflow files structure
+workflows_directory/
+└── workflow-name/
+    ├── email_1/
+    │   ├── visual_blocks/
+    │   │   └── 1.content.md
+    │   └── visual_blocks.json
+    ├── in_app_feed_1/
+    │   └── markdown_body.md
+    └── workflow.json
+```
+
+If you're migrating your local workflow files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock workflow push --all`](/cli#workflow-push). Each `workflow.json` file should follow the structure defined [here](/mapi#workflows-object).
+
+You can learn more about automating workflow management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.
+
 ## Frequently asked questions
 
 #### Is there a limit to the number of workflows I can have in Knock?

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -144,7 +144,7 @@ When workflows are pulled from Knock, they are stored in directories named by th
 
 ```txt Local workflow files structure
 workflows/
-└── workflow-name/
+└── my-workflow/ 
     ├── email_1/
     │   ├── visual_blocks/
     │   │   └── 1.content.md

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -132,7 +132,7 @@ Workflows can have preferences associated, either via individual workflow prefer
 
 ## Automate workflow management with the Knock CLI
 
-In addition to working with workflows in the Knock dashboard, you can programmatically create and update workflows using the [Knock CLI](/developer-tools/knock-cli).
+In addition to working with workflows in the Knock dashboard, you can programmatically create and update workflows using the [Knock CLI](/developer-tools/knock-cli) or our [Management API](/developer-tools/management-api).
 
 If you manage your own workflow files within your application, you can automate the creation and management of Knock workflows so that they always reflect the state of the workflow files you keep in your application code.
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -144,7 +144,7 @@ When workflows are pulled from Knock, they are stored in directories named by th
 
 ```txt Local workflow files structure
 workflows/
-└── my-workflow/ 
+└── my-workflow/
     ├── email_1/
     │   ├── visual_blocks/
     │   │   └── 1.content.md

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -264,3 +264,41 @@ Keep in mind that to override any of the base component style properties listed 
   margin-bottom: 0;
 }
 ```
+
+## Automate layout management with the Knock CLI
+
+In addition to working with layouts in the Knock dashboard, you can programmatically create and update layouts using the [Knock CLI](/developer-tools/knock-cli).
+
+If you manage your own email layout files within your application, you can automate the creation and management of Knock layouts so that they always reflect the state of the layout files you keep in your application code.
+
+The Knock CLI can also be used to commit changes and promote them to production, which means you can automate Knock email layout management as [part of your CI/CD workflow](/developer-tools/integrating-into-cicd).
+
+### Layout files structure
+
+When email layouts are pulled from Knock, they are stored in directories named by their layout key.
+
+```txt Local layout files structure
+layouts_directory/
+├── default/
+│   ├── html_layout.html
+│   ├── layout.json
+│   └── text_layout.txt
+└── custom-layout/
+    ├── html_layout.html
+    ├── layout.json
+    └── text_layout.txt
+```
+
+If you're migrating your local layout files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock layout push --all`](/cli#email-layout-push). Each `layout.json` file should follow the example shown below; additional information on the Layout structure is defined [here](/mapi#email-layouts-object).
+
+```json Local layout file example JSON
+{
+  "key": "custom-layout",
+  "name": "Custom Layout",
+  "html_layout@": "html_layout.html",
+  "text_layout@": "text_layout.txt",
+  "footer_links": [{ "text": "My link", "url": "https://example.com" }]
+}
+```
+
+You can learn more about automating layout management in the [Knock CLI reference](/cli). Feel free to <a href="mailto:support@knock.app">contact us</a> if you have questions.

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -267,7 +267,7 @@ Keep in mind that to override any of the base component style properties listed 
 
 ## Automate layout management with the Knock CLI
 
-In addition to working with layouts in the Knock dashboard, you can programmatically create and update layouts using the [Knock CLI](/developer-tools/knock-cli).
+In addition to working with layouts in the Knock dashboard, you can programmatically create and update layouts using the [Knock CLI](/developer-tools/knock-cli) or our [Management API](/developer-tools/management-api).
 
 If you manage your own email layout files within your application, you can automate the creation and management of Knock layouts so that they always reflect the state of the layout files you keep in your application code.
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -278,7 +278,7 @@ The Knock CLI can also be used to commit changes and promote them to production,
 When email layouts are pulled from Knock, they are stored in directories named by their layout key.
 
 ```txt Local layout files structure
-layouts_directory/
+layouts/
 ├── default/
 │   ├── html_layout.html
 │   ├── layout.json


### PR DESCRIPTION
This PR closes some gaps in our current CLI documentation:
- It fixes some small issues with the documentation on Translations folder structure, including updating an incorrect CLI command and adding some additional context
- It adds folder structures for both Workflows and Layouts
- It adds an additional example `layout.json` file to demonstrate linking the `html` and `text` sources from within a given Layout's folder when working with these resources locally
- It adds backlinks from the CLI reference to the folder structures referenced on the above resource pages
- It also adds a link back to the new CI/CD automation guide (#385) in each of the relevant sections
