### PR TITLE
chore: add new components to slackkit setup

### DIFF
--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -42,7 +42,7 @@ In this section we'll complete the steps for setting up your Knock account and S
         You can read more about scopes in general in [building a slack app](/integrations/chat/slack/building-a-slack-app).
       </Accordion>
       <Accordion title="Add redirect URL">
-        Under `OAuth & Permissions` in the `Features` sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
+        Under **OAuth & Permissions** in the **Features** sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
 
         Copy and paste this redirect URL:
 
@@ -52,7 +52,7 @@ In this section we'll complete the steps for setting up your Knock account and S
         />
       </Accordion>
       <Accordion title="Set up public distribution">
-        Under `Manage Distribution`, click the `Distribute app` button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for `Remove hard coded information`.
+        Under **Manage Distribution**, click the "Distribute app" button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for "Remove hard coded information."
 
         Check the box and then click "Activate Public Distribution."
       </Accordion>
@@ -60,13 +60,13 @@ In this section we'll complete the steps for setting up your Knock account and S
 
   </Step>
   <Step title="Add Slack app to Knock Slack channel">
-    Now that your Slack app is set up, you'll want to reference three attributes in the `Basic Information` section:
+    Now that your Slack app is set up, you'll want to reference three attributes in the **Basic Information** section:
 
     1. App ID
     2. Client ID
     3. Client secret
 
-    You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
+    You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click **Manage configuration**. You'll see where to paste these three strings under **Provider settings**. Click "Update settings" to save.
 
   </Step>
   <Step title="Use Slack channel in a workflow">

--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -8,65 +8,69 @@ layout: integrations
 
 In this section we'll complete the steps for setting up your Knock account and Slack app to enable SlackKit.
 
-## Set up Slack app
+<Steps>
+  <Step title="Set up Slack app">
+    See [Build a Slack app](/integrations/chat/slack/building-a-slack-app) to create the bot that you'll use to post notifications.
 
-See [Build a Slack app](/integrations/chat/slack/building-a-slack-app) to create the bot that you'll use to post notifications.
+    <Callout
+      emoji="🤖"
+      text={
+        <>
+          <strong>Prepare existing Slackbot</strong>
+          <br />
+          <br />
+          If you already have a Slackbot you want to use, you'll just need to
+          make sure it has its redirect URL set and that it's publicly distributed, which
+          is described below.
+        </>
+      }
+    />
 
-<Callout
-  emoji="🤖"
-  text={
-    <>
-      <strong>Prepare existing Slackbot</strong>
-      <br />
-      <br />
-      If you have a SlackBot you already know you want to use, you'll just need to
-      make sure it has its redirect URL set and that it's publicly distributed, which
-      is described on this page.
-    </>
-  }
-/>
+    The following steps will be completed in the **OAuth & Permissions** sidebar of your Slack app's [management page](https://api.slack.com/apps):
 
-### Scopes
+    <AccordionGroup>
+      <Accordion title="Add a scope">
+        Although SlackKit manages your scopes, you have to add one in your Slack application's settings to start with so that it exposes the form for you to add a redirect URL.
 
-Add `channels:read` to the scopes section. (Although SlackKit manages your scopes, you have to add one to start with in your Slack application so that it exposes the form for you to add a redirect URL.)
+        Add `channels:read` to the scopes section. For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need. Here is the list of scopes and they reasons they're required:
 
-For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need, but here is the list of scopes and reasons for them:
+        - `chat:write`: This scope allows your bot to send messages to channels that the bot has been explicitly invited to, including private channels. It doesn't grant the ability to send messages to public channels without an invite.
+        - `chat:write.public`: This scope extends the bot's capabilities to send messages to public channels without needing a specific invitation to those channels. It's an addition to the chat:write scope, offering broader access for the bot to interact within the workspace.
+        - `channels:read`: This scope allows your bot to list all channels in a workspace and view details about specific channels (like name, topic, purpose, members), but does not grant access to private channels.
+        - `groups:read`: This scope allows your app to list all private channels that the bot or user is a member of and to view details about those channels.
 
-- `chat:write`: This scope allows your bot to send messages to channels that the bot has been explicitly invited to, including private channels. It doesn't grant the ability to send messages to public channels without an invite.
-- `chat:write.public`: This scope extends the bot's capabilities to send messages to public channels without needing a specific invitation to those channels. It's an addition to the chat:write scope, offering broader access for the bot to interact within the workspace.
-- `channels:read`: This scope allows your bot to list all channels in a workspace and view details about specific channels (like name, topic, purpose, members), but does not grant access to private channels.
-- `groups:read`: This scope allows your app to list all private channels that the bot or user is a member of and to view details about those channels.
+        You can read more about scopes in general in [building a slack app](/integrations/chat/slack/building-a-slack-app).
+      </Accordion>
+      <Accordion title="Add redirect URL">
+        Under `OAuth & Permissions` in the `Features` sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
 
