### PR TITLE
Fix: Update non-recurring schedules anchor tag

### DIFF
--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -25,7 +25,7 @@ Some examples of where you might reach for a schedule:
 ## How schedules work
 
 1. [Create a workflow](/designing-workflows) that you wish to run in the future.
-2. Using the API, [set a repeating schedule](#scheduling-workflows-with-recurring-schedules-for-recipients) or a [non-recurring schedule](#scheduling-workflows-with-non-recurring-schedules-for-recipients) for one or more recipients for the workflow.
+2. Using the API, [set a repeating schedule](#scheduling-workflows-with-recurring-schedules-for-recipients) or a [non-recurring schedule](#scheduling-workflows-with-one-off-non-recurring-schedules-for-recipients) for one or more recipients for the workflow.
 
 Knock will preemptively schedule workflow runs for the recipient(s) that you've provided, and execute those runs at the scheduled time. At the end of the workflow run (and in case of using a recurring schedule), a future scheduled workflow will be enqueued based on the recipient's next schedule.
 


### PR DESCRIPTION
### Description

Updates the anchor tag for non-recurring schedules to the correct header. 