### PR TITLE
feat: update webhook docs to include control content types

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -9,11 +9,7 @@ section: Developer tools > Outbound Webhooks
 Occurs when a message is successfully sent to a channel provider.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.delivered`
@@ -21,11 +17,7 @@ Occurs when a message is successfully sent to a channel provider.
 Occurs when a message is marked as delivered to the user by the provider. This is only available on email providers with delivery tracking enabled.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.delivery_attempted`
@@ -33,11 +25,7 @@ Occurs when a message is marked as delivered to the user by the provider. This i
 Occurs when a message delivery attempt fails and may be retried.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
   <Attribute
     name="event_data"
     type="map"
@@ -50,11 +38,7 @@ Occurs when a message delivery attempt fails and may be retried.
 Occurs when a message delivery attempt fails permanently. Delivery will not be retried.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
   <Attribute
     name="event_data"
     type="map"
@@ -67,11 +51,7 @@ Occurs when a message delivery attempt fails permanently. Delivery will not be r
 Occurs when a message is seen by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.unseen`
@@ -79,11 +59,7 @@ Occurs when a message is seen by its recipient.
 Occurs when a message is unseen by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.read`
@@ -91,11 +67,7 @@ Occurs when a message is unseen by its recipient.
 Occurs when a message is read by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.unread`
@@ -103,11 +75,7 @@ Occurs when a message is read by its recipient.
 Occurs when a message is unread by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.archived`
@@ -115,11 +83,7 @@ Occurs when a message is unread by its recipient.
 Occurs when a message is archived by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.unarchived`
@@ -127,11 +91,7 @@ Occurs when a message is archived by its recipient.
 Occurs when a message is unarchived by its recipient.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `message.link_clicked`
@@ -139,11 +99,7 @@ Occurs when a message is unarchived by its recipient.
 Occurs when a link is clicked by the message recipient. This is only available when Knock link tracking is enabled.
 
 <Attributes>
-  <Attribute
-    name="data"
-    type="Message"
-    description="The message associated."
-  />
+  <Attribute name="data" type="Message" description="The message associated." />
 </Attributes>
 
 ### `workflow.updated`

--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -9,7 +9,7 @@ section: Developer tools > Outbound Webhooks
 Occurs when a message is successfully sent to a channel provider.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.delivered`
@@ -17,7 +17,7 @@ Occurs when a message is successfully sent to a channel provider.
 Occurs when a message is marked as delivered to the user by the provider. This is only available on email providers with delivery tracking enabled.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.delivery_attempted`
@@ -25,7 +25,7 @@ Occurs when a message is marked as delivered to the user by the provider. This i
 Occurs when a message delivery attempt fails and may be retried.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
   <Attribute
     name="event_data"
     type="map"
@@ -38,7 +38,7 @@ Occurs when a message delivery attempt fails and may be retried.
 Occurs when a message delivery attempt fails permanently. Delivery will not be retried.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
   <Attribute
     name="event_data"
     type="map"
@@ -51,7 +51,7 @@ Occurs when a message delivery attempt fails permanently. Delivery will not be r
 Occurs when a message is seen by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.unseen`
@@ -59,7 +59,7 @@ Occurs when a message is seen by its recipient.
 Occurs when a message is unseen by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.read`
@@ -67,7 +67,7 @@ Occurs when a message is unseen by its recipient.
 Occurs when a message is read by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.unread`
@@ -75,7 +75,7 @@ Occurs when a message is read by its recipient.
 Occurs when a message is unread by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.archived`
@@ -83,7 +83,7 @@ Occurs when a message is unread by its recipient.
 Occurs when a message is archived by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.unarchived`
@@ -91,7 +91,7 @@ Occurs when a message is archived by its recipient.
 Occurs when a message is unarchived by its recipient.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `message.link_clicked`
@@ -99,7 +99,7 @@ Occurs when a message is unarchived by its recipient.
 Occurs when a link is clicked by the message recipient. This is only available when Knock link tracking is enabled.
 
 <Attributes>
-  <Attribute name="data" type="Message" description="The message associated." />
+  <Attribute name="data" type="Message" description="The associated message" />
 </Attributes>
 
 ### `workflow.updated`
@@ -110,7 +110,7 @@ Occurs whenever a workflow is updated in the environment.
   <Attribute
     name="data"
     type="Workflow"
-    description="The workflow associated."
+    description="The associated workflow"
   />
 </Attributes>
 
@@ -122,7 +122,7 @@ Occurs whenever a workflow is committed to the environment.
   <Attribute
     name="data"
     type="Workflow"
-    description="The workflow associated."
+    description="The associated workflow"
   />
 </Attributes>
 
