### PR TITLE
final slackkit doc updates

### DIFF
--- a/content/concepts/tenants.mdx
+++ b/content/concepts/tenants.mdx
@@ -20,7 +20,7 @@ You use tenants in Knock to:
 
 A tenant in Knock:
 
-- Is uniquely identified by an `id`, [per-environment](/send-and-manage-data/environments)
+- Is uniquely identified by an `id`, [per-environment](/send-and-manage-data/environments). In most cases, this `id` is the same `uuid` used to identify the tenant in your system
 - Can have any number of custom properties
 - Can store branding overrides and preference defaults
 - Can be managed via the API

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -47,19 +47,41 @@ This is a token [you will generate](/integrations/chat/slack-kit/resource-access
 
 #### Tenant ID
 
-This is the ID of the tenant that will be storing the Slack access token. You will want one tenant per Slack workspace, which is generally one per organization you support. You will use this tenant to trigger notifications for the Slack workflow so your channels all have the same access token.
+This is the ID of the [tenant](/concepts/tenants) that will be storing the Slack access token. You will want one tenant per Slack workspace, which is generally one per organization you support. You will use this tenant to trigger notifications for the Slack workflow so your channels all have the same access token.
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Note: </strong>
+      You do NOT need to create your tenant with the Knock API before using it in
+      our SlackKit components. The tenant will be created automatically with the
+      ID you provide when the user connects their Slack workspace.
+    </>
+  }
+/>
 
 - **Find it:** You can generate a tenant ID based on your user's organization. For example, if your user is part of the Jurassic Park organization, you could create a tenant ID of `jurassic-park`.
 - **Store it:** This tenant ID should either be stored in or generated from data about the organization you support here.
-- **Note:** You do NOT need create your tenant with the Knock API before using it in our SlackKit components. The tenant will be created automatically when the user connects their Slack workspace.
 
 #### Recipient object ID and collection
 
 This is the ID and collection of the [object](/concepts/objects) that will be used as the recipient for your Slack notification workflow. The object will store the Slack channels your user selects to notify. When you use this object as the recipient of your workflow, it will send a notification to any slack channels stored on it. Slack channels are stored on the object as [`ChannelData`](/managing-recipients/setting-channel-data).
 
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Note: </strong>
+      You do NOT need to create your object with the Knock API before using it in
+      our SlackKit components. The object will be created automatically when the
+      user connects their Slack channel to the object.
+    </>
+  }
+/>
+
 - **Find it:** You can generate an object ID and collection to serve as the recipient object. We suggest basing this on the item you're sending a notification about. For example, if you have a collection of videos and a user wants to be notified about the comments on the `dinosaurs-loose` video, your object collection could be `videos` and the ID `dinosaurs-loose`.
 - **Store it:** This object ID and collection should either be stored in or generated from data about the item you're sending notifications about.
-- **Note:** You do NOT need create your object with the Knock API before using it in our SlackKit components. The object will be created automatically when the user connects their Slack channel to the object.
 
 ## Using SlackKit components
 

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -225,6 +225,7 @@ SLACK_APP_CLIENT_ID = "1354596639525.6166309709204";
   </KnockSlackProvider>
 </KnockProvider>
 ```
+
 <br />
 
 ```javascript title="Render your SlackAuthButton inside of KnockSlackProvider"

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -22,14 +22,14 @@ You'll also need the following data to use in your SlackKit components:
 
 ## Set up data
 
-Here's where to find each setup data variable and a recommendation of how to make it available to your client application:
+Here's where to find each setup data variable and a recommendation of how to make it available to your client application.
 
-<div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
-#### Slack app client ID The client ID of your Slack application.
+#### Slack app client ID
+
+The client ID of your Slack application.
 
 - **Find it** in your Slack app's Basic info section, or saved in the Knock Slack channel you set up in the first step of the process.
 - **Store it** as an .env variable.
-  <div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
 
 #### Knock Slack Channel ID
 
@@ -37,7 +37,6 @@ This is the ID of the Slack channel in the Knock dashboard that you linked your 
 
 - **Find it** in the Knock dashboard in the channel itself.
 - **Store it** as an .env variable.
