### PR TITLE
add t tag info to translations concept

### DIFF
--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -237,7 +237,7 @@ Knock also provides an editor-friendly `t` tag which you can use to write templa
 
 <Steps>
   <Step title="Write your message templates">
-    Wrap content you want to translate in a t tag. Any content between the opening and closing t tags will be used as the content for your account's default locale.
+    Wrap content you want to translate in a <code>t</code> tag. Any content between the opening and closing t tags will be used as the content for your account's default locale.
 
     ```liquid title="Message template"
     <p> {% t %}Have you received your order?{% endt %} </p>
@@ -245,7 +245,7 @@ Knock also provides an editor-friendly `t` tag which you can use to write templa
 
   </Step>
   <Step title="Commit your workflow">
-    After you commit your workflow, Knock will look for changes to your message templates and update a system translation file. Translation keys will be automatically generated based off of the content of the t tag. 
+    After you commit your workflow, Knock will look for changes to your message templates and update a system translation file. Translation keys will be automatically generated based off of the content of the <code>t</code> tag. 
     
     A Knock bot will commit these changes to your account with a message indicating which workflow generated the new translations.
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -231,6 +231,36 @@ The same goes for namespaced translations. If the above translation was in a tra
 <p> {{ "services:customers.orders.beenReceived" | t }} </p>
 ```
 
+## Automatically generate translations using the `t` tag in your message templates
+
+Knock also provides an editor-friendly `t` tag which you can use to write templates in their default language. Translation files for any supported languages will be automatically generated in the background when you commit a workflow.
+
+<Steps>
+  <Step title="Write your message templates">
+    Wrap content you want to translate in a t tag. Any content between the opening and closing t tags will be used as the content for your account's default locale.
+
+    ```liquid title="Message template"
+    <p> {% t %}Have you received your order?{% endt %} </p>
+    ```
+
+  </Step>
+  <Step title="Commit your workflow">
+    After you commit your workflow, Knock will look for changes to your message templates and update a system translation file. Translation keys will be automatically generated based off of the content of the t tag. 
+    
+    A Knock bot will commit these changes to your account with a message indicating which workflow generated the new translations.
+
+    ```json title="System translation file"
+    {
+      "VUCygk+2k4QK8B1D4yJp1Q==": "Have you received your order?"
+    }
+    ```
+
+  </Step>
+  <Step title="Translate the default content into additional locales">
+    You can then translate the default content into additional locales by manually editing your translation files or programmatically updating them using the Knock API and a translation service.
+  </Step>
+</Steps>
+
 ## Rules for determining the translation used for a recipient
 
 Locales have three levels of fallbacks:


### PR DESCRIPTION
### Description

Includes information on using the t tag for translations.

### Tasks
[KNO-5590](https://linear.app/knock/issue/KNO-5590/t-tag-documentation)