### PR TITLE
chore: add reference to commit model to environments page

### DIFF
--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -13,7 +13,7 @@ The API key you use determines the environment into which you'll be sending data
 
 ## Working with Knock resources across environments
 
-In order to prevent unintended changes to Knock resources (like a [workflow](/concepts/workflows) or [layout](/integrations/email/layouts)) in a production setting, we use a commit model that requires changes to be saved and committed in your Development environment and [promoted](/concepts/commits#promotion-and-rollback) to higher environments. 
+In order to prevent unintended changes to Knock resources (like a [workflow](/concepts/workflows) or [layout](/integrations/email/layouts)) in a production setting, we use a commit model that requires changes to be saved and committed in your Development environment and [promoted](/concepts/commits#promotion-and-rollback) to higher environments.
 
 [Read more about Commits](/concepts/commits)
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -6,10 +6,16 @@ section: Concepts
 ---
 
 Knock uses the concept of environments to ensure logical separation of your data between
-local, staging, and production environments. This means that users, and preferences created
+local, staging, and production environments. This means that recipients and preferences created
 in one environment are **never** accessible to another.
 
 The API key you use determines the environment into which you'll be sending data. You can find your environment-specific API keys under the "Developer" section of the Knock dashboard.
+
+## Working with Knock resources across environments
+
+In order to prevent unintended changes to Knock resources (like a [workflow](/concepts/workflows) or [layout](/integrations/email/layouts)) in a production setting, we use a commit model that requires changes to be saved and committed in your Development environment and [promoted](/concepts/commits#promotion-and-rollback) to higher environments. 
+
+[Read more about Commits](/concepts/commits)
 
 ## Create additional environments
 
@@ -17,7 +23,7 @@ By default your Knock account comes with two environments: Development and Produ
 
 To create a new environment, go to "Settings" then "Environments". You'll see a button to "Create environment".
 
-When you create an additional environment, it will be inserted between Development and Production. This means all changes will continue to be introduced in your Development environment and will need to be [promoted](/concepts/commits#promotion-and-rollback) through additional environments until they land in Production. Subsequent new environments will always be added one "level" lower than Production; environments cannot be re-ordered, as this would break the promotion model for previously-promoted changes.
+When you create an additional environment, it will be inserted between Development and Production. This means all changes will continue to be introduced in your Development environment and will need to be promoted through additional environments until they land in Production. Subsequent new environments will always be added one "level" lower than Production; environments cannot be re-ordered, as this would break the promotion model for previously-promoted changes.
 
 ## Environment-based access controls
 


### PR DESCRIPTION
### Description

In response to some customer feedback, this PR adds a reference to our commit model (and relevant links) to the Environments concept page.