-  <div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
 
 #### User JWT token with resource access grants
 
@@ -45,7 +44,6 @@ This is a token [you will generate](/integrations/chat/slack-kit/resource-access
 
 - **Find it:** Token generated for the user from your application.
 - **Store it** in local storage for your user.
-  <div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
 
 #### Tenant ID
 
@@ -53,15 +51,15 @@ This is the ID of the tenant that will be storing the Slack access token. You wi
 
 - **Find it:** You can generate a tenant ID based on your user's organization. For example, if your user is part of the Jurassic Park organization, you could create a tenant ID of `jurassic-park`.
 - **Store it:** This tenant ID should either be stored in or generated from data about the organization you support here.
-  <div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
+- **Note:** You do NOT need create your tenant with the Knock API before using it in our SlackKit components. The tenant will be created automatically when the user connects their Slack workspace.
 
-#### Recipient Object ID & collection
+#### Recipient object ID and collection
 
-This is the ID and collection of the object that will be used as the recipient for your Slack notification workflow. The object will store the Slack channels your user selects to notify as its channel data. When you use this object as the recipient of your workflow, it will send a notification to any slack channels stored in its channel data.
+This is the ID and collection of the [object](/concepts/objects) that will be used as the recipient for your Slack notification workflow. The object will store the Slack channels your user selects to notify. When you use this object as the recipient of your workflow, it will send a notification to any slack channels stored on it. Slack channels are stored on the object as [`ChannelData`](/managing-recipients/setting-channel-data).
 
 - **Find it:** You can generate an object ID and collection to serve as the recipient object. We suggest basing this on the item you're sending a notification about. For example, if you have a collection of videos and a user wants to be notified about the comments on the `dinosaurs-loose` video, your object collection could be `videos` and the ID `dinosaurs-loose`.
 - **Store it:** This object ID and collection should either be stored in or generated from data about the item you're sending notifications about.
-  <div className="api-docs-section border-b border-gray-200 dark:border-gray-800" />
+- **Note:** You do NOT need create your object with the Knock API before using it in our SlackKit components. The object will be created automatically when the user connects their Slack channel to the object.
 
 ## Using SlackKit components
 
@@ -173,51 +171,52 @@ SLACK_APP_CLIENT_ID = "1354596639525.6166309709204";
 ```
 
 <br />
+
 ```javascript // index.tsx
-
 return (
-
-<KnockProvider
-  apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-  userId={currentUser.id}
-  userToken={localStorage.getItem("knock-user-token")}
->
-  <KnockSlackProvider
-    knockSlackChannelId={process.env.KNOCK_SLACK_CHANNEL_ID}
-    tenant={currentAccount.id}
+  <KnockProvider
+    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+    userId={currentUser.id}
+    userToken={localStorage.getItem("knock-user-token")}
   >
-    <NotificationSettings />
-    <VideoProjectsIndex />
-  </KnockSlackProvider>
-</KnockProvider>
-)
-
-````
-<br/>
-```javascript
-// NotificationSettings
-const NotificationSettings = () => {
-    return <SlackAuthContainer
-                actionButton={
-                    <SlackAuthButton
-                        slackClientId={process.env.SLACK_APP_CLIENT_ID}
-                        redirectUrl={"www.my-example-app.com/notification-settings"}
-                     />
-                }
-            />
-}
-
-````
+    <KnockSlackProvider
+      knockSlackChannelId={process.env.KNOCK_SLACK_CHANNEL_ID}
+      tenant={currentAccount.id}
+    >
+      <NotificationSettings />
+      <VideoProjectsIndex />
+    </KnockSlackProvider>
+  </KnockProvider>
+);
+```
 
 <br />
-```javascript // VideoProjectsPage & VideoPage
+
+```javascript NotificationSettings
+const NotificationSettings = () => {
+  return (
+    <SlackAuthContainer
+      actionButton={
+        <SlackAuthButton
+          slackClientId={process.env.SLACK_APP_CLIENT_ID}
+          redirectUrl={"www.my-example-app.com/notification-settings"}
+        />
+      }
+    />
+  );
+};
+```
+
+<br />
+
+```javascript VideoProjectsPage & VideoPage
 
 const VideoProjectsPage = ({videos}) => {
-return (
-videos.map(video => {
-return <VideoPage {video} />
-})
-)
+    return (
+        videos.map(video => {
+            return <VideoPage {video} />
+        })
+    )
 }
 
 const VideoPage = ({video}) => {
@@ -236,8 +235,9 @@ return (
 </div>
 ) }
 
-````
-<br/>
+```
+
+<br />
 
 ## Using SlackKit headless
 
@@ -246,6 +246,7 @@ If you need custom designs or want to display additional information around your
 SlackKit exposes three levels of support: React hooks, client functions, and API endpoints.
 
 ### Hooks
+
 You can use the [Slack React hooks](/in-app-ui/react/reference#slack-hooks) under the hood to access and set Slack integration data with your own components. All of them are available from the `@knocklabs/react-core` package. All of them must still be nested under the `KnockSlackProvider` to work.
 
 To use a hook in your component, all you need to to is import it and pass it the necessary params, and then you can use the data and functions returned in each to pass to your own component UI.
@@ -261,37 +262,45 @@ We'll combine our data to create a list of channels that has a name and an `isPr
 Here's some sample code for our final list:
 
 ```javascript
-import { useConnectedSlackChannels, useSlackChannels } from "@knocklabs/react-core";
+import {
+  useConnectedSlackChannels,
+  useSlackChannels,
+} from "@knocklabs/react-core";
 
 const ConnectedChannelsList = ({ slackChannelsRecipientObject }) => {
-    const { data: slackChannels } = useSlackChannels()
-    const { data: connectedChannels } = useConnectedSlackChannels({slackChannelsRecipientObject})
+  const { data: slackChannels } = useSlackChannels();
+  const { data: connectedChannels } = useConnectedSlackChannels({
+    slackChannelsRecipientObject,
+  });
 
-    const slackChannelsMap = new Map(
-      slackChannels.map((channel) => [channel.id, channel]),
-    );
+  const slackChannelsMap = new Map(
+    slackChannels.map((channel) => [channel.id, channel]),
+  );
 
-    const hydratedConnectedChannels = connectedChannels.map( connectedChannel => {
-        const channel_id = connectedChannel.channel_id
-        return {
-            id: channel_id,
-            name: slackChannelsMap[channel_id].name,
-            isPrivate: slackChannelsMap[channel_id].is_private
-        }
-    })
+  const hydratedConnectedChannels = connectedChannels.map(
+    (connectedChannel) => {
+      const channel_id = connectedChannel.channel_id;
+      return {
+        id: channel_id,
+        name: slackChannelsMap[channel_id].name,
+        isPrivate: slackChannelsMap[channel_id].is_private,
+      };
+    },
+  );
 
-    return (
-        <ul>
-            {hydratedConnectedChannels.map( channel => {
-                return (
-                    <li key={channel.id}>{channel.name} {channel.isPrivate && <LockIcon />}</li>
-                )
-            })}
-        </ul>
-    )
-}
-
-````
+  return (
+    <ul>
+      {hydratedConnectedChannels.map((channel) => {
+        return (
+          <li key={channel.id}>
+            {channel.name} {channel.isPrivate && <LockIcon />}
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+```
 
 ### Client functions
 

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -20,7 +20,7 @@ You'll also need the following data to use in your SlackKit components:
 - Tenant ID
 - Recipient Object ID & collection
 
-## Set up data
+### Required credentials
 
 Here's where to find each setup data variable and a recommendation of how to make it available to your client application.
 
@@ -45,9 +45,25 @@ This is a token [you will generate](/integrations/chat/slack-kit/resource-access
 - **Find it:** Token generated for the user from your application.
 - **Store it** in local storage for your user.
 
+### Knock entities
+
+SlackKit uses parts of Knock's data model to facilitate OAuth and channel selection using the React components outlined below.
+
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <strong>Note: </strong>
+      If this is the first time you've thought about objects and tenants in Knock,
+      we'd recommend reviewing how they work with SlackKit on the <a href="/integrations/chat/slack-kit/overview">
+        integration overview page
+      </a> before proceeding.
+    </>
+  }
+/>
 #### Tenant ID
 
-This is the ID of the [tenant](/concepts/tenants) that will be storing the Slack access token. You will want one tenant per Slack workspace, which is generally one per organization you support. You will use this tenant to trigger notifications for the Slack workflow so your channels all have the same access token.
+This is the ID of the [tenant](/concepts/tenants) that will be storing the Slack access token. You will want one tenant per Slack workspace, which is generally one per customer you support. You will use this tenant to trigger notifications for the Slack workflow so your channels all have the same access token.
 
 <Callout
   emoji="💡"
@@ -61,7 +77,7 @@ This is the ID of the [tenant](/concepts/tenants) that will be storing the Slack
   }
 />
 
