### PR TITLE
chore: add callout on finding channel id for Discord

### DIFF
--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -56,6 +56,22 @@ Take the URL you copied from the Discord webhook and set channel data on the Obj
   title="Store Discord connection on object"
 />
 
+<br />
+
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <span className="font-bold">Potential confusion alert.</span> In the
+      example above, the KNOCK_DISCORD_CHANNEL_ID variable is the id of the
+      Knock channel you've created to represent your Discord integration within
+      the Knock dashboard. You can get it by going to{" "}
+      {"Integrations > Channels"} in the Knock dashboard and then copying the id
+      of your Discord channel.
+    </>
+  }
+/>
+
 You can navigate back to your Objects dashboard and verify that `project-1` has the appropiate data set.
 
 Now you're ready to send notifications to Discord via incoming webhook! Jump to the [Triggering the workflow](/integrations/chat/discord#triggering-the-workflow) section to do so.

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -63,9 +63,9 @@ Take the URL you copied from the Discord webhook and set channel data on the Obj
   text={
     <>
       <span className="font-bold">Potential confusion alert.</span> In the
-      example above, the <code>KNOCK_DISCORD_CHANNEL_ID</code> variable is the id of the
-      Knock channel you've created to represent your Discord integration within
-      the Knock dashboard. You can find it by going to{" "}
+      example above, the <code>KNOCK_DISCORD_CHANNEL_ID</code> variable is the
+      id of the Knock channel you've created to represent your Discord
+      integration within the Knock dashboard. You can find it by going to{" "}
       {"Integrations > Channels"} in the Knock dashboard and then copying the id
       of your Discord channel.
     </>

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -65,7 +65,7 @@ Take the URL you copied from the Discord webhook and set channel data on the Obj
       <span className="font-bold">Potential confusion alert.</span> In the
       example above, the KNOCK_DISCORD_CHANNEL_ID variable is the id of the
       Knock channel you've created to represent your Discord integration within
-      the Knock dashboard. You can get it by going to{" "}
+      the Knock dashboard. You can find it by going to{" "}
       {"Integrations > Channels"} in the Knock dashboard and then copying the id
       of your Discord channel.
     </>

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -63,7 +63,7 @@ Take the URL you copied from the Discord webhook and set channel data on the Obj
   text={
     <>
       <span className="font-bold">Potential confusion alert.</span> In the
-      example above, the KNOCK_DISCORD_CHANNEL_ID variable is the id of the
+      example above, the <code>KNOCK_DISCORD_CHANNEL_ID</code> variable is the id of the
       Knock channel you've created to represent your Discord integration within
       the Knock dashboard. You can find it by going to{" "}
       {"Integrations > Channels"} in the Knock dashboard and then copying the id

--- a/content/integrations/chat/slack-diy/building-oauth-flow.mdx
+++ b/content/integrations/chat/slack-diy/building-oauth-flow.mdx
@@ -40,10 +40,10 @@ Here's an example of setting channel data on an `object` in Knock.
   text={
     <>
       <span className="font-bold">Potential confusion alert.</span> In the
-      example above, the KNOCK_SLACK_CHANNEL_ID variable is the id of the Knock
-      channel you've created to represent your Slack app within the Knock
-      dashboard. You can get it by going to {"Integrations > Channels"} in the
-      Knock dashboard and then copying the id of your Slack app channel.
+      example above, the <code>KNOCK_SLACK_CHANNEL_ID</code> variable is the id
+      of the Knock channel you've created to represent your Slack app within the
+      Knock dashboard. You can find it by going to {"Integrations > Channels"}{" "}
+      in the Knock dashboard and then copying the id of your Slack app channel.
     </>
   }
 />


### PR DESCRIPTION
### Description

This PR adds a callout block to help a user understand what the Knock `channel_id` is and where to find it for a Discord channel (similar to the callout for setting channel data for Slack). This is in response to customer confusion on what this ID represents.

<img width="500" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/2e574f52-4b85-4ebc-a093-04f10e0aa894">

