### PR TITLE
chore: clarify list subscriptions mode parameter

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4499,7 +4499,7 @@ A subscription represents the relationship between a recipient (the subscriber) 
 <Section title="List subscriptions" slug="list-subscriptions">
 <ContentColumn>
 
-Lists all subscriptions for an object (the subscribers) or all of the current subscriptions for the object, depending on the `mode` given. Defaults to returning subscriber information.
+Lists all subscriptions to an object (the subscribers) or all of the current subscriptions for which the specified object is a recipient, depending on the `mode` given. Defaults to returning subscriber information.
 
 Will return the underlying recipient attached. Note: the object must exist.
 
@@ -4551,7 +4551,7 @@ Will return the underlying recipient attached. Note: the object must exist.
   <Attribute
     name="mode"
     type="string"
-    description="When set to `recipient` will return all of the active subscriptions for the object, not the subscribers of the object."
+    description='When set to "recipient" will return all of the active subscriptions for which the specified object is a recipient (as a subscriber to other objects), rather than the subscribers of the specified object.'
   />
   <Attribute
     name="recipients"


### PR DESCRIPTION
### Description

The List Subscriptions [endpoint](https://docs.knock.app/reference#list-subscriptions) can return all of the specified object's recipient subscribers, _or_ all of that object's subscriptions to other objects (as a recipient itself), depending on the provided `mode` parameter. There's some additional work to be done with the SDK methods to make this easier to understand (some discussion about that happened in the community slack [here](https://knockcustomers.slack.com/archives/C033CKE13SS/p1711066678839589)), but this should hopefully make it easier to understand in the meantime.