### PR TITLE
chore: add accordion groups to all FAQ sections

### DIFF
--- a/content/concepts/channels.mdx
+++ b/content/concepts/channels.mdx
@@ -58,6 +58,12 @@ You can read more about [setting channel data here](/send-notifications/setting-
 
 ## Frequently asked questions
 
-#### Can I have multiple channels for the same provider?
-
-There's no restriction on how many different channels you can have, including multiple channels for the same provider.
+<AccordionGroup>
+  <Accordion
+    title="Can I have multiple channels for the same provider?"
+    defaultOpen={true}
+  >
+    There's no restriction on how many different channels you can have,
+    including multiple channels for the same provider.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/recipients.mdx
+++ b/content/concepts/recipients.mdx
@@ -59,14 +59,20 @@ A recipient can have an optional `timezone` property, which should be a [valid t
 
 ## Frequently asked questions
 
-#### Is there a limit on the number of recipients I can have in Knock?
-
-No, there's no limit on the number of recipients you can have within Knock.
-
-#### Why would I need a non-user recipient?
-
-We support non-user entities (Objects) receiving notifications in Knock because some notifications are delivered to non-user entities. For example, a Slack notification that sends to a channel. That notification is not delivered to a user but to an entity that connects Slack and your system (such as a Project or a Team).
-
-#### Is there a limit to the size of the properties I can pass on a recipient to Knock?
-
-Currently, there's no limit to the size of the properties you can add to a recipient. We reserve the right to impose a limit here in the future, however.
+<AccordionGroup>
+  <Accordion title="Is there a limit on the number of recipients I can have in Knock?">
+    No, there's no limit on the number of recipients you can have within Knock.
+  </Accordion>
+  <Accordion title="Why would I need a non-user recipient?">
+    We support non-user entities (Objects) receiving notifications in Knock
+    because some notifications are delivered to non-user entities. For example,
+    a Slack notification that sends to a channel. That notification is not
+    delivered to a user but to an entity that connects Slack and your system
+    (such as a Project or a Team).
+  </Accordion>
+  <Accordion title="Is there a limit to the size of the properties I can pass on a recipient to Knock?">
+    Currently, there's no limit to the size of the properties you can add to a
+    recipient. We reserve the right to impose a limit here in the future,
+    however.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -248,23 +248,36 @@ Knock supports a `timezone` property on the recipient that automatically makes a
 
 ## Frequently asked questions
 
-**How can I start my repeating schedule at a particular time?**
-You can use the `scheduled_at` attribute to start your schedule at a particular time in the future.
-
-**How can my scheduled workflows use dynamic template data?**
-You can use an HTTP fetch step to fetch data in your workflow as the first step to execute to fetch dynamic template data used in your workflow.
-
-**How can I set static data per workflow schedule?**
-When scheduling a workflow for one or more recipients, you can optionally provide a static set of `data` which will be passed to the invoked workflow.
-
-**Can I cancel a scheduled workflow?**
-At any point before the scheduled workflow is invoked you can unschedule the workflow for one or more recipients. If a workflow has already run, then [normal workflow cancellation rules](/send-notifications/canceling-workflows) take effect.
-
-**Can I still debug a scheduled workflow?**
-You’ll see workflow runs that initiated from a scheduled workflow in the list of workflow runs. From there you can select the debugger and debug a given workflow.
-
-**Can I model exclusion rules in my repeat logic?**
-Currently, no but we'll be looking to add this feature in the near future.
-
-**Can I change a recurring schedule to be a non-recurring?**
-Yes, you can update the schedule to change from a recurring to a non-recurring(or viceversa). This can be done by removing the `repeats` property and setting the `scheduled_at` to the desired one-time execution time.
+<AccordionGroup>
+  <Accordion title="How can I start my repeating schedule at a particular time?">
+    You can use the `scheduled_at` attribute to start your schedule at a
+    particular time in the future.
+  </Accordion>
+  <Accordion title="How can my scheduled workflows use dynamic template data?">
+    You can use an HTTP fetch step to fetch data in your workflow as the first
+    step to execute to fetch dynamic template data used in your workflow.
+  </Accordion>
+  <Accordion title="How can I set static data per workflow schedule?">
+    When scheduling a workflow for one or more recipients, you can optionally
+    provide a static set of `data` which will be passed to the invoked workflow.
+  </Accordion>
+  <Accordion title="Can I cancel a scheduled workflow?">
+    At any point before the scheduled workflow is invoked you can unschedule the
+    workflow for one or more recipients. If a workflow has already run, then
+    [normal workflow cancellation
+    rules](/send-notifications/canceling-workflows) take effect.
+  </Accordion>
+  <Accordion title="Can I still debug a scheduled workflow?">
+    You’ll see workflow runs that initiated from a scheduled workflow in the
+    list of workflow runs. From there you can select the debugger and debug a
+    given workflow.
+  </Accordion>
+  <Accordion title="Can I model exclusion rules in my repeat logic?">
+    Currently no, but we'll be looking to add this feature in the near future.
+  </Accordion>
+  <Accordion title="Can I change a recurring schedule to be non-recurring?">
+    Yes, you can update the schedule to change from recurring to non-recurring
+    (or vice versa). This can be done by removing the `repeats` property and
+    setting `scheduled_at` to the desired one-time execution time.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -156,42 +156,51 @@ Knock always deduplicates recipients when executing a notification fan out, incl
 
 ## Frequently asked questions
 
-#### What's the maximum number of subscribers I can have against an object?
-
-There's no upper bound in the number of subscribers you can have against a recipient, although you can only **manage** 100 recipients on an object at a time using our API.
-
-#### Can I have nested relationships for my objects?
-
-Yes! An object with subscribers _can also_ be subscribed to a parent object, allowing you to create nested hierarchies of objects (like a Team has many Projects, and each Project has many Members).
-
-#### Can I manage subscribers to an object in the dashboard?
-
-Right now, you can only **view** the subscribers of an object in the dashboard. You can do so under "Objects > Subscriptions".
-
-#### Can I set custom properties on a Subscription?
-
-Yes, you can pass a set of `properties`, which is a set of unstructured key-value pairs that you set any arbitrary data about.
-
-#### Can I filter the set of Subscriptions to be notified?
-
-Right now the answer is no, but we're interested in hearing about your use case here as we're considering adding this functionality in the future.
-
-#### Can I still debug workflow runs for the subscribers of an object?
-
-Yes, you can. Once you trigger a workflow for an object that has subscribers attached, you will see a workflow run for each of the subscribers under the "Workflow runs" page.
-
-#### Can I notify both the object AND the subscribers of the object?
-
-Yes, by default when you trigger a workflow for an object that has subscriptions attached Knock will generate a workflow run for the object itself AND all of the attached subscribers.
-
-#### Can I notify a recipient each time they appear within an object subscription tree?
-
-No, currently Knock [deduplicates all recipients](#deduplication-by-default) when fanning out to object subscribers. If this is blocking one of your use cases or your adoption of Knock, please contact our [support team](mailto:support@knock.app).
-
-#### Is the object that recipients are subscribed to exposed in the workflow run scope?
-
-No, currently we do not expose the object the subscription belongs to under the workflow run scope.
-
-#### Will the `actor` included in the workflow trigger receive a notification if they are a subscriber?
-
-No, currently the `actor` is **always** excluded from being a recipient in a workflow trigger, even if they are a subscriber to an object being notified.
+<AccordionGroup>
+  <Accordion title="What's the maximum number of subscribers I can have against an object?">
+    There's no upper bound in the number of subscribers you can have against a
+    recipient, although you can only **manage** 100 recipients on an object at a
+    time using our API.
+  </Accordion>
+  <Accordion title="Can I have nested relationships for my objects?">
+    Yes! An object with subscribers _can also_ be subscribed to a parent object,
+    allowing you to create nested hierarchies of objects (like a Team has many
+    Projects, and each Project has many Members).
+  </Accordion>
+  <Accordion title="Can I manage subscribers to an object in the dashboard?">
+    Right now, you can only **view** the subscribers of an object in the
+    dashboard. You can do so under "Objects > Subscriptions".
+  </Accordion>
+  <Accordion title="Can I set custom properties on a Subscription?">
+    Yes, you can pass a set of `properties`, which is a set of unstructured
+    key-value pairs that you set any arbitrary data about.
+  </Accordion>
+  <Accordion title="Can I filter the set of Subscriptions to be notified?">
+    Right now the answer is no, but we're interested in hearing about your use
+    case here as we're considering adding this functionality in the future.
+  </Accordion>
+  <Accordion title="Can I still debug workflow runs for the subscribers of an object?">
+    Yes, you can. Once you trigger a workflow for an object that has subscribers
+    attached, you will see a workflow run for each of the subscribers under the
+    "Workflow runs" page.
+  </Accordion>
+  <Accordion title="Can I notify both the object AND the subscribers of the object?">
+    Yes, by default when you trigger a workflow for an object that has
+    subscriptions attached Knock will generate a workflow run for the object
+    itself AND all of the attached subscribers.
+  </Accordion>
+  <Accordion title="Can I notify a recipient each time they appear within an object subscription tree?">
+    No, currently Knock [deduplicates all recipients](#deduplication-by-default)
+    when fanning out to object subscribers. If this is blocking one of your use
+    cases or your adoption of Knock, please contact our [support
+    team](mailto:support@knock.app).
+  </Accordion>
+  <Accordion title="Is the object that recipients are subscribed to exposed in the workflow run scope?">
+    No, currently we do not expose the object the subscription belongs to under
+    the workflow run scope.
+  </Accordion>
+  <Accordion title="Will the actor included in the workflow trigger receive a notification if they are a subscriber?">
+    No, currently the `actor` is **always** excluded from being a recipient in a
+    workflow trigger, even if they are a subscriber to an object being notified.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/tenants.mdx
+++ b/content/concepts/tenants.mdx
@@ -222,28 +222,32 @@ You can learn more about how to set per-tenant preferences and tenant preference
 
 ## Frequently asked questions
 
-**What's the limit on the number of tenants I can sync into Knock?**<br />
-There are no limits associated with tenants.
+<AccordionGroup>
+  <Accordion title="What's the limit on the number of tenants I can sync into Knock?">
+    There are no limits associated with tenants.
+  </Accordion>
+  <Accordion title="Can I use tenants on a non-enterprise plan?">
+    Yes, you can still use our APIs to work with tenant data, and trigger workflow runs for specific tenants. However, per-tenant preferences and custom branding are features gated for enterprise plans only.
+  </Accordion>
+  <Accordion title="How does Knock map my user access permissions onto a tenant?">
+    Knock does not know anything about the mapping between your users and your tenant entities, meaning you do not need to map user permissions.
+  </Accordion>
+  <Accordion title="Can I use a tenant as a recipient in a workflow trigger?">
+    Absolutely, you can use a tenant as a `recipient` or `actor` in a workflow trigger by referencing it as an object with the structure `{ collection: "$tenants", id: "tenant-id" }`.
+  </Accordion>
+  <Accordion title="Can I subscribe recipients to a tenant?">
+    Yes, you can subscribe recipients to a tenant by setting the collection of the object to subscribe to as `$tenants` and using the `id` of the tenant as the object id.
+  </Accordion>
+  <Accordion title="Can I create per-tenant templates?">
+    We're currently working on this feature to create per-tenant template overrides at the workflow step level. If you're interested in being an early adopter of this feature, or this is blocking your adoption of Knock, [please get in touch](mailto:support@knock.app?subject=Per-tenant%20templates).
+  </Accordion>
+  <Accordion title="Can I create per-tenant workflows?">
+    While it's technically possible to create per-tenant workflows in Knock, we recommend not doing this where possible and opting to use our step conditions, preferences, and per-tenant templates to provide the customizations you need. The reason is creating and managing per-tenant workflows increases the surface area of the number of notifications you need to support, and more commonly what we've found from working with customers is there are more similarities between per-customer workflows than differences, which can usually be encapsulated in our workflow model.
 
-**Can I use tenants on a non-enterprise plan?**<br />
-Yes, you can still use our APIs to work with tenant data, and trigger workflow runs for specific tenants. However, per-tenant preferences and custom branding are features gated for enterprise plans only.
+    If you find that you have different needs here, we'd love to speak with you. Please [get in touch](mailto:support@knock.app) and we can arrange a consultation with a notification support specialist on the Knock team to walk through your use case.
 
-**How does Knock map my user access permissions onto a tenant?**<br />
-Knock does not know anything about the mapping between your users and your tenant entities, meaning you do not need to map user permissions.
-
-**Can I use a tenant as a recipient in a workflow trigger?**<br />
-Absolutely, you can trigger a workflow as a `recipient` or as the `actor` in a workflow trigger as an object reference with the structure `{ collection: "$tenants", id: "tenant-id" }`.
-
-**Can I subscribe recipients to a tenant?**<br />
-Yes, you can subscribe recipients to a tenant by setting the collection of the object to subscribe to as `$tenants` and using the `id` of the tenant as the object id.
-
-**Can I create per-tenant templates?**<br />
-We're currently working on this feature to create per-tenant template overrides at the workflow step level. If you're interested in being an early adopter of this feature, or this is blocking your adoption of Knock, [please get in touch](mailto:support@knock.app?subject=Per-tenant%20templates).
-
-**Can I create per-tenant workflows?**<br />
-While it's technically possible to create per-tenant workflows in Knock, we recommend not doing this where possible and opting to use our step conditions, preferences, and per-tenant templates to provide the customizations you need. The reason is creating and managing per-tenant workflows increases the surface area of the number of notifications you need to support, and more commonly what we've found from working with customers is there are more similarities between per-customer workflows than differences, which can usually be encapsulated in our workflow model.
-
-If you find that you have different needs here, we'd love to speak with you. Please [get in touch](mailto:support@knock.app) and we can arrange a consultation with a notification support specialist on the Knock team to walk through your use case.
-
-**Can I nest tenants?**<br />
-No, today it's only possible to have a single-level of hierarchy for your tenants. If you need to apply deeper hierarchy to your tenant objects, please [get in touch](mailto:support@knock.app) and we can discuss your use case further.
+  </Accordion>
+  <Accordion title="Can I nest tenants?">
+    No, today it's only possible to have a single-level of hierarchy for your tenants. If you need to apply deeper hierarchy to your tenant objects, please [get in touch](mailto:support@knock.app) and we can discuss your use case further.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/users.mdx
+++ b/content/concepts/users.mdx
@@ -102,35 +102,32 @@ Users can be deleted from Knock via the `users.delete` method. Deleting a user f
 
 ## Frequently asked questions
 
-**What do I do if my notification recipients aren't yet users?**
+<AccordionGroup>
+  <Accordion title="What do I do if my notification recipients aren't yet users?">
+    Commonly you'll want to send notifications to entities in your system that are not currently registered users in your product (think guests or invited users). In these situations, we recommend:
 
-Commonly you'll want to send notifications to entities in your system that are not currently registered users in your product (think guests or invited users). In these situations, we recommend:
+    1. Identifying the user with a unique identifier, such as their email address, or with a prefix (`guest_`) to denote the different type.
+    2. Where possible, if the notified user becomes a registered user in your system then using our [merge API](#merging-users) to merge the guest user and the registered user to preserve message sending history.
 
-1. Identifying the user with a unique identifier, such as their email address, or with a prefix (`guest_`) to denote the different type.
-2. Where possible, if the notified user becomes a registered user in your system then using our [merge API](#merging-users) to merge the guest user and the registered user to preserve message sending history.
+    It might feel counterintuitive to store registered users and non-registered users under a single collection in your Knock environment, but Knock should always be viewed as a _cache_ of information about users and entities that may need to be notified in your system.
 
-It might feel counterintuitive to store registered users and non-registered users under a single collection in your Knock environment, but Knock should always be viewed as a _cache_ of information about users and entities that may need to be notified in your system.
-
-**Are users unique per environment?**
-
-Yes, they are. Each environment has a separate, isolated set of users. If you need to share users across environments, you must re-identify them in each environment.
-
-**What do I do if I have different types of users?**
-
-If you want to store and notify different types of users within your Knock environment, we recommend prefixing the id with the type. So if you had two distinct user types, `owners` and `customers` you can pass Knock ids like `customer_123` and `owner_456`.
-
-**How can I send a notification to a non-user entity?**
-
-If you need to send a notification to an entity in your system you should have a look at modeling those as [Objects](/send-and-manage-data/objects). Objects can represent **any non-user entity**.
-
-**Why do I see my team members as users in Knock?**
-
-When you add new team members in the Knock dashboard, we automatically add those as "Users" within your Knock development environment so can send the notifications. We do this to help you with testing.
-
-**Can I avoid storing user data in Knock?**
-
-No, all users who are sent a notification are identified in your Knock environment and are persisted. If you have a use case here that you wish to discuss with us please [get in touch](mailto:support@knock.app).
-
-**How can I update a user's attributes?**
-
-If you need to edit or update a user's attributes in Knock, you can either use the [identify a user endpoint](https://docs.knock.app/reference#identify-user) or [inline identification](https://docs.knock.app/managing-recipients/identifying-recipients#inline-identifying-recipients) when triggering a workflow.
+  </Accordion>
+  <Accordion title="Are users unique per environment?">
+    Yes, they are. Each environment has a separate, isolated set of users. If you need to share users across environments, you must re-identify them in each environment.
+  </Accordion>
+  <Accordion title="What do I do if I have different types of users?">
+    If you want to store and notify different types of users within your Knock environment, we recommend prefixing the id with the type. So if you had two distinct user types, `owners` and `customers` you can pass Knock ids like `customer_123` and `owner_456`.
+  </Accordion>
+  <Accordion title="How can I send a notification to a non-user entity?">
+    If you need to send a notification to an entity in your system you should have a look at modeling those as [Objects](/send-and-manage-data/objects). Objects can represent **any non-user entity**.
+  </Accordion>
+  <Accordion title="Why do I see my team members as users in Knock?">
+    When you add new team members in the Knock dashboard, we automatically add them as "Users" within your Knock Development environment so you can send them notifications. We do this to help you with testing.
+  </Accordion>
+  <Accordion title="Can I avoid storing user data in Knock?">
+    No, all users who are sent a notification are identified in your Knock environment and are persisted. If you have a use case here that you wish to discuss with us please [get in touch](mailto:support@knock.app).
+  </Accordion>
+  <Accordion title="How can I update a user's attributes?">
+    If you need to edit or update a user's attributes in Knock, you can either use the [identify a user endpoint](https://docs.knock.app/reference#identify-user) or [inline identification](https://docs.knock.app/managing-recipients/identifying-recipients#inline-identifying-recipients) when triggering a workflow.
+  </Accordion>
+</AccordionGroup>

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -163,9 +163,13 @@ You can learn more about automating workflow management in the [Knock CLI refere
 
 <AccordionGroup>
   <Accordion title="Is there a limit to the number of workflows I can have in Knock?">
-    No, there's no limit to the number of workflows you can have within your Knock environment.
+    No, there's no limit to the number of workflows you can have within your
+    Knock environment.
   </Accordion>
   <Accordion title="Can I create per-tenant/per-customer workflows?">
-    While it's possible to create per-customer workflows using the management API, we recommend avoiding doing this in favor of using [per-tenant overrides](/concepts/tenants#custom-branding) and [preferences](/concepts/preferences) to control individual workflows.
+    While it's possible to create per-customer workflows using the management
+    API, we recommend avoiding doing this in favor of using [per-tenant
+    overrides](/concepts/tenants#custom-branding) and
+    [preferences](/concepts/preferences) to control individual workflows.
   </Accordion>
 </AccordionGroup>

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -161,10 +161,11 @@ You can learn more about automating workflow management in the [Knock CLI refere
 
 ## Frequently asked questions
 
-#### Is there a limit to the number of workflows I can have in Knock?
-
-No, there's no limit to the number of workflows you can have within your Knock environment.
-
-#### Can I create per-tenant/per-customer workflows?
-
-While it's possible to create per-customer workflows using the management API, we recommend avoiding doing this in favor of using per-tenant overrides and preferences to control individual workflows.
+<AccordionGroup>
+  <Accordion title="Is there a limit to the number of workflows I can have in Knock?">
+    No, there's no limit to the number of workflows you can have within your Knock environment.
+  </Accordion>
+  <Accordion title="Can I create per-tenant/per-customer workflows?">
+    While it's possible to create per-customer workflows using the management API, we recommend avoiding doing this in favor of using [per-tenant overrides](/concepts/tenants#custom-branding) and [preferences](/concepts/preferences) to control individual workflows.
+  </Accordion>
+</AccordionGroup>

--- a/content/designing-workflows/batch-function.mdx
+++ b/content/designing-workflows/batch-function.mdx
@@ -232,75 +232,67 @@ If you want to remove an item from a batch (example: a user deletes a comment), 
 
 ## Frequently asked questions
 
-#### How do I set per-environment batch windows?
+<AccordionGroup>
+  <Accordion title="How do I set per-environment batch windows?">
+    Often when you're testing your Knock workflows, you'll want your batch windows to be shorter in non-production environments to aid with testing. To set per-environment batch windows you can:
 
-Often when you're testing your Knock workflows, you'll want your batch windows to be shorter in non-production environments to aid with testing. To set per-environment batch windows you can:
+    - Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `batchWindow`
+    - Set your batch window to "Batch for a dynamic interval"
+    - Specify that your batch window will come from an environment variable
+    - Set the key to be `batchWindow`, which will resolve the batch window from the variable you created
+    - You can now override the variable per-environment to specify a shorter, or longer window as needed
 
-- Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `batchWindow`
-- Set your batch window to "Batch for a dynamic interval"
-- Specify that your batch window will come from an environment variable
-- Set the key to be `batchWindow`, which will resolve the batch window from the variable you created
-- You can now override the variable per-environment to specify a shorter, or longer window as needed
+  </Accordion>
+  <Accordion title="Can I close a batch early?">
+    Right now we don't offer a way to close a batch from a workflow trigger. One workaround is to use a [sliding batch window](/designing-workflows/batch-function#using-a-sliding-batch-window) and then set the max extension window to be a very small duration (i.e. 1 second), meaning that the batch will immediately close when a subsequent trigger occurs.
+  </Accordion>
+  <Accordion title="How can items be removed from a batch?">
+    You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to remove an item that has been accumulated into an active batch. If all items have been removed from the batch when its window closes, any channel steps proceeding will be skipped.
+  </Accordion>
+  <Accordion title="How many items can a batch contain?">
+    A batch can support an unbounded number of items per recipient, although we will only ever return either the first 10 or last 10 items to be rendered in your template. On Enterprise plan, you can configure to include up to 100 via the [render limit setting](/designing-workflows/batch-function#setting-the-batch-render-limit-beyond-10).
+  </Accordion>
+  <Accordion title="How many items can I reference in my templates from a batch?">
+    We will by default expose at most 10 activities to your template rendered in your batch (available under the `activities` variable). The `total_activities` will always include the total amount of bundled
+    activities in the batch. On Enterprise plan, you can configure to include up to 100 via the [render limit setting](/designing-workflows/batch-function#setting-the-batch-render-limit-beyond-10).
+  </Accordion>
+  <Accordion title="How can I change the order of the batch to retrieve the last 10 items instead of the first 10 items?">
+    You can use the "Batch order" setting on the batch step to set if you want the first 10 items (the default) or the last 10 items added to the batch.
+  </Accordion>
+  <Accordion title="Once activities are batched in an activity, how can I access them?">
+    You can use the `activities` property in your template to access the items included in the batch. Each `activity` will include any `data` sent along with the workflow trigger that was batched.
+  </Accordion>
+  <Accordion title="Is batching the same as digesting notifications?">
+    You can think about batching as a per-recipient, per-workflow summary of notifications that should be sent together. Many of our Knock customers use batching as a form of digest to reduce the number of notifications that their users receive. If you have more advance digesting needs that aren't covered by our current batching implementation, [please get in touch](mailto:support@knock.app).
+  </Accordion>
+  <Accordion title="Do you support per-recipient batch windows and timezones?">
+    We're currently working on this feature! If you'd like early access, please [get in touch with us](mailto:support@knock.app?subject=Per%20recipient%20batch%20windows).
+  </Accordion>
+  <Accordion title="How can I query for messages or feed items that were generated from activities with given workflow trigger call data?">
+    When messages are generated from a batch step, the workflow trigger call data for the first (or last) 10 activities of the batch will be combined into one single entity at batch closing time.
+    You will be able to filter messages or feed items using the `trigger_data` parameter of our API, which will filter the results to only the items whose workflow trigger call's data
+    contain the given `trigger_data` value.
 
-#### Can I close a batch early?
+    This means that using the `trigger_data` parameter will only return items for which the combined workflow trigger call data of the
+    first (or last) 10 activities contain the value used on the `trigger_data` parameter. If you are using a value for the `trigger_data` parameter which is not included in the
+    first (or last) 10 activities of an item, then the item will be returned.
 
-Right now we don't offer a way to close a batch from a workflow trigger. One workaround is to use a [sliding batch window](/designing-workflows/batch-function#using-a-sliding-batch-window) and then set the max extension window to be a very small duration (i.e. 1 second), meaning that the batch will immediately close when a subsequent trigger occurs.
+    To understand how the combined trigger call data will look like, let's take a look at the following example:
 
-#### How can items be removed from a batch?
+    Let's consider the case where a message was generated after a batch step with 2 batched activities closes.
+    The first activity was generated by workflow trigger call with the following trigger data: `{page: "A"}`.
+    The second activity was generated by a workflow trigger with the following trigger data: `{page: "B"}`.
+    When the batch closes, the trigger data of both activities will be merged into a single object that will contain the `{page: "B"}`.
+    If we try to filter messages or feed items using the `trigger_data` filter with value`{page: "A"}`, the message in the example won't be returned.
 
-You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to remove an item that has been accumulated into an active batch. If all items have been removed from the batch when its window closes, any channel steps proceeding will be skipped.
-
-#### How many items can a batch contain?
-
-A batch can support an unbounded number of items per recipient, although we will only ever return either the first 10 or last 10 items to be rendered in your template. On Enterprise plan, you can configure to include up to 100 via the [render limit setting](/designing-workflows/batch-function#setting-the-batch-render-limit-beyond-10).
-
-#### How many items can I reference in my templates from a batch?
-
-We will by default expose at most 10 activities to your template rendered in your batch (available under the `activities` variable). The `total_activities` will always include the total amount of bundled
-activities in the batch. On Enterprise plan, you can configure to include up to 100 via the [render limit setting](/designing-workflows/batch-function#setting-the-batch-render-limit-beyond-10).
-
-#### How can I change the order of the batch to retrieve the last 10 items instead of the first 10 items?
-
-You can use the "Batch order" setting on the batch step to set if you want the first 10 items (the default) or the last 10 items added to the batch.
-
-#### Once activities are batched in an activity, how can I access them?
-
-You can use the `activities` property in your template to access the items included in the batch. Each `activity` will include any `data` sent along with the workflow trigger that was batched.
-
-#### Is batching the same as digesting notifications?
-
-You can think about batching as a per-recipient, per-workflow summary of notifications that should be sent together. Many of our Knock customers use batching as a form of digest to reduce the number of notifications that their users receive. If you have more advance digesting needs that aren't covered by our current batching implementation, [please get in touch](mailto:support@knock.app).
-
-#### Do you support per-recipient batch windows and timezones?
-
-We're currently working on this feature! If you'd like early access, please [get in touch with us](mailto:support@knock.app?subject=Per%20recipient%20batch%20windows).
-
-#### How can I query for messages or feed items that were generated from activities with given workflow trigger call data?
-
-When messages are generated from a batch step, the workflow trigger call data for the first (or last) 10 activities of the batch will be combined into one single entity at batch closing time.
-You will be able to filter messages or feed items using the `trigger_data` parameter of our API, which will filter the results to only the items whose workflow trigger call's data
-contain the given `trigger_data` value.
-
-This means that using the `trigger_data` parameter will only return items for which the combined workflow trigger call data of the
-first (or last) 10 activities contain the value used on the `trigger_data` parameter. If you are using a value for the `trigger_data` parameter which is not included in the
-first (or last) 10 activities of an item, then the item will be returned.
-
-To understand how the combined trigger call data will look like, let's take a look at the following example:
-
-Let's consider the case where a message was generated after a batch step with 2 batched activities closes.
-The first activity was generated by workflow trigger call with the following trigger data: `{page: "A"}`.
-The second activity was generated by a workflow trigger with the following trigger data: `{page: "B"}`.
-When the batch closes, the trigger data of both activities will be merged into a single object that will contain the `{page: "B"}`.
-If we try to filter messages or feed items using the `trigger_data` filter with value`{page: "A"}`, the message in the example won't be returned.
-
-#### Can I dynamically extend the batch window?
-
-Yes, if you use the [sliding batch window](#using-a-sliding-batch-window) option then the batch window can always be extended past its original setting. When combined with a dynamic batch window from a variable, this allows you to control exactly when a specific batch window should close.
-
-#### Can I close a batch window by the number of items in the batch?
-
-Yes, you can optionally set the [maximum activity limit](#setting-the-maximum-activity-limit) to conditionally close the batch window based on the number of items contained in the batch.
-
-#### Can I have a batch with a leading debounce?
-
-If you're looking to flush the first item in the batch, and then accumulate the subsequent items over a window of time [please get in touch](mailto:support@knock.app) with the team as we're actively working on this feature.
+  </Accordion>
+  <Accordion title="Can I dynamically extend the batch window?">
+    Yes, if you use the [sliding batch window](#using-a-sliding-batch-window) option then the batch window can always be extended past its original setting. When combined with a dynamic batch window from a variable, this allows you to control exactly when a specific batch window should close.
+  </Accordion>
+  <Accordion title="Can I close a batch window by the number of items in the batch?">
+    Yes, you can optionally set the [maximum activity limit](#setting-the-maximum-activity-limit) to conditionally close the batch window based on the number of items contained in the batch.
+  </Accordion>
+  <Accordion title="Can I have a batch with a leading debounce?">
+    If you're looking to flush the first item in the batch, and then accumulate the subsequent items over a window of time [please get in touch](mailto:support@knock.app) with the team as we're actively working on this feature.
+  </Accordion>
+</AccordionGroup>

--- a/content/designing-workflows/branch-function.mdx
+++ b/content/designing-workflows/branch-function.mdx
@@ -59,18 +59,20 @@ You can debug branch execution in the [workflow debugger](/send-notifications/de
 
 ## Frequently asked questions
 
-#### Do branches work with delays, throttles, and batch functions?
-
-Yes, absolutely. You can nest delays, throttles, batches, and other branch steps inside of branches as well.
-
-#### What's the maximum depth or number of branch steps I can have in a workflow?
-
-The maximum depth for branches is set at 5. If you have needs that go beyond this, please reach out to discuss.
-
-#### What's the maximum number of branches I can have in a branch function?
-
-The maximum number is currently 10 branches, including the default, per-branch function.
-
-#### Can I have conditions on the execution of the branch step itself?
-
-No, you cannot have step conditions on the branch step.
+<AccordionGroup>
+  <Accordion title="Do branches work with delays, throttles, and batch functions?">
+    Yes, absolutely. You can nest delays, throttles, batches, and other branch
+    steps inside of branches as well.
+  </Accordion>
+  <Accordion title="What's the maximum depth or number of branch steps I can have in a workflow?">
+    The maximum depth for branches is set at 5. If you have needs that go beyond
+    this, please reach out to discuss.
+  </Accordion>
+  <Accordion title="What's the maximum number of branches I can have in a branch function?">
+    The maximum number is currently 10 branches, including the default,
+    per-branch function.
+  </Accordion>
+  <Accordion title="Can I have conditions on the execution of the branch step itself?">
+    No, you cannot have step conditions on the branch step.
+  </Accordion>
+</AccordionGroup>

--- a/content/designing-workflows/delay-function.mdx
+++ b/content/designing-workflows/delay-function.mdx
@@ -44,28 +44,27 @@ If the user completes the action you were going to remind them about, cancel the
 
 ## Frequently asked questions
 
-#### How do I set per-environment delay periods?
+<AccordionGroup>
+  <Accordion title="How do I set per-environment delay periods?">
+    Often when you're testing your Knock workflows, you'll want your delay durations to be shorter in non-production environments to aid with testing. To set per-environment delay duration you can:
 
-Often when you're testing your Knock workflows, you'll want your delay durations to be shorter in non-production environments to aid with testing. To set per-environment delay duration you can:
+    - Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `delayDuration`
+    - Set your delay duration to "Wait until a dynamic interval"
+    - Specify that your delay duration will come from an environment variable
+    - Set the key to `delayDuration`, which will resolve the delay duration from the variable you created
+    - You can now override the variable per environment to specify a shorter, or longer window as needed
 
-- Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `delayDuration`
-- Set your delay duration to "Wait until a dynamic interval"
-- Specify that your delay duration will come from an environment variable
-- Set the key to `delayDuration`, which will resolve the delay duration from the variable you created
-- You can now override the variable per environment to specify a shorter, or longer window as needed
-
-#### How can I cancel an open delay
-
-You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to cancel a delayed workflow. You must use a unique cancelation key to cancel a previously triggered workflow run.
-
-#### How long can a workflow be delayed?
-
-A workflow can be delayed for a maximum of 365 days (1 year).
-
-#### What are the guarantees around delayed workflows?
-
-Knock will ensure that your delayed workflow run will execute within ~1 - 5s of the delayed time.
-
-#### How can I see delayed workflow runs?
-
-We currently don't have a way to view all delayed workflow runs with pending messages. If this is a feature you need, please reach out as we'd love to hear your use case.
+  </Accordion>
+  <Accordion title="How can I cancel an open delay?">
+    You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to cancel a delayed workflow. You must use a unique cancelation key to cancel a previously triggered workflow run.
+  </Accordion>
+  <Accordion title="How long can a workflow be delayed?">
+    A workflow can be delayed for a maximum of 365 days (1 year).
+  </Accordion>
+  <Accordion title="What are the guarantees around delayed workflows?">
+    Knock will ensure that your delayed workflow run will execute within ~1 - 5s of the delayed time.
+  </Accordion>
+  <Accordion title="How can I see delayed workflow runs?">
+    We currently don't have a way to view all delayed workflow runs with pending messages. If this is a feature you need, please reach out as we'd love to hear your use case.
+  </Accordion>
+</AccordionGroup>

--- a/content/designing-workflows/throttle-function.mdx
+++ b/content/designing-workflows/throttle-function.mdx
@@ -75,26 +75,32 @@ Custom throttle keys must be shorter than 64 characters long after being JSON an
 
 ## Frequently asked questions
 
-#### Can I use a dynamic throttle window?
-
-Yes! A dynamic throttle window can come from a variety of dynamic sources like the recipient, the environment, or within the data payload.
-
-#### What happens when a throttle is hit?
-
-When a throttle is hit, the workflow will stop execution. You will be able to see this in your workflow run logs.
-
-#### Can an active throttle be canceled?
-
-We haven’t added this ability, but if this is something you’re looking to do, please reach out to us to discuss your use case. We’d love to hear more.
-
-#### What’s the maximum time a throttle can be open for?
-
-A throttle is allowed to be opened for a maximum of 31 days. If you have a use case for a longer throttle window, please [get in touch](mailto:support@knock.app).
-
-#### Can I have multiple throttle steps per workflow?
-
-Absolutely, each throttle step is executed independently in a workflow, so you can have as many as you need.
-
-#### Can I throttle across workflows?
-
-Currently, you cannot throttle across Knock workflows. In the future, we will be exploring adding the ability to rate-limit the number of notifications a recipient can receive in a given window of time, which will work across workflows.
+<AccordionGroup>
+  <Accordion title="Can I use a dynamic throttle window?">
+    Yes! A dynamic throttle window can come from a variety of dynamic sources
+    like the recipient, the environment, or within the data payload.
+  </Accordion>
+  <Accordion title="What happens when a throttle is hit?">
+    When a throttle is hit, the workflow will stop execution. You will be able
+    to see this in your workflow run logs.
+  </Accordion>
+  <Accordion title="Can an active throttle be canceled?">
+    We haven’t added this ability, but if this is something you’re looking to
+    do, please reach out to us to discuss your use case. We’d love to hear more.
+  </Accordion>
+  <Accordion title="What’s the maximum time a throttle can be open for?">
+    A throttle is allowed to be opened for a maximum of 31 days. If you have a
+    use case for a longer throttle window, please [get in
+    touch](mailto:support@knock.app).
+  </Accordion>
+  <Accordion title="Can I have multiple throttle steps per workflow?">
+    Absolutely, each throttle step is executed independently in a workflow, so
+    you can have as many as you need.
+  </Accordion>
+  <Accordion title="Can I throttle across workflows?">
+    Currently, you cannot throttle across Knock workflows. In the future, we
+    will be exploring adding the ability to rate-limit the number of
+    notifications a recipient can receive in a given window of time, which will
+    work across workflows.
+  </Accordion>
+</AccordionGroup>

--- a/content/developer-tools/api-keys.mdx
+++ b/content/developer-tools/api-keys.mdx
@@ -20,10 +20,14 @@ Each Knock environment will be generated with two API keys: a secret key and a p
 
 ## Frequently asked questions
 
-**Can I revoke an API key once generated?**
-
-If you need to revoke and regenerate a set of API keys, please [get in touch with our support team](mailto:support@knock.app).
-
-**Can I further scope API key access?**
-
-Currently, it's not possible to reduce the scope of an API key and limit it to a particular set of resources. Please contact our [support team if you need this feature](mailto:support@knock.app).
+<AccordionGroup>
+  <Accordion title="Can I revoke an API key once generated?">
+    If you need to revoke and regenerate a set of API keys, please [get in touch
+    with our support team](mailto:support@knock.app).
+  </Accordion>
+  <Accordion title="Can I further scope API key access?">
+    Currently, it's not possible to reduce the scope of an API key and limit it
+    to a particular set of resources. Please contact our [support team if you
+    need this feature](mailto:support@knock.app).
+  </Accordion>
+</AccordionGroup>

--- a/content/developer-tools/api-logs.mdx
+++ b/content/developer-tools/api-logs.mdx
@@ -16,6 +16,14 @@ You can filter API logs in your Knock account using the following filters:
 
 ## Frequently asked questions
 
-**How many day's worth of API logs can I view?**
+<AccordionGroup>
+  <Accordion
+    title="How many days' worth of API logs can I view?"
+    defaultOpen={true}
+  >
+    Knock will only keep 30 days of API logs available to be queried and
+    displayed at any time.
+  </Accordion>
+</AccordionGroup>
 
-Knock will only keep 30-days of API logs available to be queried and displayed at any time.
+---

--- a/content/developer-tools/service-tokens.mdx
+++ b/content/developer-tools/service-tokens.mdx
@@ -45,10 +45,17 @@ Service tokens can be revoked under the three-dot menu and by clicking on "Delet
 
 ## Frequently asked questions
 
-**Can I use a Knock service token against the Knock API?**
-
-No, a service token can only be used against the Knock Management API and not the Knock API.
-
-**How can I know which changes were made by a specific service token?**
-
-Changes made via the Management API will appear as audit logs, similar to changes made manually in the dashboard, but attributing the service token used to make the change as the author. In addition, internally we audit requests and tie them back to a corresponding service token. If you need further help understanding which request originated from a service token, please [contact our support team](mailto:support@knock.app).
+<AccordionGroup>
+  <Accordion title="Can I use a Knock service token against the Knock API?">
+    No, a service token can only be used against the Knock Management API and
+    not the Knock API.
+  </Accordion>
+  <Accordion title="How can I know which changes were made by a specific service token?">
+    Changes made via the Management API will appear as audit logs, similar to
+    changes made manually in the dashboard, but attributing the service token
+    used to make the change as the author. In addition, internally we audit
+    requests and tie them back to a corresponding service token. If you need
+    further help understanding which request originated from a service token,
+    please [contact our support team](mailto:support@knock.app).
+  </Accordion>
+</AccordionGroup>

--- a/content/guides/customer-webhooks.mdx
+++ b/content/guides/customer-webhooks.mdx
@@ -111,16 +111,21 @@ You might want to provide a way to notify your customers that their webhooks are
 
 ## Frequently asked questions
 
-**How do I power different types of webhook events, should those be different notification workflows or a single workflow?**
-The answer here really depends on how different the notifications around each event type need to be. You should consider structuring each event type as a different workflow if the types of notifications sent in each event type differ a lot, or if the templates between event types are sufficiently different.
+<AccordionGroup>
+  <Accordion title="Should different types of webhook events be sent via separate notification workflows or a single workflow?">
+    The answer here really depends on how different the notifications around each event type need to be. You should consider structuring each event type as a separate workflow if the types of notifications sent in each event type differ a lot, or if the templates between event types are sufficiently different.
+  </Accordion>
+  <Accordion title="How do I conditionally send only to webhook objects?">
+    If you need to limit the execution of the workflow steps you can add a trigger condition onto your webhook channel steps that will only send to:
 
-**How do I conditionally send to only to webhook objects?**
-If you need to limit the execution of the workflow steps you can add a trigger condition onto your webhook channel steps that will only send to:
+    - `recipient.__typename` is equal to `Object`
+    - `recipient.collection` is equal to `project_webhooks`
 
-- `recipient.__typename` is equal to `Object`
-- `recipient.collection` is equal to `project_webhooks`
+  </Accordion>
+  <Accordion title="How do I conditionally allow certain event types on my webhooks?">
+    You can store an `event_types` property on your webhook object and use a [step condition](/designing-workflows/step-conditions) to express whether or not the step should be executed (as an allow list).
 
-**How do I conditionally allow certain event types on my webhooks?**
-You can store an `event_types` property on your webhook object and use a trigger condition to express whether or not the step should be executed (as an allow list).
+    - `recipient.event_types` contains `some:event`
 
-- `recipient.event_types` contains `some:event`
+  </Accordion>
+</AccordionGroup>

--- a/content/in-app-ui/overview.mdx
+++ b/content/in-app-ui/overview.mdx
@@ -47,10 +47,17 @@ You'll need to follow our checklist on [going to production](/getting-started/go
 
 ## Frequently asked questions
 
-#### Can I have multiple in-app channels?
-
-Yes, you can. By default, Knock will create a single in-app channel for you, but you can easily add additional in-app channels should you need to support multiple feeds or different types of in-app message experiences.
-
-#### Can I 'pin' or 'favorite' messages in the in-app feed
-
-Currently you can't pin messages. The feed will only return messages in reverse chronological order with no way to change that order. You can, however, create multiple feed instances and [feed filtering](/in-app-ui/api-overview#filtering-in-app-notifications) to build a pinned notifications UI.
+<AccordionGroup>
+  <Accordion title="Can I have multiple in-app channels?">
+    Yes, you can. By default, Knock will create a single in-app channel for you,
+    but you can easily add additional in-app channels should you need to support
+    multiple feeds or different types of in-app message experiences.
+  </Accordion>
+  <Accordion title='Can I "pin" or "favorite" messages in the in-app feed?'>
+    Currently you can't pin messages. The feed will only return messages in
+    reverse chronological order with no way to change that order. You can,
+    however, create multiple feed instances and use [feed
+    filtering](/in-app-ui/api-overview#filtering-in-app-notifications) to build
+    a pinned notifications UI.
+  </Accordion>
+</AccordionGroup>

--- a/content/integrations/sources/http.mdx
+++ b/content/integrations/sources/http.mdx
@@ -68,14 +68,17 @@ You can see a log of all of the events received per source under "Developers > S
 
 ## Frequently asked questions
 
-**Can I send identify events through to the HTTP source?**
-
-No, the HTTP source only accepts events not user identifies. Please use the [user identify API](/send-and-manage-data/users) instead.
-
-**What's the rate limit Knock supports on the events endpoint?**
-
-There's no rate limit for the event ingestion endpoint, but we ask if that you're going to be sending more than 1,000 events per second that you reach out to us first so that we can provision additional capacity.
-
-**Do you support ingesting batches of events?**
-
-Currently, no the HTTP endpoint only accepts single events at a time.
+<AccordionGroup>
+  <Accordion title="Can I send identify events through to the HTTP source?">
+    No, the HTTP source only accepts events and not user identifies. Please use
+    the [user identify API](/send-and-manage-data/users) instead.
+  </Accordion>
+  <Accordion title="What's the rate limit Knock supports on the events endpoint?">
+    There's no rate limit for the event ingestion endpoint, but we ask that if
+    you're going to be sending more than 1,000 events per second you reach out
+    to us first so that we can provision additional capacity.
+  </Accordion>
+  <Accordion title="Do you support ingesting batches of events?">
+    Currently, no; the HTTP endpoint only accepts single events at a time.
+  </Accordion>
+</AccordionGroup>

--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -102,12 +102,14 @@ To test that the payload sent has not been compromised, you can recreate the sig
 
 ## Frequently asked questions
 
-**Do webhook steps always execute during a workflow run?**
+<AccordionGroup>
+  <Accordion title="Do webhook steps always execute during a workflow run?">
+    Yes. When a webhook channel exists in a workflow, it will send for every workflow run. You do not need to store any channel data on the recipient for the webhook to be triggered.
 
-Yes. When a webhook channel exists in a workflow, it will send for every workflow run. You do not need to store any channel data on the recipient for the webhook to be triggered.
+    If you want webhooks to be recipient-specific, you can use the `recipient.*` namespace to use [recipient](/send-and-manage-data/recipients) variables in the URL of your webhook. If a recipient doesn't have the requisite variables configured for the webhook request to build correctly, the webhook will not be sent at runtime.
 
-If you want webhooks to be recipient-specific, you can use the `recipient.*` namespace to use [recipient](/send-and-manage-data/recipients) variables in the url of your webhook. If a recipient doesn't have the requisitive variables configured for the webhook request to build correctly, the webhook will not be sent at runtime.
-
-**Can I use the Knock webhook channel to power customer-facing webhooks in my own product?**
-
-Yes! We cover this in more detail in [our guide on building customer configurable webhooks](/guides/customer-webhooks).
+  </Accordion>
+  <Accordion title="Can I use the Knock webhook channel to power customer-facing webhooks in my own product?">
+    Yes! We cover this in more detail in our guide on [building customer configurable webhooks](/guides/customer-webhooks).
+  </Accordion>
+</AccordionGroup>

--- a/content/manage-your-account/audit-logs.mdx
+++ b/content/manage-your-account/audit-logs.mdx
@@ -30,8 +30,14 @@ Once there, you can filter the audit log by the **Actor** who performed the acti
 
 ## Frequently asked questions
 
-**Why do I see `migration-bot@knock.app`perform changes on my account?**<br />
-When events occur that do not originate from a user action, like a side effect as the result of a merge, we attribute these events to a Knock created "Migration Bot".
-
-**Can I export my account audit logs?**<br />
-Please contact the [Knock support team](mailto:support@knock.app) if you need to export the data inside your audit logs. We'd be happy to assist.
+<AccordionGroup>
+  <Accordion title="Why do I see migration-bot@knock.app perform changes on my account?">
+    When events occur that do not originate from a user action (like a side
+    effect as the result of a merge), we attribute these events to a
+    Knock-created "Migration Bot".
+  </Accordion>
+  <Accordion title="Can I export my account audit logs?">
+    Please contact the [Knock support team](mailto:support@knock.app) if you
+    need to export the data inside your audit logs. We'd be happy to assist.
+  </Accordion>
+</AccordionGroup>

--- a/content/managing-recipients/deleting-users.mdx
+++ b/content/managing-recipients/deleting-users.mdx
@@ -35,22 +35,23 @@ When a user is deleted in Knock, we will **hard delete**:
 
 ## Frequently asked questions
 
-#### Can I delete users from the Knock dashboard?
-
-No, you must use the API to delete users.
-
-#### Is Knock GDPR compliant?
-
-Yes, Knock is GDPR compliant.
-
-#### Can I use the user deletion API to programmatically power GDPR right-to-be-forgotten requests?
-
-Absolutely. You can use our single-user deletion endpoint, or batch up deletion requests per-day using our bulk delete endpoint.
-
-#### I need to suppress a user from ever receiving notifications again from our platform, is that possible?
-
-Please get in touch with us if you have this requirement.
-
-#### If I delete a user and then re-use the identifier for that deleted user, what happens?
-
-You can re-add the same user using the previous user's identifier. The new user will not inherit any of the past user's data, given that will have been deleted.
+<AccordionGroup>
+  <Accordion title="Can I delete users from the Knock dashboard?">
+    No, you must use the API to delete users.
+  </Accordion>
+  <Accordion title="Is Knock GDPR compliant?">
+    Yes, Knock is GDPR compliant.
+  </Accordion>
+  <Accordion title="Can I use the user deletion API to programmatically power GDPR right-to-be-forgotten requests?">
+    Absolutely. You can use our single-user deletion endpoint, or batch up
+    deletion requests per-day using our bulk delete endpoint.
+  </Accordion>
+  <Accordion title="I need to suppress a user from ever receiving notifications again from our platform, is that possible?">
+    Please get in touch with us if you have this requirement.
+  </Accordion>
+  <Accordion title="If I delete a user and then re-use the identifier for that deleted user, what happens?">
+    You can re-add the same user using the previous user's identifier. The new
+    user will not inherit any of the past user's data, given that will have been
+    deleted.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

This PR places all of our "Frequently asked questions" into accordion groups. It also makes fixes for typos and outdated information ("trigger conditions," anyone?) that I found along the way.

Apologies for the massive PR, it got bigger than I expected and I was already too deep 😅 

### Screenshots

**Note:** For FAQs that had only a single question, I opted to default the accordion to "open".

<img width="600" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/e98faa89-fd8e-4a79-9075-523e3306b61d">

<img width="600" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/640b836a-bbf9-4475-98e8-a2823e2ef553">
