### PR TITLE
chore: sdk card improvements

### DIFF
--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -1,9 +1,62 @@
 import { IoCubeOutline } from "react-icons/io5";
+import { RiJavascriptFill } from "react-icons/ri";
+import {
+  FaNodeJs,
+  FaPython,
+  FaJava,
+  FaPhp,
+  FaReact,
+  FaSwift,
+  FaAngular,
+} from "react-icons/fa";
+import { DiRuby, DiDotnet } from "react-icons/di";
+import { FaGolang } from "react-icons/fa6";
+import { SiElixir, SiFlutter } from "react-icons/si";
+import { TbBrandKotlin, TbBrandReactNative } from "react-icons/tb";
+
 import { Card } from "./Card";
+
+export type SupportedIcon =
+  | "default"
+  | "node"
+  | "python"
+  | "ruby"
+  | "go"
+  | "java"
+  | "dotnet"
+  | "elixir"
+  | "php"
+  | "javascript"
+  | "react"
+  | "swift"
+  | "kotlin"
+  | "flutter"
+  | "reactnative"
+  | "angular";
+
+const icons = {
+  default: <IoCubeOutline />,
+  node: <FaNodeJs />,
+  python: <FaPython />,
+  ruby: <DiRuby />,
+  go: <FaGolang />,
+  java: <FaJava />,
+  dotnet: <DiDotnet />,
+  elixir: <SiElixir />,
+  php: <FaPhp />,
+  javascript: <RiJavascriptFill />,
+  react: <FaReact />,
+  swift: <FaSwift />,
+  kotlin: <TbBrandKotlin />,
+  flutter: <SiFlutter />,
+  reactnative: <TbBrandReactNative />,
+  angular: <FaAngular />,
+};
 
 type Props = {
   title: string;
   linkUrl: string;
+  icon: SupportedIcon;
   languages: string[];
   isExternal?: boolean;
 };
