### PR TITLE
fix: prevent `Endpoints` from overflowing container

### DIFF
--- a/components/Endpoints.tsx
+++ b/components/Endpoints.tsx
@@ -8,7 +8,9 @@ const Endpoints = ({ children, title = "Endpoints" }) => (
         {title}
       </span>
     </div>
-    <div className="m-0 py-2 px-4 dark:bg-gray-900 overflow-x-auto">{children}</div>
+    <div className="m-0 py-2 px-4 dark:bg-gray-900 overflow-x-auto">
+      {children}
+    </div>
   </div>
 );
 

--- a/components/Endpoints.tsx
+++ b/components/Endpoints.tsx
@@ -3,12 +3,12 @@ import Link from "next/link";
 
 const Endpoints = ({ children, title = "Endpoints" }) => (
   <div className="endpoints text-base lg:text-sm border dark:border-gray-800 rounded">
-    <div className="bg-gray-100 dark:bg-[#2E2F34] border-b dark:border-b-gray-800 p-2 flex">
+    <div className="bg-gray-100 dark:bg-[#2E2F34] border-b dark:border-b-gray-800 p-2 flex w-full">
       <span className="mt-0 text-xs font-medium dark:text-gray-300">
         {title}
       </span>
     </div>
-    <div className="m-0 py-2 px-4 dark:bg-gray-900">{children}</div>
+    <div className="m-0 py-2 px-4 dark:bg-gray-900 overflow-x-auto">{children}</div>
   </div>
 );
 
@@ -30,7 +30,7 @@ const EndpointText = ({ method, path }) => (
     >
       {method}
     </span>
-    <span className="font-mono text-xs text-gray-700 dark:text-gray-200">
+    <span className="font-mono mr-4 text-xs text-gray-700 dark:text-gray-200">
       {path}
     </span>
   </>


### PR DESCRIPTION
### Description

This PR fixes a UI bug in the `Endpoints` component which was allowing endpoints that exceeded a certain character length to overflow their container. The update adds a horizontal scroll bar for endpoints that are too long (mimicking the code block components) and a bit of margin on the endpoints themselves so the scrollable section has equal padding on either side.

See https://docs-git-mk-endpoints-component-knocklabs.vercel.app/reference#channel-data for an example

### Screenshots

<img width="550" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/8d045748-bad3-43a1-b6f6-b7e225988dcb">

<img width="450" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/794ff275-d6bb-421e-a9dd-39c73a61d703">

<img width="440" alt="image" src="https://github.com/knocklabs/docs/assets/70362985/5111be7d-60d4-4401-aea8-d67f0c9fd87e">
