### PR TITLE
chore: add example table definition

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -24,9 +24,7 @@ Once the information is filled out, Prequel will provide you with a table defini
     Please note that the table name will vary based on the name of the schema provided when filling out the form.
     ```markdown
         CREATE TABLE <name of schema>.messages (
-          message_id character varying(65535) NOT NULL ENCODE raw
-          distkey
-        ,
+          message_id character varying(65535) NOT NULL ENCODE raw distkey,
             account_id character varying(65535) ENCODE lzo,
             environment_id character varying(65535) ENCODE lzo,
             environment_name character varying(65535) ENCODE lzo,
@@ -57,9 +55,7 @@ Once the information is filled out, Prequel will provide you with a table defini
             has_been_interacted bigint ENCODE az64,
             has_been_archived bigint ENCODE az64,
             PRIMARY KEY (message_id)
-        ) DISTSTYLE KEY
-        SORTKEY
-          (message_id, updated_at);
+        ) DISTSTYLE KEY SORTKEY (message_id, updated_at);
     ```
   </Accordion>
 </AccordionGroup>

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -17,10 +17,16 @@ First, you'll have to give Knock your database type and host destination address
 
 Next, Knock generates a magic link you'll fill out. See what information you'll need for your particular database [here](https://docs.prequel.co/reference/post_import-magic-links).
 
-Once the information is filled out, Prequel will provide you with a table definition (example provided below). Additionally, you can run a test connection to make sure it's wired up. If it's successful, you can save it and it will proceed with the backfill transfer.
+Once the information is filled out, Prequel will provide you with a table definition. Additionally, you can run a test connection to make sure it's wired up. If it's successful, you can save it and it will proceed with the backfill transfer.
+
+## Available data
+
+Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](https://docs.knock.app/send-and-manage-data/messages). 
+
+Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the [destination type mapping](https://docs.prequel.co/docs/data-types#destination-type-mapping) in the Prequel docs.
 
 <AccordionGroup>
-  <Accordion title="Example table definition">
+<Accordion title="Table definition example">
     Please note that the table name will vary based on the name of the schema provided when filling out the form.
     ```markdown
         CREATE TABLE <name of schema>.messages (
@@ -58,169 +64,163 @@ Once the information is filled out, Prequel will provide you with a table defini
         ) DISTSTYLE KEY SORTKEY (message_id, updated_at);
     ```
   </Accordion>
+  <Accordion title="Messages table structure">
+  See possible [engagement statuses](/send-notifications/message-statuses#engagement-status) for a message.
+
+    <Table
+      headers={["Name", "Type", "Description"]}
+      rows={[
+        [
+          "message_id",
+          "string",
+          "The unique identifier for this message and the primary key for this table",
+        ],
+        ["account_id", "string", "The UUID of the message's account"],
+        ["environment_id", "string", "The UUID of the message's environment"],
+        ["environment_name", "string", "The name of the message's environment"],
+        ["environment_slug", "string", "The slug of the message's environment"],
+        ["channel_id", "string", "The UUID of the channel the message was sent on"],
+        [
+          "channel_key",
+          "string",
+          "The unique key of the channel the message was sent on",
+        ],
+        [
+          "channel_name",
+          "string",
+          "The name of the channel the message was sent on",
+        ],
+        [
+          "channel_provider",
+          "string",
+          "The provider for the channel the message was sent on",
+        ],
+        ["channel_type", "string", "The type of channel the message was sent on"],
+        [
+          "workflow_id",
+          "string",
+          "The UUID of the version of the workflow that the message belongs to",
+        ],
+        [
+          "workflow_key",
+          "string",
+          "The unique key of the workflow the message belongs to",
+        ],
+        [
+          "step_ref",
+          "string",
+          "The reference of the step on the workflow that the message belongs to",
+        ],
+        ["recipient_id", "string", "The ID of the recipient for the message"],
+        [
+          "recipient_type",
+          "string",
+          <div key="recipient_type_body">
+            The{" "}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://docs.knock.app/send-and-manage-data/recipients"
+            >
+              type of recipient for the message
+            </a>
+            , can be a user or an object
+          </div>,
+        ],
+        ["tenant_id", "string", "The tenant associated with this message"],
+        [
+          "exec_mode",
+          "string",
+          <div key="exec_mode_body">
+            The execution mode of the workflow. Possible values are:
+            <ul>
+              <li>
+                <code>trigger</code> - from the API
+              </li>
+              <li>
+                <code>rehearse</code> - test run
+              </li>
+              <li>
+                <code>rehearse_step</code> - test run a single step
+              </li>
+              <li>
+                <code>integration</code> - from an event integration source
+              </li>
+              <li>
+                <code>scheduled</code> - previously scheduled execution
+              </li>
+            </ul>
+          </div>,
+        ],
+        [
+          "message_status",
+          "string",
+          <div key="message_status_body">
+            The latest{" "}
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href="https://docs.knock.app/send-notifications/message-statuses#delivery-status"
+            >
+              delivery status of a message
+            </a>
+            .
+          </div>,
+        ],
+        [
+          "inserted_at",
+          "timestamp",
+          "The timestamp of when the message was created",
+        ],
+        [
+          "updated_at",
+          "timestamp",
+          "The timestamp of when the message was last updated",
+        ],
+        [
+          "archived_at",
+          "timestamp",
+          "The timestamp of when the message was archived",
+        ],
+        ["seen_at", "timestamp", "The timestamp of when the message was seen"],
+        ["read_at", "timestamp", "The timestamp of when the message was read"],
+        [
+          "clicked_at",
+          "timestamp",
+          "The timestamp of when a link in the message was clicked",
+        ],
+        [
+          "interacted_at",
+          "timestamp",
+          "The timestamp of when the message was interacted with",
+        ],
+        [
+          "has_been_seen",
+          "integer (0 = false, 1 = true)",
+          "Whether the message has been seen",
+        ],
+        [
+          "has_been_read",
+          "integer (0 = false, 1 = true)",
+          "Whether the message has been read",
+        ],
+        [
+          "has_been_clicked",
+          "integer (0 = false, 1 = true)",
+          "Whether a link in the message has been clicked",
+        ],
+        [
+          "has_been_interacted",
+          "integer (0 = false, 1 = true)",
+          "Whether the message has been interacted with",
+        ],
+        [
+          "has_been_archived",
+          "integer (0 = false, 1 = true)",
+          "Whether the message has been archived",
+        ],
+      ]}
+    />
+
+  </Accordion>
 </AccordionGroup>
-
-## Available data
-
-Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](https://docs.knock.app/send-and-manage-data/messages). Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the [destination type mapping](https://docs.prequel.co/docs/data-types#destination-type-mapping) in the Prequel docs.
-
-### Messages table structure
-
-{" "}
-
-<Table
-  headers={["Name", "Type", "Description"]}
-  rows={[
-    [
-      "message_id",
-      "string",
-      "The unique identifier for this message and the primary key for this table",
-    ],
-    ["account_id", "string", "The UUID of the message's account"],
-    ["environment_id", "string", "The UUID of the message's environment"],
-    ["environment_name", "string", "The name of the message's environment"],
-    ["environment_slug", "string", "The slug of the message's environment"],
-    ["channel_id", "string", "The UUID of the channel the message was sent on"],
-    [
-      "channel_key",
-      "string",
-      "The unique key of the channel the message was sent on",
-    ],
-    [
-      "channel_name",
-      "string",
-      "The name of the channel the message was sent on",
-    ],
-    [
-      "channel_provider",
-      "string",
-      "The provider for the channel the message was sent on",
-    ],
-    ["channel_type", "string", "The type of channel the message was sent on"],
-    [
-      "workflow_id",
-      "string",
-      "The UUID of the version of the workflow that the message belongs to",
-    ],
-    [
-      "workflow_key",
-      "string",
-      "The unique key of the workflow the message belongs to",
-    ],
-    [
-      "step_ref",
-      "string",
-      "The reference of the step on the workflow that the message belongs to",
-    ],
-    ["recipient_id", "string", "The ID of the recipient for the message"],
-    [
-      "recipient_type",
-      "string",
-      <div key="recipient_type_body">
-        The{" "}
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href="https://docs.knock.app/send-and-manage-data/recipients"
-        >
-          type of recipient for the message
-        </a>
-        , can be a user or an object
-      </div>,
-    ],
-    ["tenant_id", "string", "The tenant associated with this message"],
-    [
-      "exec_mode",
-      "string",
-      <div key="exec_mode_body">
-        The execution mode of the workflow. Possible values are:
-        <ul>
-          <li>
-            <code>trigger</code> - from the API
-          </li>
-          <li>
-            <code>rehearse</code> - test run
-          </li>
-          <li>
-            <code>rehearse_step</code> - test run a single step
-          </li>
-          <li>
-            <code>integration</code> - from an event integration source
-          </li>
-          <li>
-            <code>scheduled</code> - previously scheduled execution
-          </li>
-        </ul>
-      </div>,
-    ],
-    [
-      "message_status",
-      "string",
-      <div key="message_status_body">
-        The latest{" "}
-        <a
-          target="_blank"
-          rel="noreferrer"
-          href="https://docs.knock.app/send-notifications/message-statuses#delivery-status"
-        >
-          delivery status of a message
-        </a>
-        .
-      </div>,
-    ],
-    [
-      "inserted_at",
-      "timestamp",
-      "The timestamp of when the message was created",
-    ],
-    [
-      "updated_at",
-      "timestamp",
-      "The timestamp of when the message was last updated",
-    ],
-    [
-      "archived_at",
-      "timestamp",
-      "The timestamp of when the message was archived",
-    ],
-    ["seen_at", "timestamp", "The timestamp of when the message was seen"],
-    ["read_at", "timestamp", "The timestamp of when the message was read"],
-    [
-      "clicked_at",
-      "timestamp",
-      "The timestamp of when a link in the message was clicked",
-    ],
-    [
-      "interacted_at",
-      "timestamp",
-      "The timestamp of when the message was interacted with",
-    ],
-    [
-      "has_been_seen",
-      "integer (0 = false, 1 = true)",
-      "Whether the message has been seen",
-    ],
-    [
-      "has_been_read",
-      "integer (0 = false, 1 = true)",
-      "Whether the message has been read",
-    ],
-    [
-      "has_been_clicked",
-      "integer (0 = false, 1 = true)",
-      "Whether a link in the message has been clicked",
-    ],
-    [
-      "has_been_interacted",
-      "integer (0 = false, 1 = true)",
-      "Whether the message has been interacted with",
-    ],
-    [
-      "has_been_archived",
-      "integer (0 = false, 1 = true)",
-      "Whether the message has been archived",
-    ],
-  ]}
-/>
-
-See possible [engagement statuses](/send-notifications/message-statuses#engagement-status) for a message.

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -28,7 +28,7 @@ Below is a description of the columns included in the table and the data type of
 <AccordionGroup>
 <Accordion title="Table definition example">
     Please note that the table name will vary based on the name of the schema provided when filling out the form.
-    ```markdown
+    ```sql
         CREATE TABLE <name of schema>.messages (
           message_id character varying(65535) NOT NULL ENCODE raw distkey,
             account_id character varying(65535) ENCODE lzo,

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -21,7 +21,7 @@ Once the information is filled out, Prequel will provide you with a table defini
 
 ## Available data
 
-Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](https://docs.knock.app/send-and-manage-data/messages). 
+Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](https://docs.knock.app/send-and-manage-data/messages).
 
 Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the [destination type mapping](https://docs.prequel.co/docs/data-types#destination-type-mapping) in the Prequel docs.
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -9,7 +9,7 @@ You can bring your notification analytics from Knock into your own data warehous
 
 ## How it works
 
-Knock leverages [Prequel](https://www.prequel.co/) to integrate with your data warehouse. There is no self-service UI to connect your account to start receiving data; instead when you contact us to set up a sync we'll send you a secure link to fill in the information about your data warehouse. Once it's connected, you'll begin receiving a [backfill of historial data](https://docs.prequel.co/docs/transfer-logic#backfills--full-refreshes), and then going forward you will receive the most up to date data on an ongoing basis.
+Knock leverages [Prequel](https://www.prequel.co/) to integrate with your data warehouse. There is no self-service UI to connect your account to start receiving data; instead when you contact us to set up a sync we'll send you a secure link to fill in the information about your data warehouse. Once it's connected, you'll begin receiving a [backfill of historical data](https://docs.prequel.co/docs/transfer-logic#backfills--full-refreshes), and then going forward you will receive the most up to date data on an ongoing basis.
 
 ## Setup
 
@@ -17,7 +17,52 @@ First, you'll have to give Knock your database type and host destination address
 
 Next, Knock generates a magic link you'll fill out. See what information you'll need for your particular database [here](https://docs.prequel.co/reference/post_import-magic-links).
 
-Once the information is filled out, you can run a test connection to make sure it's wired up. If it's successful, you can save it and it will proceeed with the backfill transfer.
+Once the information is filled out, Prequel will provide you with a table definition (example provided below). Additionally, you can run a test connection to make sure it's wired up. If it's successful, you can save it and it will proceed with the backfill transfer.
+
+<AccordionGroup>
+  <Accordion title="Example table definition">
+    Please note that the table name will vary based on the name of the schema provided when filling out the form.
+    ```markdown
+        CREATE TABLE <name of schema>.messages (
+          message_id character varying(65535) NOT NULL ENCODE raw
+          distkey
+        ,
+            account_id character varying(65535) ENCODE lzo,
+            environment_id character varying(65535) ENCODE lzo,
+            environment_name character varying(65535) ENCODE lzo,
+            environment_slug character varying(65535) ENCODE lzo,
+            channel_id character varying(65535) ENCODE lzo,
+            channel_name character varying(65535) ENCODE lzo,
+            channel_key character varying(65535) ENCODE lzo,
+            channel_type character varying(65535) ENCODE lzo,
+            channel_provider character varying(65535) ENCODE lzo,
+            workflow_id character varying(65535) ENCODE lzo,
+            workflow_key character varying(65535) ENCODE lzo,
+            step_ref character varying(65535) ENCODE lzo,
+            recipient_id character varying(65535) ENCODE lzo,
+            recipient_type character varying(65535) ENCODE lzo,
+            tenant_id character varying(65535) ENCODE lzo,
+            exec_mode character varying(65535) ENCODE lzo,
+            message_status character varying(65535) ENCODE lzo,
+            inserted_at timestamp with time zone ENCODE az64,
+            updated_at timestamp with time zone ENCODE raw,
+            seen_at timestamp with time zone ENCODE az64,
+            read_at timestamp with time zone ENCODE az64,
+            clicked_at timestamp with time zone ENCODE az64,
+            interacted_at timestamp with time zone ENCODE az64,
+            archived_at timestamp with time zone ENCODE az64,
+            has_been_seen bigint ENCODE az64,
+            has_been_read bigint ENCODE az64,
+            has_been_clicked bigint ENCODE az64,
+            has_been_interacted bigint ENCODE az64,
+            has_been_archived bigint ENCODE az64,
+            PRIMARY KEY (message_id)
+        ) DISTSTYLE KEY
+        SORTKEY
+          (message_id, updated_at);
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Available data
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -1,7 +1,8 @@
 ---
 title: Data warehouse sync
 description: Sync notification analytics data from Knock into your own data warehouse
-section: Developer tools
+layout: integrations
+section: Integrations > Extensions
 ---
 
 You can bring your notification analytics from Knock into your own data warehouse so that you can analyze it alongside the rest of your data. This is an enterprise-only feature. To set up this sync, please contact our [support team](mailto:support@knock.app).


### PR DESCRIPTION
### Description

Adds an example of what the table definitions from Prequel are for customers to be able to review prior to completing the setup via the magic link. It also fixes a breadcrumb issue on the `/data-sync` page.

https://docs-git-rt-add-schema-definitions-knocklabs.vercel.app/integrations/extensions/data-sync

Let me know if there's any information I should exclude from the example (i.e., varying lengths)