### PR TITLE
fix: import structure for ruby examples

### DIFF
--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -35,7 +35,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/messages/get-activities.ts
+++ b/data/code/messages/get-activities.ts
@@ -34,7 +34,7 @@ client.messages.get_activities(message.id)
 Knock.Messages.get_activities(message.id, {'page_size': 10})
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Messages.get_activities(id: message.id)

--- a/data/code/messages/get-content.ts
+++ b/data/code/messages/get-content.ts
@@ -17,7 +17,7 @@ client = Knock(api_key="sk_12345")
 client.messages.get_content(message.id)
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Messages.get_content(id: message.id)

--- a/data/code/messages/get-events.ts
+++ b/data/code/messages/get-events.ts
@@ -34,7 +34,7 @@ client.messages.get_events(message.id)
 Knock.Messages.get_events(message.id, {'page_size': 10})
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Messages.get_events(id: message.id)

--- a/data/code/messages/get.ts
+++ b/data/code/messages/get.ts
@@ -17,7 +17,7 @@ client = Knock(api_key="sk_12345")
 client.messages.get(message.id)
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Messages.get(id: message.id)

--- a/data/code/messages/list.ts
+++ b/data/code/messages/list.ts
@@ -37,7 +37,7 @@ client.messages.list()
 client.messages.list({'page_size': 20, 'tenant': "my_tenant"})
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Messages.list()

