### PR TITLE
fix: clarify push notification status updates

### DIFF
--- a/content/send-notifications/message-statuses.mdx
+++ b/content/send-notifications/message-statuses.mdx
@@ -68,7 +68,7 @@ On a per-channel level, `delivered` means that:
 
 - **Email** — Your message was successfully delivered to the recipient's email service provider.
 - **In-app** — Your message was successfully delivered to the recipient's feed.
-- **Push** — We do not support delivery tracking for push channels, so push channel messages will never have a delivery status greater than `sent`. You can set up delivery tracking by introducing a handler into your mobile app to tell Knock when the message has successfully made it to your recipient's device.
+- **Push** — We do not support delivery tracking for push channels, so push channel messages will never have a delivery status greater than `sent`. However, you can introduce a handler into your mobile app to update a given message's [engagement status](#engagement-status) when the message has successfully made it to your recipient's device, using the `knock_message_id` from the push notification payload.
 - **SMS** — Your message was successfully sent to the recipient's SMS provider. Note that not all SMS delivery providers support delivery tracking. See the [Knock integration guides for SMS providers](/integrations/sms/overview) for more information.
 - **Chat** — Delivery tracking is not available for chat platforms, so chat channel messages will never have a delivery status greater than `sent`. In most cases, a `sent` status will also mean that the message has been delivered to the recipient.
 


### PR DESCRIPTION
This PR updates the delivery status documentation to clarify that you cannot update a push notification's delivery status, but you _can_ update the engagement status manually by using the `knock_message_id`.