@@ -134,7 +134,7 @@ Occurs whenever an email layout is updated in the environment.
   <Attribute
     name="data"
     type="EmailLayout"
-    description="The email layout associated."
+    description="The associated email layout"
   />
 </Attributes>
 
@@ -146,7 +146,7 @@ Occurs whenever an email layout is committed to the environment.
   <Attribute
     name="data"
     type="EmailLayout"
-    description="The email layout associated."
+    description="The associated email layout"
   />
 </Attributes>
 
@@ -158,7 +158,7 @@ Occurs whenever a translation is updated in the environment.
   <Attribute
     name="data"
     type="Translation"
-    description="The translation associated."
+    description="The associated translation"
   />
 </Attributes>
 
@@ -170,7 +170,7 @@ Occurs whenever a translation is committed to the environment.
   <Attribute
     name="data"
     type="Translation"
-    description="The translation associated."
+    description="The associated translation"
   />
 </Attributes>
 
@@ -182,7 +182,7 @@ Occurs whenever a source event action is updated in the environment.
   <Attribute
     name="data"
     type="SourceEventAction"
-    description="The source event action associated."
+    description="The associated source event action"
   />
 </Attributes>
 
@@ -194,6 +194,6 @@ Occurs whenever a source event action is committed to the environment.
   <Attribute
     name="data"
     type="SourceEventAction"
-    description="The translation associated."
+    description="The associated source event action"
   />
 </Attributes>

