### PR TITLE
chore: update documentation for commits and promotion 

### DIFF
--- a/content/concepts/commits.mdx
+++ b/content/concepts/commits.mdx
@@ -53,9 +53,9 @@ Changes must be made in the development environment, then staged and tested befo
       disable a workflow in any environment without needing to go through
       environment promotion. This is your kill switch for a given workflow
       should you need it; this status is displayed on each workflow in your
-      dashboard's "Workflows" section, and can
-      be set by clicking on the workflow and using the "Status" selector. It is
-      environment-specific and will only be applied to the current environment.
+      dashboard's "Workflows" section, and can be set by clicking on the
+      workflow and using the "Status" selector. It is environment-specific and
+      will only be applied to the current environment.
     </>
   }
 />

--- a/content/concepts/commits.mdx
+++ b/content/concepts/commits.mdx
@@ -1,0 +1,70 @@
+---
+title: Commits
+description: Learn about how Knock's commit and promotion model works.
+tags:
+  [
+    "branches",
+    "env",
+    "version control",
+    "versions",
+    "commit",
+    "promote",
+    "promotion",
+    "staging",
+    "active",
+    "inactive",
+    "diffs",
+  ]
+section: Concepts
+---
+
+To version the changes you make in your [environments](/concepts/environments), Knock uses a commit model. When you make a change to a workflow or a layout in the Knock dashboard, you'll need to commit it to your development environment before those changes will appear in workflows triggered via the API.
+
+After you modify a resource, you'll see a "Save" button that allows you to store those changes. When you're ready to permanently store your updates with version control, they should be committed with the "Commit to development" button that will come into focus after changes have been saved.
+
+**A few things to note:**
+
+- Channel configurations, branding, and variables do not need to be committed, as they live at the account-level. This means that if you make a change to a channel configuration, it will update immediately on notifications sent in that environment.
+- Any changes you have saved but not yet committed **will** apply when you're using the test runner. This allows you to test your latest changes before you commit them to your development environment.
+- You can work with Knock resources outside of your dashboard if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources programmatically. The commit model applies to all methods of interacting with Knock resources, whether directly in the dashboard or with the Management API or CLI.
+
+## Commit diffs
+
+Clicking the "Commit to development" button will show you a view of changes between your current commit and the most-recent version of the resource that you're updating. Commit diffs are also available on your full commit log (viewable on the "Commits" page in your dashboard), so you can view the commit history for a resource and know exactly what was changed with each commit.
+
+![Commit diffs in Knocks version control](/images/commit-diff-showcase.gif)
+
+## Promotion and rollback
+
+Knock is designed to allow large teams to create and manage notifications at scale. That means that
+notifications changes must be versioned, tested, and promoted to production environments, so that if there are
+any issues they can be rolled back with ease.
+
+Knock uses a model where all changes to the production environment must be **promoted** and cannot be made directly.
+Changes must be made in the development environment, then staged and tested before being rolled out (similar to a git-based workflow).
+
+<Callout
+  emoji={"🚨"}
+  text={
+    <>
+      <span className="font-bold">Note:</span> There is one exception to the
+      commit and promote rule — the active/inactive status on a workflow lives
+      independently from the commit model so that you can immediately enable or
+      disable a workflow in any environment without needing to go through
+      environment promotion. This is your kill switch for a given workflow
+      should you need it; this status is displayed on each workflow in your
+      dashboard's "Workflows" section, and can
+      be set by clicking on the workflow and using the "Status" selector. It is
+      environment-specific and will only be applied to the current environment.
+    </>
+  }
+/>
+
+To promote a committed change to a higher environment, navigate to the "Commits" page in your Knock dashboard and click on "Unpromoted changes". Here you'll see a list of commits that are ready for promotion. Clicking "View commit" on a given commit will show you a commit diff for that change, and clicking the "Promote to [environment]" button will promote the staged commit to the next-higher environment (whose name is displayed on the button).
+
+**A typical deployment lifecycle in Knock looks like:**
+
+1. Introduce any backend changes to support a new workflow (users and preference properties)
+2. Build the workflow in a dev environment in Knock and commit it to that environment
+3. Test the workflow
+4. When you're ready to go live, promote the workflow to production

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -3,19 +3,12 @@ title: Environments
 description: Learn about how Knock's isolated environment model works and how it fits into your system development lifecycle.
 tags:
   [
-    "how knock works",
-    "branches",
     "env",
     "version control",
-    "versions",
     "variables",
-    "commit",
     "promote",
     "promotion",
-    "staging",
-    "active",
-    "inactive",
-    "diffs",
+    "staging"
   ]
 section: Concepts
 ---
