### PR TITLE
fix(kno-5353): update slack overview

### DIFF
--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -5,15 +5,17 @@ section: Integrations > Slack
 layout: integrations
 ---
 
-Building a Slack integration can feel like a daunting task. There is a lot you can build on top of the Slack API and app platform, and there's a lot of documentation that comes with it. Knock has SlackKit to manage all of that for you, but you also have the option of building it yourself. We'll cover both methods of integrating Slack into your application in the guides that follow:
+In this guide you'll learn how to use Knock to send notifications to Slack. There are two ways to do this:
 
-- **The Knock-Slack model.** An overview of how you'll build your Knock-Slack integration and the key concepts involved.
-- **Building a Slack app.** How to build a Slack app you'll use for SlackKit or your own DIY approach.
-- **SlackKit.** Knock's managed approach to integrating Slack (recommended).
-- **DIY Integration.** How to build your own Slack integration with Knock.
-- **Designing Slack templates.** How to design your Slack notification templates in Knock using our markdown or JSON block editors.
-- **Powering Slack interactivity.** How to build interactive Slack messages using Knock.
-- **Example use cases.** Step-by-step walkthroughs of a number of example Slack use cases, from notifying a user via DM to notifying a channel in your own Slack workspace.
+1. [SlackKit](/integrations/chat/slack-kit/overview): Follow this guide to use the Knock-managed approach to integrating Slack. Using this method, Knock handles authorization and API calls to Slack on your users' behalf and provides pre-built components and hooks for you to quickly build out the UI of your Slack integration.
+2. [DIY Slack OAuth](/integrations/chat/slack-diy/slack-apps-and-scopes): If you want to connect Slack yourself either via incoming webhooks or access tokens, this guide will show you how to implement this for yourself. You'll have to build out the UI yourself when using this method.
+
+We'll also cover:
+- [**The Knock-Slack model.**](/integrations/chat/slack/how-knock-slacks) An overview of how you'll build your Knock-Slack integration and the key concepts involved.
+- [**Building a Slack app.**](/integrations/chat/slack/building-a-slack-app) How to build a Slack app you'll use for SlackKit or your own DIY approach.
+- [**Designing Slack templates.**](/integrations/chat/slack/designing-slack-templates) How to design your Slack notification templates in Knock using our markdown or JSON block editors.
+- [**Powering Slack interactivity.**](/integrations/chat/slack/slack-interactivity) How to build interactive Slack messages using Knock.
+- [**Example use cases.**](/integrations/chat/slack/slack-examples) Step-by-step walkthroughs of a number of example Slack use cases, from notifying a user via DM to notifying a channel in your own Slack workspace.
 
 <Callout
   emoji="👩‍💻"

--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -11,6 +11,7 @@ In this guide you'll learn how to use Knock to send notifications to Slack. Ther
 2. [DIY Slack OAuth](/integrations/chat/slack-diy/slack-apps-and-scopes): If you want to connect Slack yourself either via incoming webhooks or access tokens, this guide will show you how to implement this for yourself. You'll have to build out the UI yourself when using this method.
 
 We'll also cover:
+
 - [**The Knock-Slack model.**](/integrations/chat/slack/how-knock-slacks) An overview of how you'll build your Knock-Slack integration and the key concepts involved.
 - [**Building a Slack app.**](/integrations/chat/slack/building-a-slack-app) How to build a Slack app you'll use for SlackKit or your own DIY approach.
 - [**Designing Slack templates.**](/integrations/chat/slack/designing-slack-templates) How to design your Slack notification templates in Knock using our markdown or JSON block editors.


### PR DESCRIPTION
### Description
Updates the overview for Slack.
<img width="729" alt="Screen Shot 2024-02-27 at 1 39 39 PM" src="https://github.com/knocklabs/docs/assets/24256463/29fc7296-fb19-4890-9591-bae1d0babb28">

### Tasks
[KNO-5353](https://linear.app/knock/issue/KNO-5353/docs-update)