### PR TITLE
fix: update Go code example for setting a tenant

### DIFF
--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -111,7 +111,9 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 tenant, _ := knockClient.Tenants.Set(ctx, &knock.SetTenantRequest{
   ID:         "tenant-1",
-  Name:       "Tenant 1"
+  Properties: map[string]interface{
+    Name:       "Tenant 1"
+  }
   Settings: map[string]interface{
     "branding":  map[string]interface{
       "primary_color":          "#33FF5B",

--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -112,7 +112,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 tenant, _ := knockClient.Tenants.Set(ctx, &knock.SetTenantRequest{
   ID:         "tenant-1",
   Properties: map[string]interface{
-    Name:       "Tenant 1"
+    "Name":       "Tenant 1"
   }
   Settings: map[string]interface{
     "branding":  map[string]interface{

--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -112,7 +112,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 tenant, _ := knockClient.Tenants.Set(ctx, &knock.SetTenantRequest{
   ID:         "tenant-1",
   Properties: map[string]interface{
-    "Name":       "Tenant 1"
+    "name":       "Tenant 1"
   }
   Settings: map[string]interface{
     "branding":  map[string]interface{


### PR DESCRIPTION
A customer reported an issue with the way we document the Golang example for setting a tenant [in the API reference](https://docs.knock.app/reference#set-tenant). This PR resolves the issue.