### PR TITLE
fix: example for Java merge

### DIFF
--- a/data/code/users/merge.ts
+++ b/data/code/users/merge.ts
@@ -60,7 +60,7 @@ KnockClient client = KnockClient.builder()
     .apiKey("sk_12345")
     .build();
 
-UserIdentity user = client.users().identify(user.getId(), "user-to-merge-from");
+UserIdentity user = client.users().merge(user.getId(), "user-to-merge-from");
 `,
 };
 


### PR DESCRIPTION
### Description

The Java example for `merge` used the `identify` method instead.

