### PR TITLE
fix: update teardown refs for client

### DIFF
--- a/content/in-app-ui/javascript/quick-start.mdx
+++ b/content/in-app-ui/javascript/quick-start.mdx
@@ -46,7 +46,7 @@ const knockFeed = knockClient.feeds.initialize(
 );
 
 // Setup a real-time connection
-const teardown = knockFeed.listenForUpdates();
+knockFeed.listenForUpdates();
 
 // Fetch items for the feed
 knockFeed.fetch();

--- a/content/in-app-ui/javascript/reference.mdx
+++ b/content/in-app-ui/javascript/reference.mdx
@@ -168,6 +168,8 @@ Represents the connection between a user and a feed, including methods for inter
 
 Connects the feed instance to the realtime socket so that any new items published to the feed are received over the websocket.
 
+**Returns**: `void`
+
 **Example**:
 
 ```javascript Connecting to a realtime stream
@@ -184,8 +186,6 @@ knockFeed.listenForUpdates();
 // Stop listening
 knockFeed.teardown();
 ```
-
-**Returns**: `void`
 
 ### `on`
 

--- a/content/in-app-ui/javascript/reference.mdx
+++ b/content/in-app-ui/javascript/reference.mdx
@@ -168,8 +168,6 @@ Represents the connection between a user and a feed, including methods for inter
 
 Connects the feed instance to the realtime socket so that any new items published to the feed are received over the websocket.
 
-**Returns**: a teardown function.
-
 **Example**:
 
 ```javascript Connecting to a realtime stream
@@ -187,7 +185,7 @@ knockFeed.listenForUpdates();
 knockFeed.teardown();
 ```
 
-**Returns**: void
+**Returns**: `void`
 
 ### `on`
 


### PR DESCRIPTION
### Description
Fix a few outdated references to `knockClient.listenForUpdates` return type