@@ -26,67 +19,13 @@ in one environment are **never** accessible to another.
 
 The API key you use determines the environment into which you'll be sending data. You can find your environment-specific API keys under the "Developer" section of the Knock dashboard.
 
-## Commits
-
-To version the changes you make in your environments, Knock uses a commit model. When you make a change to a workflow or a layout in the Knock dashboard, you'll need to commit it to your development environment before those changes will appear in workflows triggered via the API.
-
-After you modify a resource, you'll see a "Save" button that allows you to store those changes. When you're ready to permanently store your updates with version control, these changes should then be committed with the "Commit to development" button that will come into focus after changes have been saved.
-
-**A few things to note:**
-
-- Channel configurations, branding, and variables do not need to be committed, as they live at the account-level. This means that if you make a change to a channel configuration, it will update immediately on notifications sent in that environment.
-- Any changes you have saved but not yet committed **will** apply when you're using the test runner. This way you can test your latest changes before you commit them to your development environment.
-- You can work with Knock resources outside of your dashboard if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources programmatically.
-- The commit model applies to all methods of interacting with Knock resources, whether directly in the dashboard or with the Management API and CLI.
-
-### Commit diffs
-
-Clicking the "Commit to development" button will show you a view of changes between your current commit and the most-recent version of the resource that you're updating. Commit diffs are also available on your full commit log (viewable on the **Commits** page in your dashboard), so you can view the commit history for a resource and know exactly what was changed with each commit.
-
-![Commit diffs in Knocks version control](/images/commit-diff-showcase.gif)
-
-## Promotion and rollback
-
-Knock is designed to allow large teams to create and manage notifications at scale. That means that
-notifications changes must be versioned, tested, and promoted to production environments, so that if there are
-any issues they can be rolled back with ease.
-
-Knock uses a model where all changes to the production environment must be **promoted** and cannot be made directly.
-This means that changes must be made in the development environment, then staged and tested before being rolled out (similar to a git-based workflow).
-
-<Callout
-  emoji={"🚨"}
-  text={
-    <>
-      <span className="font-bold">Note:</span> There is one exception to the
-      commit and promote rule — the active/inactive status on a workflow. This
-      status lives independently from the commit model so that you can
-      immediately enable or disable a workflow in any environment without
-      needing to go through environment promotion. This is your kill switch for
-      a given workflow should you need it; this status is displayed on each
-      workflow in your dashboard's <span className="font-bold">Workflows</span>{" "}
-      section, and can be set by clicking on the workflow and using the "Status"
-      selector.
-    </>
-  }
-/>
-
-To promote a committed change to a higher environment, navigate to the **Commits** page in your Knock dashboard and click on "Unpromoted changes". Here you'll see a list of commits that are ready for promotion. Clicking "View commit" on a given commit will show you a commit diff for that change, and clicking the "Promote to [environment]" button will promote the staged commit to the next-higher environment (whose name is displayed on the button).
-
-**A typical deployment lifecycle in Knock looks like:**
-
-1. Introduce any backend changes to support a new workflow (users and preference properties)
-2. Build the workflow in a dev environment in Knock and commit it to that environment
-3. Test the workflow
-4. When you're ready to go live, promote the workflow to production
-
 ## Create additional environments
 
 By default your Knock account comes with two environments: Development and Production. If you need an additional environment in Knock to mirror your own development lifecycle (for example, a Staging environment) you can add it on the settings page of the Knock dashboard.
 
 To create a new environment, go to "Settings" then "Environments". You'll see a button to "Create environment".
 
