### PR TITLE
chore: add custom email font guidance

### DIFF
--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -90,8 +90,11 @@ If you want to create your own custom email layouts, you can go into the layout 
 Knock supports custom web fonts that are referenced inside your email layout's `<head>`. This should be done via a `<link>` tag, as the style `@import` rule is not supported:
 
 ```html
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
-```  
+<link
+  href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+  rel="stylesheet"
+/>
+```
 
 Because many widely-used email clients do not support web fonts, we highly recommend choosing a web safe font as a fallback when using custom web fonts to ensure a consistent user experience.
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -85,6 +85,16 @@ If you want to create your own custom email layouts, you can go into the layout 
   }
 />
 
+### Using custom fonts
+
+Knock supports custom web fonts that are referenced inside your email layout's `<head>`. This should be done via a `<link>` tag, as the style `@import` rule is not supported:
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+```  
+
+Because many widely-used email clients do not support web fonts, we highly recommend choosing a web safe font as a fallback when using custom web fonts to ensure a consistent user experience.
+
 ### Using variables and brand attributes in a custom layout
 
 It's helpful to remember that you can use variables you create at the account and environment-levels by injecting them into your layout with the `vars.*` namespace. This is a great tool for global values that will be the same across all emails you send, such as base URL for embedded links in your email notifications.


### PR DESCRIPTION
### Description

This PR adds a section on custom fonts in email layouts. In includes the proper way to import them and calls out the lack of support for custom fonts in many popular email clients.
