### PR TITLE
Chore: Add max limit to page_size for feed

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -2502,7 +2502,7 @@ along with a user token to make this request**
   <Attribute
     name="page_size"
     type="number"
-    description="The total number to retrieve per page (defaults to 50)"
+    description="The total number to retrieve per page. Defaults to 50 and the max limit is 200."
   />
   <Attribute
     name="after"


### PR DESCRIPTION
### Description

Clarifies in the documentation that the max limit for the `page_size` query param for feed requests is 200. 