-When you create an additional environment, it will be inserted between Development and Production. This means all changes will be continue to be introduced in your Development environment and will need to be promoted through additional environments until they land in Production.
+When you create an additional environment, it will be inserted between Development and Production. This means all changes will continue to be introduced in your Development environment and will need to be [promoted](/concepts/commits#promotion-and-rollback) through additional environments until they land in Production. Subsequent new environments will always be added one "level" lower than Production; environments cannot be re-ordered, as this would break the promotion model for previously-promoted changes.
 
 ## Environment-based access controls
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -58,21 +58,22 @@ This means that changes must be made in the development environment, then staged
   emoji={"🚨"}
   text={
     <>
-      <span className="font-bold">There is one exception to this rule:</span>{" "}
-      the active/inactive status on a workflow. This status lives independently
-      from the commit model so that you can immediately enable or disable a
-      workflow in any environment without needing to go through environment
-      promotion. This is your kill switch for a given workflow should you need
-      it; this status is displayed on each workflow in your dashboard's{" "}
-      <span className="font-bold">Workflows</span> section, and can be set by
-      clicking on the workflow and using the "Status" selector.
+      <span className="font-bold">Note:</span> There is one exception to the
+      commit and promote rule — the active/inactive status on a workflow. This
+      status lives independently from the commit model so that you can
+      immediately enable or disable a workflow in any environment without
+      needing to go through environment promotion. This is your kill switch for
+      a given workflow should you need it; this status is displayed on each
+      workflow in your dashboard's <span className="font-bold">Workflows</span>{" "}
+      section, and can be set by clicking on the workflow and using the "Status"
+      selector.
     </>
   }
 />
 
-To promote a committed change to a higher environment, navigate to the **Commits** page in your Knock dashboard and click on "Unpromoted changes". Here you'll see a list of commits that are ready for promotion. Clicking "view commit" on a given commit will show you a commit diff for that change, and clicking the "Promote to [environment]" button will promote the staged commit to the next-higher environment (whose name is displayed).
+To promote a committed change to a higher environment, navigate to the **Commits** page in your Knock dashboard and click on "Unpromoted changes". Here you'll see a list of commits that are ready for promotion. Clicking "View commit" on a given commit will show you a commit diff for that change, and clicking the "Promote to [environment]" button will promote the staged commit to the next-higher environment (whose name is displayed on the button).
 
-A typical deployment lifecycle in Knock looks like:
+**A typical deployment lifecycle in Knock looks like:**
 
 1. Introduce any backend changes to support a new workflow (users and preference properties)
 2. Build the workflow in a dev environment in Knock and commit it to that environment
@@ -85,7 +86,7 @@ By default your Knock account comes with two environments: Development and Produ
 
 To create a new environment, go to "Settings" then "Environments". You'll see a button to "Create environment".
 
-When you create an additional environment, it will be inserted between Development and Production. This means all changes will be continue to be introduced in your Development environment and will be promoted through additional environments until they land in Production.
+When you create an additional environment, it will be inserted between Development and Production. This means all changes will be continue to be introduced in your Development environment and will need to be promoted through additional environments until they land in Production.
 
 ## Environment-based access controls
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -9,6 +9,13 @@ tags:
     "version control",
     "versions",
     "variables",
+    "commit",
+    "promote",
+    "promotion",
+    "staging",
+    "active",
+    "inactive",
+    "diffs"
   ]
 section: Concepts
 ---
@@ -23,12 +30,18 @@ The API key you use determines the environment into which you'll be sending data
 
 To version the changes you make in your environments, Knock uses a commit model. When you make a change to a workflow or a layout in the Knock dashboard, you'll need to commit it to your development environment before those changes will appear in workflows triggered via the API.
 
