### PR TITLE
fix: aside height render for deployed site

### DIFF
--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -104,7 +104,7 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
   return (
     <aside
       className="fixed top-30 pl-5 pb-4 w-64 overflow-y-auto"
-      style={{ height: "calc(100vh - 16.5em)" }}
+      style={{ height: "calc(100vh - 15.8rem)" }}
     >
       <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">
         On this page


### PR DESCRIPTION
### Description

This PR should fix the persistent issue with `<aside>` height rendering that #444 was meant to fix; there appears to be some extra padding on the deployed version of the docs site that means that the version which looks correct locally does not look exactly the same when deployed.

I tested this by editing the component height directly in the browser to find the correct height calc. We should be able to take a look at the Vercel preview here to confirm that all looks good (I like to navigate to the "Preferences" page, then make sure my screen is both wide enough to render the `<aside>` element and short enough that it requires scrolling. Scroll all the way to the bottom to see whether the footer overlaps the "On this page" sidebar).
