### PR TITLE
chore: clarify reason for channel_invalid error

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -411,7 +411,7 @@ Knock uses standard [HTTP response codes](https://developer.mozilla.org/en-US/We
 
 <ErrorExample
   title="channel_invalid"
-  description="The channel you supplied in this request is invalid."
+  description="The channel you supplied in this request is invalid. A common cause of this error is that the channel you're referencing has not yet been configured in the current environment."
 />
 
 <ErrorExample


### PR DESCRIPTION
### Description

Add context on a common reason for the `invalid_channel` error.