-You can read more about scopes in general in [building a slack app](/integrations/chat/slack/building-a-slack-app).
+        Copy and paste this redirect URL:
 
-### Add redirect URL
+        <CopyableText
+          label="https://api.knock.app/providers/slack/authenticate"
+          content="https://api.knock.app/providers/slack/authenticate"
+        />
+      </Accordion>
+      <Accordion title="Set up public distribution">
+        Under `Manage Distribution`, click the `Distribute app` button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for `Remove hard coded information`. 
+        
+        Check the box and then click "Activate Public Distribution."
+      </Accordion>
+    </AccordionGroup>
+  </Step>
+  <Step title="Add Slack app to Knock Slack channel">
+    Now that your Slack app is set up, you'll want to reference three attributes in the `Basic Information` section:
 
-Under `OAuth & Permissions` in the `Features` sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
+    1. App ID
+    2. Client ID
+    3. Client secret
 
-Copy and paste this redirect url:
-
-<CopyableText
-  label="https://api.knock.app/providers/slack/authenticate"
-  content="https://api.knock.app/providers/slack/authenticate"
-/>
-
-### Set up public distribution
-
-Under `Manage Distribution`, click the `Distribute app` button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for `Remove hard coded information`. Check the box and then click "Activate Public Distribution."
-
-## Add Slack app to Knock Slack channel
-
-Now that your Slack app is set up, you'll want to reference three attributes in the `Basic Information` section:
-
-1. App ID
-2. Client ID
-3. Client secret
-
-You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
-
-## Use Slack channel in a workflow
-
-In order to test this flow, you'll want to set up a workflow with a Slack channel step. Later on we'll discuss how you can [design your notification templates for Slack](/integrations/chat/slack/designing-slack-templates), but for now you can just add the channel step to a workflow.
+    You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
+  </Step>
+  <Step title="Use Slack channel in a workflow">
+    In order to test this flow, you'll want to set up a workflow with a Slack channel step. Later on we'll discuss how you can [design your notification templates for Slack](/integrations/chat/slack/designing-slack-templates), but for now you can just add the channel step to a workflow.
+  </Step>
+</Steps>
 
 ## Summary
 

--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -52,11 +52,12 @@ In this section we'll complete the steps for setting up your Knock account and S
         />
       </Accordion>
       <Accordion title="Set up public distribution">
-        Under `Manage Distribution`, click the `Distribute app` button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for `Remove hard coded information`. 
-        
+        Under `Manage Distribution`, click the `Distribute app` button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for `Remove hard coded information`.
+
         Check the box and then click "Activate Public Distribution."
       </Accordion>
     </AccordionGroup>
+
   </Step>
   <Step title="Add Slack app to Knock Slack channel">
     Now that your Slack app is set up, you'll want to reference three attributes in the `Basic Information` section:
@@ -66,6 +67,7 @@ In this section we'll complete the steps for setting up your Knock account and S
     3. Client secret
 
     You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click `Manage configuration`. You'll see where to paste these three strings under `Provider settings`. Click `Update settings` to save.
+
   </Step>
   <Step title="Use Slack channel in a workflow">
     In order to test this flow, you'll want to set up a workflow with a Slack channel step. Later on we'll discuss how you can [design your notification templates for Slack](/integrations/chat/slack/designing-slack-templates), but for now you can just add the channel step to a workflow.

--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -32,7 +32,7 @@ In this section we'll complete the steps for setting up your Knock account and S
       <Accordion title="Add a scope">
         Although SlackKit manages your scopes, you have to add one in your Slack application's settings to start with so that it exposes the form for you to add a redirect URL.
 
-        Add `channels:read` to the scopes section. For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need. Here is the list of scopes and they reasons they're required:
+        Add `channels:read` to the scopes section. For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need. Here is the list of scopes and the reasons they're required:
 
         - `chat:write`: This scope allows your bot to send messages to channels that the bot has been explicitly invited to, including private channels. It doesn't grant the ability to send messages to public channels without an invite.
         - `chat:write.public`: This scope extends the bot's capabilities to send messages to public channels without needing a specific invitation to those channels. It's an addition to the chat:write scope, offering broader access for the bot to interact within the workspace.

--- a/content/integrations/chat/slack-kit/setup.mdx
+++ b/content/integrations/chat/slack-kit/setup.mdx
@@ -8,7 +8,7 @@ layout: integrations
 
 In this section we'll complete the steps for setting up your Knock account and Slack app to enable SlackKit.
 
-<Steps>
+<Steps titleSize="h2">
   <Step title="Set up Slack app">
     See [Build a Slack app](/integrations/chat/slack/building-a-slack-app) to create the bot that you'll use to post notifications.
 


### PR DESCRIPTION
### Description

This PR adds the new Step and Accordion components to the SlackKit setup page to organize things better. It also makes a few copy edits for clarity and grammar, and removes `code` styling from non-code references.

https://docs-o4ex5sir5-knocklabs.vercel.app/integrations/chat/slack-kit/setup