### PR TITLE
chore: clarify inline preference set

### DIFF
--- a/content/managing-recipients/setting-preferences.mdx
+++ b/content/managing-recipients/setting-preferences.mdx
@@ -109,28 +109,29 @@ In the case in which the per-tenant preference set doesn't exist, the [`default`
 
 ### Setting preferences inline during a workflow trigger
 
-Preferences can also be set for one or more recipients during a workflow trigger using [inline identify](/send-notifications/triggering-workflows#identifying-recipients-inline).
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <strong>Please note:</strong> setting preferences inline will always upsert
+      the preference set, meaning that changes will overide any extant preferences. We generally
+      recommend against using inline preferences to ensure the integrity of your
+      data.
+    </>
+  }
+/>
 
-One or more preference sets can be set inline for the recipient during the workflow trigger, including the ability to set **per-tenant preferences** by passing a dictionary of preference sets, where the key in the dictionary is the preference set id.
+Preferences can also be set during a workflow trigger using [inline identify](/send-notifications/triggering-workflows#identifying-recipients-inline). One or more preference sets (including **per-tenant preferences**) can be upserted by passing a dictionary of [preference sets](/concepts/preferences#preference-sets), where each key in the dictionary is the preference set ID.
+
+Unlike the `setPreferences` [method](/managing-recipients/setting-preferences#setting-preferences), setting preferences inline requires you to explictly provide the `default` preference set key when updating default preferences.
+<br />
 
 <MultiLangCodeBlock
   title="Setting preferences during a workflow trigger"
   snippet="workflows.trigger-with-user-preferences"
 />
 
-<br />
 
-<Callout
-  emoji="🚨"
-  text={
-    <>
-      <strong>Please note</strong> setting preferences inline will always upsert
-      the preference set, meaning that changes will be overidden. Generally, we
-      recommend against using inline preferences to ensure the integrity of your
-      data.
-    </>
-  }
-/>
 
 ## Client integration
 

--- a/content/managing-recipients/setting-preferences.mdx
+++ b/content/managing-recipients/setting-preferences.mdx
@@ -113,10 +113,10 @@ In the case in which the per-tenant preference set doesn't exist, the [`default`
   emoji="🚨"
   text={
     <>
-      <strong>Please note:</strong> setting preferences inline will always upsert
-      the preference set, meaning that changes will overide any extant preferences. We generally
-      recommend against using inline preferences to ensure the integrity of your
-      data.
+      <strong>Please note:</strong> setting preferences inline will always
+      upsert the preference set, meaning that changes will overide any extant
+      preferences. We generally recommend against using inline preferences to
+      ensure the integrity of your data.
     </>
   }
 />
@@ -124,14 +124,13 @@ In the case in which the per-tenant preference set doesn't exist, the [`default`
 Preferences can also be set during a workflow trigger using [inline identify](/send-notifications/triggering-workflows#identifying-recipients-inline). One or more preference sets (including **per-tenant preferences**) can be upserted by passing a dictionary of [preference sets](/concepts/preferences#preference-sets), where each key in the dictionary is the preference set ID.
 
 Unlike the `setPreferences` [method](/managing-recipients/setting-preferences#setting-preferences), setting preferences inline requires you to explictly provide the `default` preference set key when updating default preferences.
+
 <br />
 
 <MultiLangCodeBlock
   title="Setting preferences during a workflow trigger"
   snippet="workflows.trigger-with-user-preferences"
 />
-
-
 
 ## Client integration
 


### PR DESCRIPTION
### Description

This PR updates our documentation for setting preferences inline. In particular, it makes it a bit clearer that you must explicitly provide the `default` key when setting preferences this way, unlike the other ways of setting preferences (when using one of our SDKs), which will default to `default` when no preference set ID is provided. I also moved the callout block above the code example, as I think it was likely burying the lede a bit before.
