### PR TITLE
chore: add examples for the socket manager

### DIFF
--- a/content/in-app-ui/javascript/quick-start.mdx
+++ b/content/in-app-ui/javascript/quick-start.mdx
@@ -99,3 +99,20 @@ await knockClient.preferences.set({
   },
 });
 ```
+
+## Automatically disconnecting sockets from inactive tabs
+
+Optionally, you can configure the client to disconnect socket connections with inactive tabs after a brief delay. If the tab becomes active again, the socket will reconnect to continue receiving real-time updates.
+
+```javascript Automatically manage socket connections
+// Initialize the feed and configure the automatic disconnect settings
+const feedClient = knockClient.feeds.initialize(
+  process.env.KNOCK_FEED_CHANNEL_ID,
+  {
+    // Turn on the automatic connection manager
+    auto_manage_socket_connection: true,
+    // Optionally, customize the delay amount in milliseconds. Defaults to 2000ms or 2s
+    auto_manage_socket_connection_delay: 2500,
+  },
+);
+```

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -270,7 +270,7 @@ You can see a demo of this behavior here:
   ></iframe>
 </div>
 
-## Automatically disconnecting sockets from inactive tabs
+### Automatically disconnecting sockets from inactive tabs
 
 Optionally, you can configure the `Feed` to disconnect socket connections with inactive tabs after a brief delay. If the tab becomes active again, the socket will reconnect to continue receiving real-time updates.
 

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -270,6 +270,23 @@ You can see a demo of this behavior here:
   ></iframe>
 </div>
 
+## Automatically disconnecting sockets from inactive tabs
+
+Optionally, you can configure the `Feed` to disconnect socket connections with inactive tabs after a brief delay. If the tab becomes active again, the socket will reconnect to continue receiving real-time updates.
+
+```jsx Automatically manage socket connections
+import { KnockFeedProvider } from "@knocklabs/react";
+
+<KnockFeedProvider
+  defaultFeedOptions={{
+    // Turn on the automatic connection manager
+    auto_manage_socket_connection: true,
+    // Optionally, customize the delay amount in milliseconds. Defaults to 2000ms or 2s
+    auto_manage_socket_connection_delay: 2500,
+  }}
+/>;
+```
+
 ### Customizing the feed styling
 
 The complete theme that controls the look and feel of the feed components can be customized for theme in a few different ways:


### PR DESCRIPTION
### Description

Adds examples showing how to use the socket manager in the JS SDK and React SDK