@@ -15,6 +68,7 @@ const SdkCardGroup = ({ children }) => (
 const SdkCard: React.FC<Props> = ({
   title,
   linkUrl,
+  icon = "default",
   languages,
   isExternal,
 }) => (
@@ -23,7 +77,7 @@ const SdkCard: React.FC<Props> = ({
     linkUrl={linkUrl}
     footer={
       <div className="flex items-center text-gray-500 dark:text-gray-200">
-        <IoCubeOutline />
+        {icons[icon]}
         <span className="ml-2 text-[14px] font-medium">
           {languages.map((lang) => lang).join(" · ")}
         </span>

--- a/content/getting-started/example-app.mdx
+++ b/content/getting-started/example-app.mdx
@@ -13,17 +13,23 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
   <SdkCard
     title="In-app feed & toasts"
     linkUrl="https://github.com/knocklabs/in-app-notifications-example-nextjs"
+    icon="react"
     languages={["React", "Next.js"]}
+    isExternal={true}
   />
   <SdkCard
     title="In-app feed"
     linkUrl="https://github.com/knocklabs/angular-in-app-feed-example"
+    icon="angular"
     languages={["Angular"]}
+    isExternal={true}
   />
   <SdkCard
     title="Notion-style feed"
     linkUrl="https://github.com/knocklabs/notion-feed-example"
+    icon="react"
     languages={["React", "Next.js"]}
+    isExternal={true}
   />
 </SdkCardGroup>
 
@@ -33,7 +39,9 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
   <SdkCard
     title="SlackKit example"
     linkUrl="https://github.com/knocklabs/slack-kit-example"
+    icon="react"
     languages={["React", "Next.js"]}
+    isExternal={true}
   />
 </SdkCardGroup>
 
@@ -43,11 +51,15 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
   <SdkCard
     title="iOS example"
     linkUrl="https://github.com/knocklabs/ios-example-app"
+    icon="swift"
     languages={["Swift"]}
+    isExternal={true}
   />
   <SdkCard
-    title="Android"
-    linkUrl="https://github.com/knocklabs/knock-android"
+    title="Android example"
+    linkUrl="https://github.com/knocklabs/knock-android/tree/main/knock-example-app"
+    icon="kotlin"
     languages={["Kotlin"]}
+    isExternal={true}
   />
 </SdkCardGroup>

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -27,7 +27,7 @@ Workflows are a foundational concept in Knock. They allow you to easily model co
   width={1356}
   height={1452}
   className="rounded-md shadow-sm"
-></Image>
+/>
 
 Your application can trigger workflows using our REST API, any one of our [available SDKs](/sdks/overview), or by integrating a CDP like Segment as an event source. You can use the dropdown menu on the code sample below to look at a sample in your language of choice:
 
@@ -168,7 +168,7 @@ In Knock, each workflow run is executed on behalf of a recipient, and each recip
   width={1356}
   height={1452}
   className="rounded-md"
-></Image>
+/>
 
 Application developers have control over how these preference sets are presented to the user and which options to surface, but Knock enforces these preferences during every workflow run automatically.
 
@@ -222,17 +222,23 @@ If you want to keep learning about Knock using a curated example application, ch
   <SdkCard
     title="In-app feed & toasts"
     linkUrl="https://github.com/knocklabs/in-app-notifications-example-nextjs"
+    icon="react"
     languages={["React", "Next.js"]}
+    isExternal={true}
   />
   <SdkCard
     title="SlackKit example"
     linkUrl="https://github.com/knocklabs/slack-kit-example"
+    icon="react"
     languages={["React", "Next.js"]}
+    isExternal={true}
   />
   <SdkCard
     title="iOS example"
     linkUrl="https://github.com/knocklabs/ios-example-app"
+    icon="swift"
     languages={["Swift"]}
+    isExternal={true}
   />
 </SdkCardGroup>
 

--- a/content/sdks/overview.mdx
+++ b/content/sdks/overview.mdx
@@ -13,42 +13,58 @@ Knock's server-side helper libraries (also known as server-side SDKs) reduce the
   <SdkCard
     title="Node SDK"
     linkUrl="https://github.com/knocklabs/knock-node"
+    icon="node"
     languages={["Node.js", "TypeScript"]}
+    isExternal={true}
   />
   <SdkCard
     title="Python SDK"
     linkUrl="https://github.com/knocklabs/knock-python"
+    icon="python"
     languages={["Python"]}
+    isExternal={true}
   />
   <SdkCard
     title="Ruby SDK"
     linkUrl="https://github.com/knocklabs/knock-ruby"
+    icon="ruby"
     languages={["Ruby"]}
+    isExternal={true}
   />
   <SdkCard
     title="Go SDK"
     linkUrl="https://github.com/knocklabs/knock-go"
+    icon="go"
     languages={["Golang"]}
+    isExternal={true}
   />
   <SdkCard
     title="Java SDK"
     linkUrl="https://github.com/knocklabs/knock-java"
+    icon="java"
     languages={["Java"]}
+    isExternal={true}
   />
   <SdkCard
-    title="Dot.net SDK"
+    title=".NET SDK"
     linkUrl="https://github.com/knocklabs/knock-dotnet"
+    icon="dotnet"
     languages={["C#"]}
+    isExternal={true}
   />
   <SdkCard
     title="Elixir SDK"
     linkUrl="https://github.com/knocklabs/knock-elixir"
+    icon="elixir"
     languages={["Elixir"]}
+    isExternal={true}
   />
   <SdkCard
     title="PHP SDK"
     linkUrl="https://github.com/knocklabs/knock-php"
+    icon="php"
     languages={["PHP"]}
+    isExternal={true}
   />
 </SdkCardGroup>
 
@@ -62,12 +78,16 @@ Knock's client-side libraries (also known as client-side SDKs) reduce the amount
   <SdkCard
     title="Javascript SDK"
     linkUrl="https://github.com/knocklabs/javascript/tree/main/packages/client"
+    icon="javascript"
     languages={["JavaScript", "TypeScript"]}
+    isExternal={true}
   />
   <SdkCard
     title="React SDK"
     linkUrl="https://github.com/knocklabs/javascript/tree/main/packages/react"
+    icon="react"
     languages={["JavaScript", "TypeScript"]}
+    isExternal={true}
   />
 </SdkCardGroup>
 
@@ -77,21 +97,29 @@ Knock's client-side libraries (also known as client-side SDKs) reduce the amount
   <SdkCard
     title="iOS SDK"
     linkUrl="https://github.com/knocklabs/knock-swift"
+    icon="swift"
     languages={["Swift"]}
+    isExternal={true}
   />
   <SdkCard
     title="Android SDK"
     linkUrl="https://github.com/knocklabs/knock-android"
+    icon="kotlin"
     languages={["Kotlin"]}
+    isExternal={true}
   />
   <SdkCard
     title="Flutter SDK"
     linkUrl="https://github.com/knocklabs/knock-flutter"
+    icon="flutter"
     languages={["Flutter", "Dart"]}
+    isExternal={true}
   />
   <SdkCard
     title="React Native SDK"
     linkUrl="https://github.com/knocklabs/javascript/tree/main/packages/react-native"
+    icon="reactnative"
     languages={["JavaScript", "TypeScript"]}
+    isExternal={true}
   />
 </SdkCardGroup>

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^18.2.0",
     "react-focus-lock": "^2.9.1",
     "react-hotkeys-hook": "^3.4.6",
-    "react-icons": "4.2.0",
+    "react-icons": "5.2.0",
     "react-syntax-highlighter": "^15.4.3",
     "react-use-clipboard": "1.0.7",
     "rehype-mdx-code-props": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7746,10 +7746,10 @@ react-hotkeys-hook@^4.4.1:
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.5.0.tgz#807b389b15256daf6a813a1ec09e6698064fe97f"
   integrity sha512-Samb85GSgAWFQNvVt3PS90LPPGSf9mkH/r4au81ZP1yOIFayLC3QAvqTgGtJ8YEDMXtPmaVBs6NgipHO6h4Mug==
 
-react-icons@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.2.0.tgz#6dda80c8a8f338ff96a1851424d63083282630d0"
-  integrity sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==
+react-icons@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.2.0.tgz#790c92d5f1888ef2dbbd3468c553fd4bb5c8bf7e"
+  integrity sha512-n52Y7Eb4MgQZHsSZOhSXv1zs2668/hBYKfSRIvKh42yExjyhZu0d1IK2CLLZ3BZB1oo13lDfwx2vOh2z9FTV6Q==
 
 react-icons@^4.10.1:
   version "4.12.0"


### PR DESCRIPTION
### Description

This PR does a few things related to the `SdkCard` component:
- makes the SDK Card a bit more flexible so you can choose your own icon for the card
- bumps the version of `react-icons` to allow for import of all the relevant icons
- imports a bunch of icons for our various SDKs and example apps and adds them to a typed list of supported icons
- adds `icon` props to all of the currently-existing SDK cards for which they were relevant
- adds the `isExternal` prop to all cards that have external links so that they'll open in a new tab
