### PR TITLE
chore: remove dateFnsLocale params

### DIFF
--- a/content/in-app-ui/react-native/reference.mdx
+++ b/content/in-app-ui/react-native/reference.mdx
@@ -268,11 +268,6 @@ Exposed under `KnockI18nProvider` child components.
     type="(key: string) => string"
     description="A helper function to get the value of a translation from the current `Translations`."
   />
-  <Attribute
-    name="dateFnsLocale"
-    type="() => Locale"
-    description="Returns a Locale for use in date-fns. Defaults to `en-US`."
-  />
 </Attributes>
 
 ## Types

--- a/content/in-app-ui/react/reference.mdx
+++ b/content/in-app-ui/react/reference.mdx
@@ -460,11 +460,6 @@ Exposed under `KnockI18nProvider` child components.
     type="(key: string) => string"
     description="A helper function to get the value of a translation from the current `Translations`."
   />
-  <Attribute
-    name="dateFnsLocale"
-    type="() => Locale"
-    description="Returns a Locale for use in date-fns. Defaults to `en-US`."
-  />
 </Attributes>
 
 ## Types


### PR DESCRIPTION
### Description

Docs updates for https://github.com/knocklabs/docs/pull/391 as that PR proposes removing date-fns locales and relying only on built-in browser localization using the `Intl` module.
