### PR TITLE
chore: add titlesize to steps component

### DIFF
--- a/components/Step.tsx
+++ b/components/Step.tsx
@@ -1,15 +1,34 @@
 import React from "react";
 
-const Steps = ({ children }) => (
+const Steps = ({ titleSize = "p", children }) => (
   <div role="list" className="ml-3.5 mt-10 mb-6">
     {React.Children.map(children, (child, i) =>
-      React.cloneElement(child, { stepNumber: i + 1 }),
+      React.cloneElement(child, { titleSize, stepNumber: i + 1 }),
     )}
   </div>
 );
 
-const Step = ({ title, children, stepNumber }) => (
-  <div role="listitem" className="relative flex items-start pb-2">
+function TitleTag({ size, children }) {
+  const classNames =
+    "!m-0 !mt-2 font-semibold !text-[16px] prose dark:prose-invert text-gray-900 dark:text-gray-200";
+
+  switch (size) {
+    case "p": {
+      return <p className={classNames}>{children}</p>;
+    }
+    case "h2": {
+      return <h2 className={classNames}>{children}</h2>;
+    }
+    case "h3": {
+      return <h3 className={classNames}>{children}</h3>;
+    }
+    default:
+      return null;
+  }
+}
+
+const Step = ({ titleSize = "p", title, children, stepNumber }) => (
+  <div role="listitem" className="relative flex items-start pb-4">
     <div className="absolute w-px h-[calc(100%-2.75rem)] top-[2.75rem] bg-gray-200/70 dark:bg-white/10" />
     <div className="absolute ml-[-14px] py-2">
       <div className="w-7 h-7 shrink-0 rounded-lg bg-gray-100 dark:text-white dark:bg-[#26292E] text-sm text-gray-800 font-semibold flex items-center justify-center">
@@ -17,10 +36,8 @@ const Step = ({ title, children, stepNumber }) => (
       </div>
     </div>
     <div className="w-full overflow-hidden pl-12 pr-px">
-      <p className="!m-0 !mt-2 font-semibold prose dark:prose-invert text-gray-900 dark:text-gray-200">
-        {title}
-      </p>
-      <div>{children}</div>
+      <TitleTag size={titleSize}>{title}</TitleTag>
+      <div className="!-mt-2">{children}</div>
     </div>
   </div>
 );

--- a/content/getting-started/quick-start.mdx
+++ b/content/getting-started/quick-start.mdx
@@ -7,7 +7,7 @@ section: Getting started
 
 In this guide, you'll integrate Knock with your backend web application and send your first notification using Knock.
 
-<Steps>
+<Steps titleSize="h2">
   <Step title="Create a Knock account">
     First, [create a Knock account](https://dashboard.knock.app/signup) if you don't already have one and log into the [Knock dashboard](https://dashboard.knock.app).
   </Step>


### PR DESCRIPTION
### Description

Adds a new `titleSize` prop to `Steps` and `Step` component that will render h2, h3, or p tags (default). Using `h2` or `h3` means the jump nav will be rendered.

### Screenshots

<img width="1624" alt="image" src="https://github.com/knocklabs/docs/assets/822528/7d5987ae-eba5-4ba6-a622-77f8fb88b7cb">
