### PR TITLE
chore: add yaml syntax highlighting

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -11,6 +11,7 @@ import shell from "react-syntax-highlighter/dist/cjs/languages/hljs/shell";
 import liquid from "react-syntax-highlighter/dist/cjs/languages/hljs/handlebars";
 import go from "react-syntax-highlighter/dist/cjs/languages/hljs/go";
 import java from "react-syntax-highlighter/dist/cjs/languages/hljs/java";
+import yaml from "react-syntax-highlighter/dist/cjs/languages/hljs/yaml";
 import { IoCheckmark, IoCopy } from "react-icons/io5";
 import useClipboard from "react-use-clipboard";
 
@@ -31,6 +32,7 @@ SyntaxHighlighter.registerLanguage("shell", shell);
 SyntaxHighlighter.registerLanguage("liquid", liquid);
 SyntaxHighlighter.registerLanguage("go", go);
 SyntaxHighlighter.registerLanguage("java", java);
+SyntaxHighlighter.registerLanguage("yaml", yaml);
 
 export type SupportedLanguage =
   | "javascript"
@@ -43,7 +45,8 @@ export type SupportedLanguage =
   | "php"
   | "json"
   | "go"
-  | "java";
+  | "java"
+  | "yaml";
 
 const LanguageLabel = {
   javascript: "JavaScript",
@@ -57,6 +60,7 @@ const LanguageLabel = {
   json: "JSON",
   go: "Go",
   java: "Java",
+  yaml: "YAML"
 };
 
 export interface Props {

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -60,7 +60,7 @@ const LanguageLabel = {
   json: "JSON",
   go: "Go",
   java: "Java",
-  yaml: "YAML"
+  yaml: "YAML",
 };
 
 export interface Props {

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -58,9 +58,9 @@ When you’re ready to commit your locally-developed feature (including any upda
   }
 />
 
-This sample GitHub Action `.yml` file shows how you might promote all committed changes from your Development environment to your Staging environment:
+This sample GitHub Action `.yaml` file shows how you might promote all committed changes from your Development environment to your Staging environment:
 
-```yml
+```yaml
 name: Knock Workflow Promotion to Staging
 
 on:
@@ -96,9 +96,9 @@ jobs:
 
 Once a pull request has been approved and is ready to be merged into your `main` branch, you can once again include the Knock CLI in your CI/CD pipeline to promote your relevant Knock resources to your Production environment.
 
-This sample GitHub Action `.yml` file shows how you might promote all changes from your Staging environment to your Production environment:
+This sample GitHub Action `.yaml` file shows how you might promote all changes from your Staging environment to your Production environment:
 
-```yml
+```yaml
 name: Knock Workflow Promotion to Production
 
 on:


### PR DESCRIPTION
This PR does two things:

- Change all references of `yml` -> `yaml` to reflect the accepted convention
- Import YAML as one of the available languages for `react-syntax-highlighter` so that adding `yaml` to a markdown code block actually does something 😃 