### PR TITLE
add renderHeader reference

### DIFF
--- a/content/sdks/react/reference.mdx
+++ b/content/sdks/react/reference.mdx
@@ -391,6 +391,11 @@ A provider to inject translations into components.
     description="A function invoked per `FeedItem` to be rendered that should return a cell to be rendered in the feed. Useful when you want to render a custom feed cell. Defaults to rendering a `NotificationCell`."
   />
   <Attribute
+    name="renderHeader"
+    type="function"
+    description="A function invoked that returns a header to be rendered in the feed. Useful when you want to render a custom header. Defaults to rendering a `NotificationFeedHeader`."
+  />
+  <Attribute
     name="onNotificationClick"
     type="function"
     description="A custom function to be invoked when a notification cell is clicked."


### PR DESCRIPTION
### Description

Adds a reference section for `renderHeader` to the `NotificationFeed` for header overrides
