### PR TITLE
chore(kno-5594): add recipients filter param to list subscriptions ap…

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4553,6 +4553,11 @@ Will return the underlying recipient attached. Note: the object must exist.
     type="string"
     description="When set to `recipient` will return all of the active subscriptions for the object, not the subscribers of the object."
   />
+  <Attribute
+    name="recipients"
+    type="string[]"
+    description="A list of recipient identifiers to filter subscribers of the object. Filtering by recipients will only be enabled when mode is not set."
+  />
 </Attributes>
 
 ### Response


### PR DESCRIPTION
### Description

Updates the api docs to include new recipients filter when listing subscriptions for object. 

### Tasks

[] Release [changes](https://github.com/knocklabs/switchboard/pull/2139) to infra-prod

### Screenshots

<img width="1001" alt="Screenshot 2024-03-26 at 4 36 08 PM" src="https://github.com/knocklabs/docs/assets/162606520/594662fa-6d25-4a0c-88dd-f2583eb98044">
