### PR TITLE
chore: add support for dynamic language list on multilang code block

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -33,6 +33,7 @@ SyntaxHighlighter.registerLanguage("liquid", liquid);
 SyntaxHighlighter.registerLanguage("go", go);
 SyntaxHighlighter.registerLanguage("java", java);
 SyntaxHighlighter.registerLanguage("yaml", yaml);
+SyntaxHighlighter.registerLanguage("curl", shell);
 
 export type SupportedLanguage =
   | "javascript"
@@ -46,7 +47,8 @@ export type SupportedLanguage =
   | "json"
   | "go"
   | "java"
-  | "yaml";
+  | "yaml"
+  | "curl";
 
 const LanguageLabel = {
   javascript: "JavaScript",
@@ -61,6 +63,7 @@ const LanguageLabel = {
   go: "Go",
   java: "Java",
   yaml: "YAML",
+  curl: "cURL",
 };
 
 export interface Props {

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -117,10 +117,23 @@ export const CodeBlock: React.FC<Props> = ({
   const { theme } = useTheme();
 
   const params = useMemo(() => getParams(className) as any, [className]);
-  const lang = useMemo(
-    () => language ?? params.language ?? "shell",
-    [language, params],
-  );
+
+  //Determine language to be used for syntax highlighting
+  const lang = useMemo(() => {
+    // Check if `language` and `languages` exist, and if so, whether `language` is in the `languages` list for the block
+    // If so, we want to use it for syntax highlighting
+    if (language && languages && languages.includes(language)) {
+      return language;
+    }
+    // If `language` is defined but not in the `languages` list, default syntax highlighting to the first item in the languages list
+    else if (language && languages && !languages.includes(language)) {
+      return languages[0];
+    }
+    // Finally, fallback to `params.language` or to "shell" if it's also not defined
+    else {
+      return params.language ?? "shell";
+    }
+  }, [language, languages, params.language]);
 
   const [content] = useMemo(
     () =>

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -12,6 +12,8 @@ import liquid from "react-syntax-highlighter/dist/cjs/languages/hljs/handlebars"
 import go from "react-syntax-highlighter/dist/cjs/languages/hljs/go";
 import java from "react-syntax-highlighter/dist/cjs/languages/hljs/java";
 import yaml from "react-syntax-highlighter/dist/cjs/languages/hljs/yaml";
+import kotlin from "react-syntax-highlighter/dist/cjs/languages/hljs/kotlin";
+import swift from "react-syntax-highlighter/dist/cjs/languages/hljs/swift";
 import { IoCheckmark, IoCopy } from "react-icons/io5";
 import useClipboard from "react-use-clipboard";
 
@@ -34,6 +36,8 @@ SyntaxHighlighter.registerLanguage("go", go);
 SyntaxHighlighter.registerLanguage("java", java);
 SyntaxHighlighter.registerLanguage("yaml", yaml);
 SyntaxHighlighter.registerLanguage("curl", shell);
+SyntaxHighlighter.registerLanguage("swift", swift);
+SyntaxHighlighter.registerLanguage("kotlin", kotlin);
 
 export type SupportedLanguage =
   | "javascript"
@@ -47,6 +51,8 @@ export type SupportedLanguage =
   | "json"
   | "go"
   | "java"
+  | "kotlin"
+  | "swift"
   | "yaml"
   | "curl";
 
@@ -64,6 +70,8 @@ const LanguageLabel = {
   java: "Java",
   yaml: "YAML",
   curl: "cURL",
+  kotlin: "Kotlin",
+  swift: "Swift",
 };
 
 export interface Props {

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -3,7 +3,7 @@
 */
 
 import { useEventEmitter } from "@byteclaw/use-event-emitter";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useIsMounted } from "../hooks/useIsMounted";
 import useLocalStorage from "../hooks/useLocalStorage";
 import { CodeBlock, SupportedLanguage } from "./CodeBlock";

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -154,9 +154,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet }) => {
   // If the language in the snippet is "javascript", we need to display "node" in the switcher
   const languages = useMemo(() => {
     const snippetCode = snippets[snippet];
-    return DEFAULT_ORDER.map((key) =>
-      key === "javascript" ? "node" : key,
-    ).filter(
+    return DEFAULT_ORDER.filter(
       (key) =>
         key in snippetCode || (key === "node" && "javascript" in snippetCode),
     );

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -112,8 +112,7 @@ const snippets = {
     require("../data/code/workflows/trigger-with-user-channel-data").default,
   "workflows.trigger-with-user-preferences":
     require("../data/code/workflows/trigger-with-user-preferences").default,
-    "workflows.playground":
-    require("../data/code/workflows/playground").default,
+  "workflows.playground": require("../data/code/workflows/playground").default,
 };
 /* eslint-enable */
 
@@ -163,7 +162,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({
   const content = useMemo(() => {
     const snippetCode = snippets[snippet];
     const actualLanguage = language === "node" ? "javascript" : language;
-    
+
     // When a given block does not include any example code for the language that is currently stored in localstorage, we want to display the code that matches the first language in its switcher (which is what will be "selected" and displayed on the switcher by default)
     // When that first language in the switcher is "node", we once again need to reference the "javascript" code example.
     const listedLanguage = (languages && languages[0]) || DEFAULT_LANGUAGES[0];

--- a/content/playground.mdx
+++ b/content/playground.mdx
@@ -99,7 +99,4 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 The `MultiLangCodeBlock` will populate a switcher based on the examples provided in the snippet file.
 
-<MultiLangCodeBlock
-  snippet="workflows.playground"
-  title="Trigger a workflow"
-/>
+<MultiLangCodeBlock snippet="workflows.playground" title="Trigger a workflow" />

--- a/content/playground.mdx
+++ b/content/playground.mdx
@@ -94,3 +94,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
   </Card>
   <Card title="Second card">Content for the second card.</Card>
 </CardGroup>
+
+### `MultiLangCodeBlock`
+
+You can (optionally) define the explicit list of `languages` that are included in a code block example, and decide whether you'd like to include the default list of languages (defined in the component file) in addition to those that you define. `includeDefault` (optional) will default to `true`; when `true`, the provided `languages` array  will be concatenated onto the `DEFAULT_LANGUAGES` list, minus any duplicates. When `false`, only the provided `languages` will appear in the switcher.
+
+<MultiLangCodeBlock snippet="workflows.playground" title="Trigger a workflow" languages={["python", "ruby", "csharp", "curl"]} includeDefault={false}/>

--- a/content/playground.mdx
+++ b/content/playground.mdx
@@ -97,11 +97,9 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 ### `MultiLangCodeBlock`
 
-You can (optionally) define the explicit list of `languages` that are included in a code block example, and decide whether you'd like to include the default list of languages (defined in the component file) in addition to those that you define. `includeDefault` (optional) will default to `true`; when `true`, the provided `languages` array will be concatenated onto the `DEFAULT_LANGUAGES` list, minus any duplicates. When `false`, only the provided `languages` will appear in the switcher.
+The `MultiLangCodeBlock` will populate a switcher based on the examples provided in the snippet file.
 
 <MultiLangCodeBlock
   snippet="workflows.playground"
   title="Trigger a workflow"
-  languages={["python", "ruby", "csharp", "curl"]}
-  includeDefault={false}
 />

--- a/content/playground.mdx
+++ b/content/playground.mdx
@@ -97,6 +97,11 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor i
 
 ### `MultiLangCodeBlock`
 
-You can (optionally) define the explicit list of `languages` that are included in a code block example, and decide whether you'd like to include the default list of languages (defined in the component file) in addition to those that you define. `includeDefault` (optional) will default to `true`; when `true`, the provided `languages` array  will be concatenated onto the `DEFAULT_LANGUAGES` list, minus any duplicates. When `false`, only the provided `languages` will appear in the switcher.
+You can (optionally) define the explicit list of `languages` that are included in a code block example, and decide whether you'd like to include the default list of languages (defined in the component file) in addition to those that you define. `includeDefault` (optional) will default to `true`; when `true`, the provided `languages` array will be concatenated onto the `DEFAULT_LANGUAGES` list, minus any duplicates. When `false`, only the provided `languages` will appear in the switcher.
 
-<MultiLangCodeBlock snippet="workflows.playground" title="Trigger a workflow" languages={["python", "ruby", "csharp", "curl"]} includeDefault={false}/>
+<MultiLangCodeBlock
+  snippet="workflows.playground"
+  title="Trigger a workflow"
+  languages={["python", "ruby", "csharp", "curl"]}
+  includeDefault={false}
+/>

--- a/data/code/workflows/playground.ts
+++ b/data/code/workflows/playground.ts
@@ -1,0 +1,69 @@
+const languages = {
+  python: `
+from knockapi import Knock
+client = Knock(api_key="sk_12345")
+
+client.workflows.trigger(
+    key="new-comment",
+    recipients=["1", "2"]
+
+    # optional
+    data={ "project_name": "My Project" },
+    actor="3",
+    cancellation_key="cancel_123",
+    tenant="jurassic_world_employees"
+)
+`,
+  ruby: `
+require "knock"
+Knock.key = "sk_12345"
+
+Knock::Workflows.trigger(
+  key: "new-comment",
+  recipients: ["1", "2"]
+
+  # optional
+  data: { project_name: "My Project" },
+  actor: "3",
+  cancellation_key: "cancel_123",
+  tenant: "jurassic_world_employees"
+)
+`,
+  csharp: `
+var knockClient = new KnockClient(
+    new KnockOptions { ApiKey = "sk_12345" }
+);
+
+var workflowTriggerOpts = new TriggerWorkflow {
+  Recipients = new List<string>{"1", "2"}
+
+  // optional
+  Data = new Dictionary<string, string>{
+    {"project_name", "My Project"}
+  },
+  Actor = "3",
+  CancellationKey = "cancel_123",
+  Tenant = "jurassic_world_employees"
+};
+
+var result = await knockClient.Workflows.Trigger("new-comment", workflowTriggerOpts)
+`,
+  curl: `
+curl -X POST 'https://api.knock.app/v1/workflows/new-comment/trigger' \\ \n\
+     -H 'Authorization: Bearer sk_test_12345' \\ \n\
+     -H 'Content-Type: application/json' \\ \n\
+     -H 'Idempotency-Key: 123' \\ \n\
+     -d '{
+           "recipients": ["1", "2"],
+           "data": {
+             "project_name": "My Project"
+           },
+           "actor": "3",
+           "cancellation_key": "cancel_123",
+           "tenant": "jurassic_world_employees"
+         }'
+
+`,
+};
+
+export default languages;


### PR DESCRIPTION
### Description

In preparation for adding `cURL` and mobile SDK examples to some of our multi-language code block examples (in the API ref), this PR does several things:

- register `cURL`, Kotlin, and Swift as `SupportedLanguages`
- refactor `MultiLanguageCodeBlock` to base the list of languages in the switcher on the examples in the given code `snippet`, ordered by a `DEFAULT_ORDER`
- add additional logic to the rendered `code` so that if a given code block does not include an example for the language that is currently stored in `localstorage`, we will still render the correct code to match the language that is displayed on the switcher (which will always be the first language in the list).
For example: if you switch a block to `cURL` and `"curl"` is subsequently set in local storage, with the current component any block which doesn't include example `curl` code will display as empty even though the switcher will show the first language in its list.
- add a usage example and explanation to the `/playground` page

### Questions

1. What should the `DEFAULT_ORDER` be? Do we have any sense of the popularity of certain SDKs after Node? For now I essentially kept the order the same as before, adding `cURL` and `shell` at the beginning (with the assumption that these should be first when present) and everything else at the end of the list.
