### PR TITLE
fix: use required keyword arg naming for ruby set tenant example

### DIFF
--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -56,7 +56,7 @@ Knock.key = "sk_12345"
 
 Knock::Tenants.set(
   id: "tenant-1",
-  data: {
+  tenant_data: {
     name: "Tenant 1",
     settings: {
       branding: {


### PR DESCRIPTION
### Description

The `knock-ruby` SDK has a [required keyword argument](https://github.com/knocklabs/knock-ruby/blob/main/lib/knock/tenants.rb#L48) `tenant_data` for the `Tenants.set()` function. This PR updates the example usage. 
