### PR TITLE
chore: add tags to new webhook docs

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -2,6 +2,7 @@
 title: Webhook event types
 description: Learn more about the types of events that Knock sends webhook events for.
 section: Developer tools > Outbound Webhooks
+tags: ["events", "data", "analytics", "webhook configuration"]
 ---
 
 ### `message.sent`

--- a/content/developer-tools/outbound-webhooks/overview.mdx
+++ b/content/developer-tools/outbound-webhooks/overview.mdx
@@ -2,6 +2,7 @@
 title: Outbound Webhooks
 description: Learn how to use outbound webhooks to get the data you need from Knock into your product.
 section: Developer tools
+tags: ["events", "data", "analytics", "webhook configuration"]
 ---
 
 Use outbound webhooks to be notified of events happening within your Knock environment, and respond to those events in realtime in your product.


### PR DESCRIPTION
This PR adds a few search tags to the new documentation for outbound webhooks.