### PR TITLE
chore: document payload data cap

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -1151,6 +1151,10 @@ A trigger calls a workflow created via the Knock dashboard.
 
 <RateLimit tier={5} />
 
+### Payload size limit
+
+Workflow trigger endpoints enforce a `10MB` payload `data` limit.
+
 ### Path parameters
 
 <Attributes>
@@ -1231,6 +1235,10 @@ See our guides on inline identification [for users](/send-and-manage-data/users#
 ### Rate limit
 
 <RateLimit tier={5} />
+
+### Payload size limit
+
+Workflow trigger endpoints enforce a `10MB` payload `data` limit.
 
 ### Path parameters
 


### PR DESCRIPTION
### Description

This PR documents a data cap on trigger payload size, per [this Slack discussion](https://knocklabs.slack.com/archives/C06FHSQ18G4/p1712776895554139). As this limit is only relevant to workflow triggers (I think? Correct me if I'm wrong), I opted to document it under the endpoints themselves. I also thought calling it out in a similar way that we document rate limits could be helpful (as opposed to only under the `data` parameter), but we can change that up.
