### PR TITLE
Remove data prefix callout from segment doc

### DIFF
--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -59,7 +59,7 @@ From the source environment configuration page click the "View in environment" b
 
 ## Connecting a track event to a workflow
 
-To start sending notifications using your Segment track event, you'll need to connect it to a workflow. 
+To start sending notifications using your Segment track event, you'll need to connect it to a workflow.
 
 You can do this directly within the workflow builder by selecting a trigger type of "event" and selecting the event. Once you've selected the event, you can map its properties to any of Knock's workflow parameters including `recipients`, `actor`, `tenant`, and `cancellation_key`.
 
@@ -86,7 +86,8 @@ You can do this directly within the workflow builder by selecting a trigger type
       all <code>properties</code> are available to you as data variables. You can access them directly in your templates without
       the <code>properties.</code> prefix.
     </>
-  }
+
+}
 />
 
 ## Committing the event action configuration

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -57,9 +57,37 @@ Once your Segment destination is set up all events you trigger from the Segment 
 
 From the source environment configuration page click the "View in environment" button on one of the source environments. You'll be taken to the Segment source in the environment you selected and you should see events sent. If you don't, try clicking the refresh button on the top of the list to refetch any incoming events.
 
-## Connecting a track event to an action
+## Connecting a track event to a workflow
 
-You can add a **track event** as a trigger to your workflow directly from the workflow builder. Click on the workflow's trigger step and change the type from "API" to "Event". Then you'll be able to select the event and map its properties into the data the workflow needs.
+To start sending notifications using your Segment track event, you'll need to connect it to a workflow. 
+
+You can do this directly within the workflow builder by selecting a trigger type of "event" and selecting the event. Once you've selected the event, you can map its properties to any of Knock's workflow parameters including `recipients`, `actor`, `tenant`, and `cancellation_key`.
+
+<Callout
+  emoji="✨"
+  text={
+    <>
+      <span className="font-bold">Using event data in workflow trigger mappings.</span> When connecting an event to a workflow, you can use any of the data available within the event payload in the workflow's parameters. For example, if your payload looks like this:
+      <div className="mt-2 mb-2">
+        <pre>
+          <code>{eventPayload}</code>
+        </pre>
+      </div>
+      and you wanted the commenter from the action to appear as the{" "}
+      <code>Actor</code> in the workflow, then in the{" "}
+      <code>Actor</code> field you would write{" "}
+      <code>properties.commenter.id</code> to supply their ID as the actor.
+      <br/><br/>
+      If you wanted to supply the event's <code>userId</code> as the workflow's recipient, 
+      you'd write <code>userId</code> in the <code>Recipients</code> field.
+      <br/><br/>
+
+      <span className="font-bold">Note:</span> when you're editing message templates,
+      all <code>properties</code> are available to you as data variables. You can access them directly in your templates without
+      the <code>properties.</code> prefix.
+    </>
+  }
+/>
 
 ## Committing the event action configuration
 

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -61,26 +61,6 @@ From the source environment configuration page click the "View in environment" b
 
 You can add a **track event** as a trigger to your workflow directly from the workflow builder. Click on the workflow's trigger step and change the type from "API" to "Event". Then you'll be able to select the event and map its properties into the data the workflow needs.
 
-<Callout
-  emoji="✨"
-  text={
-    <>
-      <span className="font-bold">Using properties.</span> To use any of the
-      properties fields, you can access them with dot-syntax by prefixing them
-      with <code>data.</code>. For example, if your payload looks like this:
-      <div className="mt-2 mb-2">
-        <pre>
-          <code>{eventPayload}</code>
-        </pre>
-      </div>
-      and you wanted the commenter from the action to appear as the{" "}
-      <text className="font-bold">Actor</text> in the workflow, then in the{" "}
-      <text className="font-bold">Actor</text> field you would write{" "}
-      <code>data.commenter.id</code> to supply their ID as the actor.
-    </>
-  }
-/>
-
 ## Committing the event action configuration
 
 Event action configurations are stored in the commit history, just like workflows and email layouts. Once you're happy with the mapping, you can save it and commit it to your development environment using the same commit button as your workflow. When you're ready you can publish this event action configuration to your other environments from the commit page.

--- a/data/code/sources/eventPayload.ts
+++ b/data/code/sources/eventPayload.ts
@@ -1,5 +1,7 @@
 const eventPayload = `
 {
+    "event": "Guests-welcomed",
+    "userId": "JohnHammond1",
     "properties": {
         "commenter": {
             "id": 123,


### PR DESCRIPTION
Removing callout that you need to append "data." in place of "properties." to access variables that live within "properties" object of a segment track event. 

I just tested this and if you use `properties.` instead of `data.` it still works as expected, so I think we should remove this callout that you need to prefix properties with `data.` to use them in event action mappings. 

Here's a Loom of me testing this if you want to confirm: https://www.loom.com/share/e7dab22258f44ea996d2bad4089dc231