### PR TITLE
chore: update "Thinking in workflows" to recommend more-strongly against complex workflows

### DIFF
--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -19,9 +19,11 @@ Workflows in Knock:
 
 ## Thinking in workflows
 
-A workflow groups together cross-channel notifications and the business logic that governs those notifications into a single entity. Workflows are always executed on behalf of a single recipient and can have other properties associated with them, like the "actor" of who performed the action that triggered the notification.
+A workflow groups together cross-channel notifications and the business logic that governs those notifications into a single entity. Workflows are always executed on behalf of a single recipient and can have other properties associated with them, like the "actor" who performed the action that triggered the notification.
 
-It's most common to group notifications about the same "topic" or "entity" in your system into individual workflows. As an example, if we're building a document collaboration app where users can comment on specific documents we might group all of the logic about the cross-channel comment notifications we have into a single `new-comment` workflow.
+It's highly recommended to group notifications about the same "topic" or "entity" in your system into individual workflows. While it might be tempting to build a single workflow with conditional logic for all of your notification use cases that can be triggered from anywhere within your application with the same workflow `key`, modularizing your workflows by topic and use case allows you to offer the highest level of configurability to your users via [Preferences](/concepts/preferences). Our customers also find that concise, topic-specific workflows are easier to maintain and iterate on.
+
+As an example, if we're building a document collaboration app where users can comment on specific documents, we might group all of the logic about the cross-channel comment notifications we have into a single `new-comment` workflow.
 
 <Callout
   emoji="💡"
@@ -52,10 +54,11 @@ Knock workflows can be managed either via the Knock Dashboard or programmaticall
   text={
     <>
       <span className="font-bold">Note:</span> remember that workflows and other
-      resources in Knock can only ever be edited in the development environment.
+      resources in Knock can only ever be edited in the development environment.{" "}
       <a href="/concepts/environments">
         Learn more about versioning and environments
-      </a>.
+      </a>
+      .
     </>
   }
 />


### PR DESCRIPTION
Per recent discussions, I've expanded a bit on our recommendations under "Thinking in workflows."

Also removed a superfluous word and fixed spacing in a callout block on the same page.