--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -1,0 +1,243 @@
+---
+title: Webhook event types
+description: Learn more about the types of events that Knock sends webhook events for.
+section: Developer tools > Outbound Webhooks
+---
+
+### `message.sent`
+
+Occurs when a message is successfully sent to a channel provider.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.delivered`
+
+Occurs when a message is marked as delivered to the user by the provider. This is only available on email providers with delivery tracking enabled.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.delivery_attempted`
+
+Occurs when a message delivery attempt fails and may be retried.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+  <Attribute
+    name="event_data"
+    type="map"
+    description="Additional information about the attempt, the total attempts, and whether or not it will be retried"
+  />
+</Attributes>
+
+### `message.undelivered`
+
+Occurs when a message delivery attempt fails permanently. Delivery will not be retried.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+  <Attribute
+    name="event_data"
+    type="map"
+    description="May include additional information about the failure reason, and the failure details"
+  />
+</Attributes>
+
+### `message.seen`
+
+Occurs when a message is seen by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.unseen`
+
+Occurs when a message is unseen by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.read`
+
+Occurs when a message is read by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.unread`
+
+Occurs when a message is unread by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.archived`
+
+Occurs when a message is archived by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.unarchived`
+
+Occurs when a message is unarchived by its recipient.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `message.link_clicked`
+
+Occurs when a link is clicked by the message recipient. This is only available when Knock link tracking is enabled.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The message associated."
+  />
+</Attributes>
+
+### `workflow.updated`
+
+Occurs whenever a workflow is updated in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Workflow"
+    description="The workflow associated."
+  />
+</Attributes>
+
+### `workflow.committed`
+
+Occurs whenever a workflow is committed in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Workflow"
+    description="The workflow associated."
+  />
+</Attributes>
+
+### `email_layout.updated`
+
+Occurs whenever an email layout is updated in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="EmailLayout"
+    description="The email layout associated."
+  />
+</Attributes>
+
+### `email_layout.committed`
+
+Occurs whenever an email layout is committed in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="EmailLayout"
+    description="The email layout associated."
+  />
+</Attributes>
+
+### `translation.updated`
+
+Occurs whenever a translation is updated in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Translation"
+    description="The translation associated."
+  />
+</Attributes>
+
+### `translation.committed`
+
+Occurs whenever a translation is committed in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Translation"
+    description="The translation associated."
+  />
+</Attributes>
+
+### `source_event_action.updated`
+
+Occurs whenever a source event action is updated in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="SourceEventAction"
+    description="The source event action associated."
+  />
+</Attributes>
+
+### `source_event_action.committed`
+
+Occurs whenever a source event action is committed in the environment.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="SourceEventAction"
+    description="The translation associated."
+  />
+</Attributes>

--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -42,7 +42,7 @@ Occurs when a message delivery attempt fails permanently. Delivery will not be r
   <Attribute
     name="event_data"
     type="map"
-    description="May include additional information about the failure reason, and the failure details"
+    description="May include additional information about the failure reason and the failure details"
   />
 </Attributes>
 
@@ -116,7 +116,7 @@ Occurs whenever a workflow is updated in the environment.
 
 ### `workflow.committed`
 
-Occurs whenever a workflow is committed in the environment.
+Occurs whenever a workflow is committed to the environment.
 
 <Attributes>
   <Attribute
@@ -140,7 +140,7 @@ Occurs whenever an email layout is updated in the environment.
 
 ### `email_layout.committed`
 
-Occurs whenever an email layout is committed in the environment.
+Occurs whenever an email layout is committed to the environment.
 
 <Attributes>
   <Attribute
@@ -164,7 +164,7 @@ Occurs whenever a translation is updated in the environment.
 
 ### `translation.committed`
 
-Occurs whenever a translation is committed in the environment.
+Occurs whenever a translation is committed to the environment.
 
 <Attributes>
   <Attribute
@@ -188,7 +188,7 @@ Occurs whenever a source event action is updated in the environment.
 
 ### `source_event_action.committed`
 
-Occurs whenever a source event action is committed in the environment.
+Occurs whenever a source event action is committed to the environment.
 
 <Attributes>
   <Attribute

--- a/content/developer-tools/outbound-webhooks/overview.mdx
+++ b/content/developer-tools/outbound-webhooks/overview.mdx
@@ -20,7 +20,7 @@ You can learn more about the types of events that [Knock sends webhooks for here
 
 ## Payload & headers
 
-A webhook payload for the message events will always include the message sent and the type of event that triggered the payload. This is an example of what will be sent to your webhook endpoint:
+A webhook payload will always be of the following base shape, where the `type` will be determined by the supported [webhook event types](/developer-tools/outbound-webhooks/event-types). The `data` field will include the entity that the event references.
 
 ```json A sample event payload
 {
@@ -38,8 +38,6 @@ A webhook payload for the message events will always include the message sent an
   }
 }
 ```
-
-You'll notice if you've explored the [get messages endpoint](/reference#get-a-message) that the `"data"` key contains all of the same fields as a message retrieved from there.
 
 The request header will also contain the following:
 
@@ -156,7 +154,7 @@ app.listen(4242, () => console.log("Running on port 4242"));
 
 ### Using the data
 
-Once you receive a webhook request and return a `2xx` status code, you can make additional requests to the Knock API to gather more information about the message event. For example, if you'd like to log the message's content when an event type comes through as `message.undelivered`, you can use the message ID to send a request to [get message content](/reference#get-message-content) when that condition is met.
+Once you receive a webhook request and return a `2xx` status code, you can make additional requests to the Knock API to gather more information about the event. For example, if you're building a webhook for the `message.undelivered` event, and you'd like to log the message's content, you can use the message ID to send a request to [get message content](/reference#get-message-content) when that event is received.
 
 ## Managing webhooks
 

--- a/content/developer-tools/outbound-webhooks/overview.mdx
+++ b/content/developer-tools/outbound-webhooks/overview.mdx
@@ -20,7 +20,7 @@ You can learn more about the types of events that [Knock sends webhooks for here
 
 ## Payload & headers
 
-A webhook payload will always be of the following base shape, where the `type` will be determined by the supported [webhook event types](/developer-tools/outbound-webhooks/event-types). The `data` field will include the entity that the event references.
+A webhook payload will always take the following base shape, where the `type` will be determined by the supported [webhook event types](/developer-tools/outbound-webhooks/event-types). The `data` field will include the entity that the event references.
 
 ```json A sample event payload
 {

--- a/content/developer-tools/outbound-webhooks/overview.mdx
+++ b/content/developer-tools/outbound-webhooks/overview.mdx
@@ -10,63 +10,15 @@ Use outbound webhooks to be notified of events happening within your Knock envir
 
 Knock can send a JSON payload to your backend with data about events that occur within Knock, like a message's status changing from `sent` to `delivered`. You can configure an endpoint and select which events you'd like it to listen to. When that event happens you'll get a POST request to the endpoint you've provided and then can use that data to trigger side-effects in your app.
 
+You can learn more about the types of events that [Knock sends webhooks for here](/developer-tools/outbound-webhooks/event-types).
+
 ## Quickstart
 
 1. [Create an endpoint in your app to receive webhook requests](#1-create-an-endpoint-to-receive-the-webhook-payload) and respond to requests with a `200` or `204` status code
 2. [Create a webhook in the Knock dashboard](#2-create-the-knock-webhook) pointing to your endpoint
 3. Start receiving webhook events!
 
-## Events that can trigger a Knock webhook
-
-Currently, we support webhooks for status changes on messages. A message represents a notification sent from a workflow, so keep in mind that one workflow with several channel steps can result in many messages and therefore a high number of status changes, or `message events`.
-
-This is the list of events that Knock can use to trigger a webhook:
-
-<Table
-  headers={["Event", "Description"]}
-  rows={[
-    [
-      "message.sent",
-      "Occurs when a message is successfully sent to a channel provider.",
-    ],
-    [
-      "message.delivered",
-      "Occurs when a message is marked as delivered to the user by the provider. This is only available on email providers with delivery tracking enabled.",
-    ],
-    [
-      "message.delivery_attempted",
-      "Occurs when a message delivery attempt fails and may be retried.",
-    ],
-    [
-      "message.undelivered",
-      "Occurs when a message delivery attempt fails permanently. Delivery will not be retried.",
-    ],
-    ["message.seen", "Occurs when a message is seen by its recipient."],
-    [
-      "message.unseen",
-      "Occurs when a message is marked unseen by the recipient.",
-    ],
-    [
-      "message.read",
-      "Occurs when a message is marked as read by its recipient.",
-    ],
-    [
-      "message.unread",
-      "Occurs when a message is marked unread by the recipient.",
-    ],
-    ["message.archived", "Occurs when a message is archived by its recipient."],
-    [
-      "message.unarchived",
-      "Occurs when a message is unarchived by its recipient.",
-    ],
-    [
-      "message.link_clicked",
-      "Occurs when a link is clicked by the message recipient. This is only available when Knock link tracking is enabled.",
-    ],
-  ]}
-/>
-
-## Webhook payload & header
+## Payload & headers
 
 A webhook payload for the message events will always include the message sent and the type of event that triggered the payload. This is an example of what will be sent to your webhook endpoint:
 
@@ -77,31 +29,7 @@ A webhook payload for the message events will always include the message sent an
   "type": "message.sent",
   "created_at": "2022-05-31T17:12:59.958652Z",
   "data": {
-    // The message for which this event is being reported
-    "__typename": "Message",
-    "archived_at": null,
-    "clicked_at": null,
-    "channel_id": "f5674f8b-81bb-49b1-9d52-e29d754b8a1b",
-    "data": null,
-    "id": "29wHMT3jeGfPE02PHezR8go0cK1",
-    "inserted_at": "2022-05-31T17:12:59.933761Z",
-    "metadata": {
-      // The `id` of the delivered message that the delivery provider may return
-      "external_id": "external_id_from_provider"
-    },
-    "read_at": null,
-    "recipient": "fd3d0708-ebee-456b-a324-1312a30edd0c",
-    "seen_at": null,
-    "source": {
-      // The source workflow that triggered this message
-      "__typename": "NotificationSource",
-      "key": "new-comment",
-      "version_id": "f5917d67-8a2f-487d-a544-83cacbdb1cfb"
-    },
-    // The current status of the message sent
-    "status": "delivered",
-    "tenant": null,
-    "updated_at": "2022-05-31T17:12:59.942374Z"
+    // Information about the entity
   },
   // (Optional) additional metadata related to the event
   "event_data": {
@@ -167,7 +95,7 @@ To test that the payload sent has not been compromised, you can recreate the sig
 2. Construct the value of the signature by concatenating:
 
    - The timestamp (as a string)
-   - The character .
+   - The character `.`
    - The stringified JSON payload
 
 3. Generate the signature with an HMAC and SHA256 algorithm using the secret key from your webhook's dashboard
@@ -251,7 +179,3 @@ When you create a webhook it will automatically be set to `enabled`. You can dis
 ### Deleting a webhook
 
 To stop receiving data to your endpoint, you can delete the webhook from its page. From `/webhooks`, click on the webhook you'd like to delete and you'll see a three-dot menu to the right of the header. Click there and you'll see the delete prompt. Keep in mind that if you delete a webhook, you'll have to recreate it to start receiving data to that endpoint again.
-
-## Try it out
-
-Before implementing an endpoint in your app, you can get a sense of how it works by creating a Knock webhook that points to an example endpoint, such as those provided by https://webhook.site/.

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -186,7 +186,14 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/knock-cli", title: "Knock CLI" },
       { slug: "/management-api", title: "Management API" },
       { slug: "/api-logs", title: "API logs" },
-      { slug: "/outbound-webhooks", title: "Outbound webhooks" },
+      {
+        slug: "/outbound-webhooks",
+        title: "Outbound webhooks",
+        pages: [
+          { slug: "/overview", title: "Overview" },
+          { slug: "/event-types", title: "Event types" },
+        ],
+      },
       { slug: "/integrating-into-cicd", title: "Integrating into CI/CD" },
     ],
   },

--- a/next.config.js
+++ b/next.config.js
@@ -248,6 +248,11 @@ const nextConfig = {
         destination: "/getting-started/security",
         permanent: true,
       },
+      {
+        source: "/developer-tools/outbound-webhooks",
+        destination: "/developer-tools/outbound-webhooks/overview",
+        permanent: false,
+      },
     ];
   },
 };


### PR DESCRIPTION
### Description

- Adds all the new control webhook types into the docs
- Breaks out a new event types page for all of the supported webhook event types