-There is one exception to this rule: the active/inactive status on a given workflow. This status lives independently from the commit model so that you can immediately enable or disable a workflow in any environment without needing to go through environment promotion. This is your kill switch for a given workflow should you need it.
+After you modify a resource, you'll see a "Save" button that allows you to store those changes. When you're ready to permanently store your updates with version control, these changes should then be committed with the "Commit to development" button that will come into focus after changes have been saved.
 
-A couple other things to note:
+**A few things to note:**
 
 - Channel configurations, branding, and variables do not need to be committed, as they live at the account-level. This means that if you make a change to a channel configuration, it will update immediately on notifications sent in that environment.
 - Any changes you have not yet committed to your current environment **will** apply when you're using the test runner. This way you can test your latest changes before you commit them to your environment.
+- You can work with Knock resources programmatically, outside of your dashboard, if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources locally.
+- The commit model applies to all methods of interacting with Knock resources, whether directly in the dashboard or with the Management API and CLI.
+
+### Commit Diffs
+
+Clicking the "Commit to development" button will show you a 
 
 ## Promotion and rollback
 
@@ -38,6 +51,10 @@ any issues they can be rolled back with ease.
 
 Knock uses a model where all changes to the production environment must be **promoted** and cannot be made directly.
 This means that changes must be made in the development environment, then staged and tested before being rolled out (similar to a git-based workflow).
+
+There is one exception to this rule: the active/inactive status on a given workflow. This status lives independently from the commit model so that you can immediately enable or disable a workflow in any environment without needing to go through environment promotion. This is your kill switch for a given workflow should you need it; this status is displayed on each workflow in your dashboard's **Workflows** section, and can be set by clicking on the workflow and using the "Status" selector.
+
+
 
 A typical deployment lifecycle in Knock looks like:
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -15,7 +15,7 @@ tags:
     "staging",
     "active",
     "inactive",
-    "diffs"
+    "diffs",
   ]
 section: Concepts
 ---
@@ -35,13 +35,15 @@ After you modify a resource, you'll see a "Save" button that allows you to store
 **A few things to note:**
 
 - Channel configurations, branding, and variables do not need to be committed, as they live at the account-level. This means that if you make a change to a channel configuration, it will update immediately on notifications sent in that environment.
-- Any changes you have not yet committed to your current environment **will** apply when you're using the test runner. This way you can test your latest changes before you commit them to your environment.
-- You can work with Knock resources programmatically, outside of your dashboard, if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources locally.
+- Any changes you have saved but not yet committed **will** apply when you're using the test runner. This way you can test your latest changes before you commit them to your development environment.
+- You can work with Knock resources outside of your dashboard if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources programmatically.
 - The commit model applies to all methods of interacting with Knock resources, whether directly in the dashboard or with the Management API and CLI.
 
 ### Commit Diffs
 
-Clicking the "Commit to development" button will show you a 
+Clicking the "Commit to development" button will show you a view of changes between your current commit and the most-recent version of the resource that you're updating. Commit diffs are also available on your full commit log (viewable on the **Commits** page in your dashboard), so you can view the commit history for a resource and know exactly what was changed with each commit.
+
+![Commit diffs in Knocks version control](/images/commit-diff-showcase.gif)
 
 ## Promotion and rollback
 
@@ -52,9 +54,23 @@ any issues they can be rolled back with ease.
 Knock uses a model where all changes to the production environment must be **promoted** and cannot be made directly.
 This means that changes must be made in the development environment, then staged and tested before being rolled out (similar to a git-based workflow).
 
-There is one exception to this rule: the active/inactive status on a given workflow. This status lives independently from the commit model so that you can immediately enable or disable a workflow in any environment without needing to go through environment promotion. This is your kill switch for a given workflow should you need it; this status is displayed on each workflow in your dashboard's **Workflows** section, and can be set by clicking on the workflow and using the "Status" selector.
+<Callout
+  emoji={"🚨"}
+  text={
+    <>
+      <span className="font-bold">There is one exception to this rule:</span>{" "}
+      the active/inactive status on a workflow. This status lives independently
+      from the commit model so that you can immediately enable or disable a
+      workflow in any environment without needing to go through environment
+      promotion. This is your kill switch for a given workflow should you need
+      it; this status is displayed on each workflow in your dashboard's{" "}
+      <span className="font-bold">Workflows</span> section, and can be set by
+      clicking on the workflow and using the "Status" selector.
+    </>
+  }
+/>
 