-- **Find it:** You can generate a tenant ID based on your user's organization. For example, if your user is part of the Jurassic Park organization, you could create a tenant ID of `jurassic-park`.
+- **Find it:** In most cases, you should use the UUID that represents your user's organization in your system. For example, if your user is part of the Jurassic Park organization, you could create a tenant ID of `jurassic-park`.
 - **Store it:** This tenant ID should either be stored in or generated from data about the organization you support here.
 
 #### Recipient object ID and collection
@@ -91,7 +107,7 @@ Once you've provided access to the necessary data, you can drop Knock's pre-buil
 
 In order to give your components the data they need, they must be wrapped in the `KnockSlackProvider`. We recommend putting this high in your component tree so that any Slack components that you use will be rendered within it. The Slack provider goes inside of the `KnockProvider`. Your hierarchy will look like this:
 
-```javascript
+```javascript title="Wrap your UI components in data providers"
 <KnockProvider
     apiKey="Public API key"
     userId="User ID"
@@ -114,7 +130,7 @@ The `KnockSlackProvider` gives your components access to the status of the conne
 
 Your users will give your Slack app access to their own Slack workspaces via the `SlackAuthButton`. This button can be used on its own, or nested in the `SlackAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
 
-```javascript
+```javascript title="Initiate OAuth and display auth state with SlackAuthButton"
 // Without container
 <SlackAuthButton
     slackClientId="Slack app client ID"
@@ -144,7 +160,7 @@ The combobox has an option to show connected channels below it, which is a list 
 
 Add your combobox to your application where you'd like the user to select channels to notify:
 
-```javascript
+```javascript title="The SlackChannelCombobox connects an object to one or more channels"
 <SlackChannelCombobox
   slackChannelsRecipientObject={{
     id: "object id",
@@ -183,7 +199,7 @@ Add your combobox to your application where you'd like the user to select channe
 
 Here's an example of these components in a React application.
 
-```javascript
+```javascript title="Store Knock and Slack credentials as .env vars"
 // .env
 
 KNOCK_PUBLIC_API_KEY = "pk_test_12345";
@@ -194,7 +210,7 @@ SLACK_APP_CLIENT_ID = "1354596639525.6166309709204";
 
 <br />
 
-```javascript // index.tsx
+```javascript title="Providers wrap your UI components"
 <KnockProvider
   apiKey={process.env.KNOCK_PUBLIC_API_KEY}
   userId={currentUser.id}
@@ -212,7 +228,7 @@ SLACK_APP_CLIENT_ID = "1354596639525.6166309709204";
 
 <br />
 
-```javascript NotificationSettings
+```javascript title="Render your SlackAuthButton inside of KnockSlackProvider"
 const NotificationSettings = () => {
   return (
     <SlackAuthContainer
@@ -229,7 +245,7 @@ const NotificationSettings = () => {
 
 <br />
 
-```javascript VideoProjectsPage & VideoPage
+```javascript title="Render a SlackChannelCombobox for each object"
 
 const VideoProjectsPage = ({videos}) => {
     return (
@@ -281,7 +297,7 @@ We'll combine our data to create a list of channels that has a name and an `isPr
 
 Here's some sample code for our final list:
 
