### PR TITLE
fix: <aside> component height

### DIFF
--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -103,8 +103,8 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
 
   return (
     <aside
-      className="fixed top-30 pl-5 w-64 overflow-y-auto"
-      style={{ height: "calc(100vh - 200px)" }}
+      className="fixed top-30 pl-5 pb-4 w-64 overflow-y-auto"
+      style={{ height: "calc(100vh - 16.5em)" }}
     >
       <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">
         On this page


### PR DESCRIPTION
### Description

This PR adjusts the height calculation of the `<aside>` menu component so that it never overlaps the footer.

### Video explanation

https://www.loom.com/share/e371409be70c459f902a5b751ca9e5eb?sid=8f7a53b0-e4b6-4813-a3f5-4fa17d1d1e74