-
+To promote a committed change to a higher environment, navigate to the **Commits** page in your Knock dashboard and click on "Unpromoted changes". Here you'll see a list of commits that are ready for promotion. Clicking "view commit" on a given commit will show you a commit diff for that change, and clicking the "Promote to [environment]" button will promote the staged commit to the next-higher environment (whose name is displayed).
 
 A typical deployment lifecycle in Knock looks like:
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -1,15 +1,7 @@
 ---
 title: Environments
 description: Learn about how Knock's isolated environment model works and how it fits into your system development lifecycle.
-tags:
-  [
-    "env",
-    "version control",
-    "variables",
-    "promote",
-    "promotion",
-    "staging"
-  ]
+tags: ["env", "version control", "variables", "promote", "promotion", "staging"]
 section: Concepts
 ---
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -39,7 +39,7 @@ After you modify a resource, you'll see a "Save" button that allows you to store
 - You can work with Knock resources outside of your dashboard if you prefer. We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources programmatically.
 - The commit model applies to all methods of interacting with Knock resources, whether directly in the dashboard or with the Management API and CLI.
 
-### Commit Diffs
+### Commit diffs
 
 Clicking the "Commit to development" button will show you a view of changes between your current commit and the most-recent version of the resource that you're updating. Commit diffs are also available on your full commit log (viewable on the **Commits** page in your dashboard), so you can view the commit history for a resource and know exactly what was changed with each commit.
 

--- a/content/concepts/overview.mdx
+++ b/content/concepts/overview.mdx
@@ -17,15 +17,27 @@ A channel in Knock represents a configured provider, such as Sendgrid for email,
 
 [Learn more →](/concepts/channels)
 
+## Commits
+
+Knock uses a commit model to version changes that you make to all of your Knock resources. When you make a change to a workflow or a layout in the Knock dashboard, you'll need to commit it to your development environment before those changes will appear in workflows triggered via the API.
+
+[Learn more →](/concepts/commits)
+
 ## Environments
 
 Knock uses the concept of environments to ensure logical separation of your data and configuration. This means that users, and preferences created in one environment are **never** accessible to another. Environments usually map to the environments you have in your software development life cycle (SDLC).
 
 [Learn more →](/concepts/environments)
 