--- a/data/code/objects/bulk-delete.ts
+++ b/data/code/objects/bulk-delete.ts
@@ -22,8 +22,7 @@ client.objects.bulk_delete(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.bulk_delete(

--- a/data/code/objects/bulk-set.ts
+++ b/data/code/objects/bulk-set.ts
@@ -58,8 +58,7 @@ client.objects.bulk_set(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.bulk_set(

--- a/data/code/objects/delete.ts
+++ b/data/code/objects/delete.ts
@@ -20,8 +20,7 @@ client.objects.delete(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.delete(

--- a/data/code/objects/get-channel-data.ts
+++ b/data/code/objects/get-channel-data.ts
@@ -28,8 +28,7 @@ client.objects.get_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.get_channel_data(

--- a/data/code/objects/get-preferences.ts
+++ b/data/code/objects/get-preferences.ts
@@ -17,7 +17,7 @@ client = Knock(api_key="sk_12345")
 client.objects.get_preferences(collection="projects", id="project-1")
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.get_preferences(collection: "projects", id: "project-1")  

--- a/data/code/objects/get.ts
+++ b/data/code/objects/get.ts
@@ -20,8 +20,7 @@ client.objects.get(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.get(

--- a/data/code/objects/messages.ts
+++ b/data/code/objects/messages.ts
@@ -51,7 +51,7 @@ client.objects.get_messages(
 )
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.get_messages(

--- a/data/code/objects/set-channel-data-discord-bot.ts
+++ b/data/code/objects/set-channel-data-discord-bot.ts
@@ -47,8 +47,7 @@ client.objects.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set_channel_data(

--- a/data/code/objects/set-channel-data-discord-webhook.ts
+++ b/data/code/objects/set-channel-data-discord-webhook.ts
@@ -47,8 +47,7 @@ client.objects.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set_channel_data(

--- a/data/code/objects/set-channel-data-ms-teams.ts
+++ b/data/code/objects/set-channel-data-ms-teams.ts
@@ -47,8 +47,7 @@ client.objects.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set_channel_data(

--- a/data/code/objects/set-channel-data-slack.ts
+++ b/data/code/objects/set-channel-data-slack.ts
@@ -47,8 +47,7 @@ client.objects.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set_channel_data(

--- a/data/code/objects/set-preferences.ts
+++ b/data/code/objects/set-preferences.ts
@@ -36,8 +36,7 @@ client.objects.set_preferences(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set_preferences(

--- a/data/code/objects/set.ts
+++ b/data/code/objects/set.ts
@@ -33,8 +33,7 @@ client.objects.set_object(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.set(

--- a/data/code/objects/unset-channel-data.ts
+++ b/data/code/objects/unset-channel-data.ts
@@ -27,8 +27,7 @@ client.objects.unset_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Objects.unset_channel_data(

--- a/data/code/tenants/delete.ts
+++ b/data/code/tenants/delete.ts
@@ -19,8 +19,7 @@ client.tenants.delete(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Tenants.delete(

--- a/data/code/tenants/get.ts
+++ b/data/code/tenants/get.ts
@@ -19,8 +19,7 @@ client.tenants.get(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Tenants.get(

--- a/data/code/tenants/list.ts
+++ b/data/code/tenants/list.ts
@@ -37,7 +37,7 @@ client.tenants.list()
 client.tenants.list({'page_size': 20, 'name': "Tenant 1"})
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Tenants.list()

--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -50,8 +50,7 @@ client.tenants.set_tenant(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Tenants.set(

--- a/data/code/users/bulk-delete.ts
+++ b/data/code/users/bulk-delete.ts
@@ -17,8 +17,7 @@ client = Knock(api_key="sk_12345")
 client.users.bulk_delete(user_ids=user_ids)
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.bulk_delete(user_ids: user_ids)  

--- a/data/code/users/bulk-identify.ts
+++ b/data/code/users/bulk-identify.ts
@@ -49,7 +49,7 @@ client.users.bulk_identify([
 ])
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.bulk_identify([

--- a/data/code/users/bulk-set-preferences.ts
+++ b/data/code/users/bulk-set-preferences.ts
@@ -30,7 +30,7 @@ client.users.bulk_set_preferences(
 )
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 user_ids = ["jhammond", "dnedry", "imalcolm", "esattler"]

--- a/data/code/users/delete.ts
+++ b/data/code/users/delete.ts
@@ -17,8 +17,7 @@ client = Knock(api_key="sk_12345")
 client.users.delete(user.id)
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.delete(id: user.id)  

--- a/data/code/users/get-channel-data.ts
+++ b/data/code/users/get-channel-data.ts
@@ -29,7 +29,7 @@ client.users.get_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.get_channel_data(

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -17,7 +17,7 @@ client = Knock(api_key="sk_12345")
 client.users.get_preferences(user.id)
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.get_preferences(id: user.id)  

--- a/data/code/users/get.ts
+++ b/data/code/users/get.ts
@@ -17,8 +17,7 @@ client = Knock(api_key="sk_12345")
 client.users.get(user.id)
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.get(id: user.id)  

--- a/data/code/users/identify.ts
+++ b/data/code/users/identify.ts
@@ -29,8 +29,7 @@ client.users.identify(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.identify(

--- a/data/code/users/merge.ts
+++ b/data/code/users/merge.ts
@@ -20,8 +20,7 @@ client.users.merge(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.merge(

--- a/data/code/users/messages.ts
+++ b/data/code/users/messages.ts
@@ -40,7 +40,7 @@ client.users.get_messages(
 client.users.get_messages(id="639a2d5f-d1b7-4cf3-b81b-7d9604665276", options={'page_size': 10, 'tenant': "my_tenant"})
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.get_messages(

--- a/data/code/users/set-channel-data-push.ts
+++ b/data/code/users/set-channel-data-push.ts
@@ -22,8 +22,7 @@ client.users.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.set_channel_data(

--- a/data/code/users/set-channel-data.ts
+++ b/data/code/users/set-channel-data.ts
@@ -22,8 +22,7 @@ client.users.set_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.set_channel_data(

--- a/data/code/users/set-preferences-per-tenant.ts
+++ b/data/code/users/set-preferences-per-tenant.ts
@@ -36,8 +36,7 @@ client.users.set_preferences(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.set_preferences(

--- a/data/code/users/set-preferences-with-conditions.ts
+++ b/data/code/users/set-preferences-with-conditions.ts
@@ -37,8 +37,7 @@ client.users.set_preferences(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.set_preferences(

--- a/data/code/users/set-preferences.ts
+++ b/data/code/users/set-preferences.ts
@@ -35,8 +35,7 @@ client.users.set_preferences(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.set_preferences(

--- a/data/code/users/unset-channel-data.ts
+++ b/data/code/users/unset-channel-data.ts
@@ -17,8 +17,7 @@ client.users.unset_channel_data(
 )
   `,
   ruby: `
-require "knockapi"
-
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Users.unset_channel_data(

--- a/data/code/workflows/cancel-with-recipients.ts
+++ b/data/code/workflows/cancel-with-recipients.ts
@@ -20,7 +20,7 @@ client.workflows.cancel(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.cancel(

--- a/data/code/workflows/cancel.ts
+++ b/data/code/workflows/cancel.ts
@@ -17,7 +17,7 @@ client.workflows.cancel(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.cancel(

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -31,7 +31,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-attachment.ts
+++ b/data/code/workflows/trigger-with-attachment.ts
@@ -41,7 +41,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-branding-tenant.ts
+++ b/data/code/workflows/trigger-with-branding-tenant.ts
@@ -25,7 +25,7 @@ client.workflows.trigger(
 )
   `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -55,7 +55,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-object-as-actor.ts
+++ b/data/code/workflows/trigger-with-object-as-actor.ts
@@ -19,7 +19,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-object-as-recipient.ts
+++ b/data/code/workflows/trigger-with-object-as-recipient.ts
@@ -21,7 +21,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -49,7 +49,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-tenant.ts
+++ b/data/code/workflows/trigger-with-tenant.ts
@@ -31,7 +31,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -41,7 +41,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 apns_push_token = "apns-push-token"

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -41,7 +41,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -54,7 +54,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 apns_push_token = "apns-push-token"

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -29,7 +29,7 @@ client.workflows.trigger(
 )
 `,
   ruby: `
-require "knockapi"
+require "knock"
 Knock.key = "sk_12345"
 
 Knock::Workflows.trigger(


### PR DESCRIPTION
This PR updates all of our `ruby` examples to import the Knock client the correct way, i.e. `require "knock"` rather than `require "knockapi"` (which is the name of the gem but not the way that the client is named in the library).
