### PR TITLE
chore: add faq about inline identification for generic http source

### DIFF
--- a/content/integrations/sources/http.mdx
+++ b/content/integrations/sources/http.mdx
@@ -73,6 +73,14 @@ You can see a log of all of the events received per source under "Developers > S
     No, the HTTP source only accepts events and not user identifies. Please use
     the [user identify API](/send-and-manage-data/users) instead.
   </Accordion>
+  <Accordion title="Can I identify recipients inline via track events that I send to the HTTP source?">
+    Yes. You can use inline identification with the source events that you send
+    to Knock according to the instructions
+    [here](/integrations/sources/overview#inline-identify-users-in-a-source-event).
+    You'll need to ensure that the schema mapping for your event maps the
+    **Recipients** of your workflow to the same field where you provide the
+    recipient object.
+  </Accordion>
   <Accordion title="What's the rate limit Knock supports on the events endpoint?">
     There's no rate limit for the event ingestion endpoint, but we ask that if
     you're going to be sending more than 1,000 events per second you reach out


### PR DESCRIPTION
### Description

This PR adds an FAQ callout to the generic HTTP source page to clarify that you can use inline identification with that source (and how to do it).