-```javascript
+```javascript title="Fetch Slack channels without the SlackChannelCombobox"
 import {
   useConnectedSlackChannels,
   useSlackChannels,

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -195,21 +195,19 @@ SLACK_APP_CLIENT_ID = "1354596639525.6166309709204";
 <br />
 
 ```javascript // index.tsx
-return (
-  <KnockProvider
-    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
-    userId={currentUser.id}
-    userToken={localStorage.getItem("knock-user-token")}
+<KnockProvider
+  apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+  userId={currentUser.id}
+  userToken={localStorage.getItem("knock-user-token")}
+>
+  <KnockSlackProvider
+    knockSlackChannelId={process.env.KNOCK_SLACK_CHANNEL_ID}
+    tenant={currentAccount.id}
   >
-    <KnockSlackProvider
-      knockSlackChannelId={process.env.KNOCK_SLACK_CHANNEL_ID}
-      tenant={currentAccount.id}
-    >
-      <NotificationSettings />
-      <VideoProjectsIndex />
-    </KnockSlackProvider>
-  </KnockProvider>
-);
+    <NotificationSettings />
+    <VideoProjectsIndex />
+  </KnockSlackProvider>
+</KnockProvider>
 ```
 
 <br />
@@ -242,20 +240,20 @@ const VideoProjectsPage = ({videos}) => {
 }
 
 const VideoPage = ({video}) => {
-return (
-
-<div>
-  <div>{video.name}</div>
-  <div>{video.content}</div>
-  <div>{video.comments}</div>
-  <SlackChannelCombobox
-    slackChannelsRecipientObject={{
-      id: video.id,
-      collection: "videos",
-    }}
-  />
-</div>
-) }
+  return (
+    <div>
+      <div>{video.name}</div>
+      <div>{video.content}</div>
+      <div>{video.comments}</div>
+      <SlackChannelCombobox
+        slackChannelsRecipientObject={{
+          id: video.id,
+          collection: "videos",
+        }}
+      />
+    </div>
+  )
+}
 
 ```
 

--- a/content/integrations/chat/slack-kit/overview.mdx
+++ b/content/integrations/chat/slack-kit/overview.mdx
@@ -6,7 +6,7 @@ section: Integrations > SlackKit
 layout: integrations
 ---
 
-SlackKit is Knock's collection of components, hooks, and API's to quickly set up Slack in your application for your users to integrate with their own workspaces.
+SlackKit is Knock's collection of components, hooks, and APIs to quickly set up Slack in your application for your users to integrate with their own workspaces.
 
 <Callout
   emoji="🚧"
@@ -36,7 +36,9 @@ If you already use Knock's tenant concept to power other 'account-based' feature
     <>
       <strong>Note: </strong>
       Our recommendation on best practice is that tenants in Knock should map one-to-one
-      to whatever abstraction you use to model accounts, organizations, or workspaces. You can think of tenants as the top-level container within your data model that you use to power multi-tenancy in your application.
+      to whatever abstraction you use to model accounts, organizations, or workspaces.
+      You can think of tenants as the top-level container within your data model
+      that you use to power multi-tenancy in your application.
     </>
   }
 />
@@ -47,6 +49,17 @@ If you already use Knock's tenant concept to power other 'account-based' feature
 
 In the context of SlackKit, objects serve two purposes. First, they store the Slack channel or channels you want to notify. Second, they act as the recipient of the workflow that sends message to Slack.
 
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Note: </strong>
+      You can think of collections as the different tables within your database that
+      represent resources in your application. Objects are the rows within those
+      tables.
+    </>
+  }
+/>
 #### Example
 
 Let's say we're building an example source control application like GitHub, where teams can collaborate and share code repositories. In this context, each GitHub organization would map to a tenant in Knock, and each repository would become an object inside of a `repositories` collection.

--- a/content/integrations/chat/slack-kit/overview.mdx
+++ b/content/integrations/chat/slack-kit/overview.mdx
@@ -20,6 +20,56 @@ SlackKit is Knock's collection of components, hooks, and API's to quickly set up
 
 Instead of handling the OAuth handshake, access token grants, and channel connection yourself, you can use our pre-built components or build your own components on top of our API.
 
+## Key concepts
+
+SlackKit connects multiple concepts in Knock to make it easier for users to create a Slack integration. There are two key concepts you'll see throughout the following docs that are foundational to how SlackKit works, but might not be used in every implementation of Knock: tenants and objects.
+
+### About tenants
+
+[Tenants](/concepts/tenants) in Knock are meant to represent segments of your user base. You might call these "accounts," "organizations," "workspaces," or something similar. In a standard SlackKit implementation, you'll store a Slack workspace's `access_token` on a corresponding tenant in Knock.
+
+If you already use Knock's tenant concept to power other 'account-based' features, you likely create tenants in Knock when an account or organization is created in your application. If you don't already use tenants in Knock, SlackKit can create tenants for you on the fly if they don't already exist.
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Note: </strong>
+      Our recommendation on best practice is that tenants in Knock should map one-to-one
+      to whatever abstraction you use to model accounts, organizations, or workspaces.
+    </>
+  }
+/>
+
+### About objects
+
+[Objects](/concepts/objects) in Knock are flexible abstractions meant to map to a resource in your system. Each individual object in Knock exists within a `collection` and requires an `id` unique to that collection.
+
+In the context of SlackKit, objects serve two purposes. First, they store the Slack channel or channels you want to notify. Second, they act as the recipient of the workflow that sends message to Slack.
+
+#### Example
+
+Let's say we're building an example source control application like GitHub, where teams can collaborate and share code repositories. In this context, each GitHub organization would map to a tenant in Knock, and each repository would become an object inside of a `repositories` collection.
+
+If we want to be notified in Slack each time an issue is opened against a repository, we would store a Slack channel on each repository object and then trigger a `new-issue` workflow. Knock will use the data stored on the object and tenant to route a message to the correct Slack channel:
+
+```javascript
+await knockClient.workflows.trigger("new-issue", {
+  recipients: [
+    {
+      collection: "repositories",
+      id: "knocklabs/javascript",
+    },
+  ],
+  tenant: "knocklabs",
+  data: {
+    message: formData.get("newIssue"),
+  },
+});
+```
+
+## Next steps
+
 We also have two **example apps** for you to get the feel of how to integrate Slack and Knock with SlackKit:
 
 - [SlackKit tutorial](https://github.com/knocklabs/javascript/tree/main/examples/slack-kit-example)

--- a/content/integrations/chat/slack-kit/overview.mdx
+++ b/content/integrations/chat/slack-kit/overview.mdx
@@ -36,7 +36,7 @@ If you already use Knock's tenant concept to power other 'account-based' feature
     <>
       <strong>Note: </strong>
       Our recommendation on best practice is that tenants in Knock should map one-to-one
-      to whatever abstraction you use to model accounts, organizations, or workspaces.
+      to whatever abstraction you use to model accounts, organizations, or workspaces. You can think of tenants as the top-level container within your data model that you use to power multi-tenancy in your application.
     </>
   }
 />

--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -62,7 +62,7 @@ Now that your Slack app is set up, you'll want to reference three attributes in 
 2. Client ID
 3. Client secret
 
-You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, create a Slack channel or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
+You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
 
 ## Use Slack channel in a workflow
 


### PR DESCRIPTION
@meryldakin @JEverhart383 ahead of SlackKit's big day next week started a quick PR of final docs clean up based on beta feedback doc in notion here: https://www.notion.so/knockapp/SlackKit-beta-feedback-a33859a547944653ad09492892f39b7b

**done**
- cleaning up some formatting stuff on react slackkit page
- added in some links to other parts of docs where helpful

**remaining:**
- some of code examples at bottom of doc could use clean up on indentation etc
- looks like we aren't able to pass titles to code components for some reason but think those would help a lot especially in full sample code section where there a bunch of code samples one after the other. as a new reader to those found it a bit hard to understand what i was looking at 