### PR TITLE
fix: typos in code examples for feed filtering

### DIFF
--- a/content/guides/filtering-in-app-feeds.mdx
+++ b/content/guides/filtering-in-app-feeds.mdx
@@ -31,7 +31,7 @@ We include this concept in Knock as [Tenancy](/send-and-manage-data/tenants), wh
 
 ```js Triggering our workflow with a tenant
 await knock.workflows.trigger("new-comment", {
-  reipients: ["jane"],
+  recipients: ["jane"],
   data: {
     pageId: page.id,
     commentId: comment.id,
@@ -86,7 +86,7 @@ Imagine that we want to show all of the comment notifications the current user h
 
 ```js Triggering a workflow with data
 await knock.workflows.trigger("new-comment", {
-  reipients: recipientIds,
+  recipients: recipientIds,
   data: {
     pageId: page.id,
     commentId: comment.id,


### PR DESCRIPTION
We misspelled "recipients" in a couple spots on this page.
