### PR TITLE
chore(kno-5632): update api docs with recipients and objects filtering

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4554,9 +4554,14 @@ Will return the underlying recipient attached. Note: the object must exist.
     description='When set to "recipient" will return all of the active subscriptions for which the specified object is a recipient (as a subscriber to other objects), rather than the subscribers of the specified object.'
   />
   <Attribute
+    name="objects"
+    type="dictionary<string, ObjectRef>"
+    description='A collection of ObjectRefs, containing the object collection and id, to filter subscriptions. Filtering by objects will only be enabled when mode is set to "recipient".'
+  />
+  <Attribute
     name="recipients"
-    type="string[]"
-    description="A list of recipient identifiers to filter subscribers of the object. Filtering by recipients will only be enabled when mode is not set."
+    type="string[] | dictionary<string, RecipientRef>"
+    description="A collection of recipient identifiers (user_ids and/or ObjectRefs) to filter subscribers of the object. Filtering by recipients will only be enabled when mode is not set."
   />
 </Attributes>
 
@@ -4638,6 +4643,11 @@ Returns a paginated list of subscriptions for a single user, in descending order
     name="before"
     type="string"
     description="The cursor to retrieve items before (hint: use the `__cursor` field)"
+  />
+  <Attribute
+    name="objects"
+    type="dictionary<string, ObjectRef>"
+    description="A collection of ObjectRefs, containing the object collection and id, to filter subscriptions."
   />
 </Attributes>
 
@@ -5089,8 +5099,8 @@ Returns a paginated list of schedules in descending order.
   />
   <Attribute
     name="recipients"
-    type="string[]"
-    description="A list of recipient identifiers to filter schedules for."
+    type="string[] | dictionary<string, RecipientRef>"
+    description="A collection of recipient identifiers (user_ids and/or ObjectRefs) to filter schedules for."
   />
   <Attribute
     name="tenant"


### PR DESCRIPTION
### Description

Update api docs to represent `recipients` and `objects` filtering as a map of maps. For recipients, both list and map structures are accepted

### Tasks

Ticker [KNO-5632](https://linear.app/knock/issue/KNO-5632/[docs]-update-objects-and-recipients-support-for)