### PR TITLE
chore: add support to open card links in new tab

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,7 +6,7 @@ type Props = {
   title: string;
   linkUrl: string;
   footer?: ReactElement;
-  newTab?: boolean;
+  isExternal?: boolean;
 };
 
 const CardGroup = ({ children, cols = 2 }) => (
@@ -26,11 +26,11 @@ const Card: React.FC<Props> = ({
   children,
   footer,
   linkUrl,
-  newTab = false,
+  isExternal = false,
 }) => (
   <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors p-3">
     <a
-      target={newTab ? "_blank" : undefined}
+      target={isExternal ? "_blank" : undefined}
       href={linkUrl}
       title={title}
       className="!no-underline !text-inherit"

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -20,9 +20,21 @@ const CardGroup = ({ children, cols = 2 }) => (
   </div>
 );
 
-const Card: React.FC<Props> = ({ emoji, title, children, footer, linkUrl, newTab=false }) => (
+const Card: React.FC<Props> = ({
+  emoji,
+  title,
+  children,
+  footer,
+  linkUrl,
+  newTab = false,
+}) => (
   <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors p-3">
-    <a target={newTab ? "_blank" : undefined} href={linkUrl} title={title} className="!no-underline !text-inherit">
+    <a
+      target={newTab ? "_blank" : undefined}
+      href={linkUrl}
+      title={title}
+      className="!no-underline !text-inherit"
+    >
       <>
         {emoji && <div className="mb-1">{emoji}</div>}
 

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,6 +6,7 @@ type Props = {
   title: string;
   linkUrl: string;
   footer?: ReactElement;
+  newTab?: boolean;
 };
 
 const CardGroup = ({ children, cols = 2 }) => (
@@ -19,9 +20,9 @@ const CardGroup = ({ children, cols = 2 }) => (
   </div>
 );
 
-const Card: React.FC<Props> = ({ emoji, title, children, footer, linkUrl }) => (
+const Card: React.FC<Props> = ({ emoji, title, children, footer, linkUrl, newTab=false }) => (
   <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors p-3">
-    <a href={linkUrl} title={title} className="!no-underline !text-inherit">
+    <a target={newTab ? "_blank" : undefined} href={linkUrl} title={title} className="!no-underline !text-inherit">
       <>
         {emoji && <div className="mb-1">{emoji}</div>}
 

--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -5,13 +5,14 @@ type Props = {
   title: string;
   linkUrl: string;
   languages: string[];
+  newTab: boolean;
 };
 
 const SdkCardGroup = ({ children }) => (
   <div className="grid grid-cols-3 gap-2">{children}</div>
 );
 
-const SdkCard: React.FC<Props> = ({ title, linkUrl, languages }) => (
+const SdkCard: React.FC<Props> = ({ title, linkUrl, languages, newTab }) => (
   <Card
     title={title}
     linkUrl={linkUrl}
@@ -23,6 +24,7 @@ const SdkCard: React.FC<Props> = ({ title, linkUrl, languages }) => (
         </span>
       </div>
     }
+    newTab={newTab}
   />
 );
 

--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -5,14 +5,19 @@ type Props = {
   title: string;
   linkUrl: string;
   languages: string[];
-  newTab: boolean;
+  isExternal?: boolean;
 };
 
 const SdkCardGroup = ({ children }) => (
   <div className="grid grid-cols-3 gap-2">{children}</div>
 );
 
-const SdkCard: React.FC<Props> = ({ title, linkUrl, languages, newTab }) => (
+const SdkCard: React.FC<Props> = ({
+  title,
+  linkUrl,
+  languages,
+  isExternal,
+}) => (
   <Card
     title={title}
     linkUrl={linkUrl}
@@ -24,7 +29,7 @@ const SdkCard: React.FC<Props> = ({ title, linkUrl, languages, newTab }) => (
         </span>
       </div>
     }
-    newTab={newTab}
+    isExternal={isExternal}
   />
 );
 


### PR DESCRIPTION
### Description

Adds the option to open a card component's link in a new tab.

https://www.loom.com/share/cc6ab01d1fd14c11ae90e32ba30c285e?sid=f40e8424-d220-44d1-99c2-c5fa21f831bf
