### PR TITLE
fix: typo on flutter page

### DIFF
--- a/content/in-app-ui/flutter/overview.mdx
+++ b/content/in-app-ui/flutter/overview.mdx
@@ -22,7 +22,7 @@ Using the Flutter SDK it's possible to:
 
 ## Need help?
 
-Our Flutter library is worked on full-time by the Knock JavaScript team.
+Our Flutter library is worked on full-time by the Knock Mobile team.
 
 ### Join the community
 


### PR DESCRIPTION
"JavaScript" -> "Mobile"
