### PR TITLE
feat(kno-5428): add docs for onAuthenticationComplete

### DIFF
--- a/content/in-app-ui/react/reference.mdx
+++ b/content/in-app-ui/react/reference.mdx
@@ -511,6 +511,11 @@ Renders a notification bell icon, with a badge showing the number of unseen item
     type="string"
     description="The URL of your application to return to once Slack authorization is complete."
   />
+  <Attribute
+    name="onAuthenticationComplete"
+    type="(authenticationResult: 'authComplete' | 'authFailed') => void;"
+    description="An optional callback function you can pass to this component that will execute upon completion of the authentication flow. Takes one argument of the authentication result for you to handle in your callback."
+  />
 </Attributes>
 
 ### `SlackAuthContainer`


### PR DESCRIPTION
### Description
Documentation for the `onAuthenticationComplete` callback

### Tasks
[KNO-5428](https://linear.app/knock/issue/KNO-5428/onauthenticationcomplete-docs)