+## Recipients
+
+A Recipient within Knock is any [User](#users) or [Object](#objects) that may wish to receive notifications.
+
+[Learn more →](/concepts/recipients)
+
 ## Users
 
-A user in Knock represents someone who should receive a message. A user's profile information contains important attributes about the user that will be used in messages (name, email). The user object can contain other key-value pairs that can be used to further personalize your messages.
+A user in Knock represents an individual who should receive a message. A user's profile information contains important attributes about the user that will be used in messages (name, email). The user object can contain other key-value pairs that can be used to further personalize your messages.
 
 [Learn more →](/concepts/users)
 
@@ -34,12 +46,6 @@ A user in Knock represents someone who should receive a message. A user's profil
 A preference indicates a user's willingness to receive a particular type of notification. Preferences always belong to a user and can be paired with an identifier that represents the account or tenant that the user belongs to (for multi-tenant applications).
 
 [Learn more →](/concepts/preferences)
-
-## Schedules
-
-A schedule allows you to automatically trigger a workflow at a given time for one or more recipients. You can think of a schedule as a managed, recipient-timezone-aware cron job that Knock will run on your behalf.
-
-[Read more →](/concepts/schedules)
 
 ## Objects
 
@@ -53,17 +59,23 @@ You can use objects to:
 
 [Learn more →](/concepts/objects)
 
-## Tenants
-
-Tenants represent segments your users belong to. You might call these "accounts," "organizations," "workspaces," or similar. This is a common pattern in many SaaS applications: users have a single login joined to multiple tenants to represent their membership within each. Within Knock you can model your tenant objects as first-class entities and use them to scope features.
-
-[Learn more →](/concepts/tenants)
-
 ## Subscriptions
 
 A subscription represents a relationship between a non-user entity (an Object) and a Recipient (the subscriber). Subscriptions are used to model pub/sub behavior and lists of recipients that Knock will automatically fan out a workflow trigger to on your behalf.
 
 [Learn more →](/concepts/subscriptions)
+
+## Schedules
+
+A schedule allows you to automatically trigger a workflow at a given time for one or more recipients. You can think of a schedule as a managed, recipient-timezone-aware cron job that Knock will run on your behalf.
+
+[Read more →](/concepts/schedules)
+
+## Tenants
+
+Tenants represent segments your users belong to. You might call these "accounts," "organizations," "workspaces," or similar. This is a common pattern in many SaaS applications: users have a single login joined to multiple tenants to represent their membership within each. Within Knock you can model your tenant objects as first-class entities and use them to scope features.
+
+[Learn more →](/concepts/tenants)
 
 ## Messages
 

--- a/content/concepts/overview.mdx
+++ b/content/concepts/overview.mdx
@@ -25,7 +25,7 @@ Knock uses a commit model to version changes that you make to all of your Knock 
 
 ## Environments
 
-Knock uses the concept of environments to ensure logical separation of your data and configuration. This means that users, and preferences created in one environment are **never** accessible to another. Environments usually map to the environments you have in your software development life cycle (SDLC).
+Knock uses the concept of environments to ensure logical separation of your data and configuration. This means that users and preferences created in one environment are **never** accessible to another. Environments usually map to the environments you have in your software development life cycle (SDLC).
 
 [Learn more →](/concepts/environments)
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -55,10 +55,8 @@ Knock workflows can be managed either via the Knock Dashboard or programmaticall
     <>
       <span className="font-bold">Note:</span> remember that workflows and other
       resources in Knock can only ever be edited in the development environment.{" "}
-      <a href="/concepts/environments">
-        Learn more about versioning and environments
-      </a>
-      .
+      <a href="/concepts/commits">Learn more about versioning</a> and{" "}
+      <a href="/concepts/environments">environments</a>.
     </>
   }
 />
@@ -81,7 +79,7 @@ Each workflow can have one or more categories associated with it. Categories are
 
 All changes to workflows, including changes made to the templates inside of a workflow, are version controlled. Changes must be made in the development environment and are then "committed" and then "promoted" between environments for that version to be live within an environment. This allows you to confidently make changes to workflows, without affecting any running in production.
 
-[Read more about environments and versioning in Knock](/concepts/environments)
+Read more about [environments](/concepts/environments) and [versioning](/concepts/commits) in Knock.
 
 ## Running workflows
 

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -23,6 +23,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/overview", title: "Overview" },
       { slug: "/workflows", title: "Workflows" },
       { slug: "/channels", title: "Channels" },
+      { slug: "/commits", title: "Commits" },
       { slug: "/environments", title: "Environments" },
       { slug: "/recipients", title: "Recipients" },
       { slug: "/users", title: "Users" },


### PR DESCRIPTION
This PR updates the Environments concept page in our docs and moves the concepts of Commits and Promotion to a separate page. The changes include:

- Rearrange the order of some content to make it clearer
- Add additional search tags
- Add a new section on commit diffs (including a gif asset)
- Add explicit instructions on how to take certain actions in your dashboard, and mention the ability to perform these same actions via the MAPI or CLI
- Add Commits to sidebar nav
- Add Commits to the Concepts overview page, re-order the concepts on the overview page to match the nav ordering, and add a section for Recipients, which was missing
- Update the Workflows concept page's backlinks to separate version control and environments