### PR TITLE
chore: homepage cards

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const CardGroup = ({ children, cols = 2 }) => (
   <div
-    className={clsx(`grid gap-2 auto-rows-[minmax(140px,auto)]`, {
+    className={clsx(`grid gap-2`, {
       "grid-cols-2": cols == 2,
       "grid-cols-3": cols == 3,
     })}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const CardGroup = ({ children, cols = 2 }) => (
   <div
-    className={clsx(`grid gap-2`, {
+    className={clsx(`grid gap-2 auto-rows-[minmax(140px,auto)]`, {
       "grid-cols-2": cols == 2,
       "grid-cols-3": cols == 3,
     })}
@@ -28,18 +28,18 @@ const Card: React.FC<Props> = ({
   linkUrl,
   isExternal = false,
 }) => (
-  <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors p-3">
+  <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors flex h-full">
     <a
       target={isExternal ? "_blank" : undefined}
       href={linkUrl}
       title={title}
-      className="!no-underline !text-inherit"
+      className="!no-underline !text-inherit w-full p-3"
     >
       <>
         {emoji && <div className="mb-1">{emoji}</div>}
 
         <div className="mb-1">
-          <span className="text-brand text-[14px] font-semibold">{title}</span>
+          <span className="text-brand text-[15px] font-semibold">{title}</span>
         </div>
 
         {children && <div className="not-prose text-[14px]">{children}</div>}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,7 +80,7 @@ export default function Home() {
                     title={String(s.title)}
                     linkUrl={s.slug + s.pages[0].slug}
                     footer={
-                      <div className="flex text-[14px] text-gray-500 dark:text-gray-200 min-h-[110px]">
+                      <div className="flex text-[14px] text-gray-500 dark:text-gray-200 min-h-[90px]">
                         {s.desc}
                       </div>
                     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,7 +80,7 @@ export default function Home() {
                     title={String(s.title)}
                     linkUrl={s.slug + s.pages[0].slug}
                     footer={
-                      <div className="flex items-center text-[14px] text-gray-500 dark:text-gray-200">
+                      <div className="flex text-[14px] text-gray-500 dark:text-gray-200 min-h-[110px]">
                         {s.desc}
                       </div>
                     }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { Page } from "../layouts/Page";
 import DocsSidebar from "../components/DocsSidebar";
 import MinimalHeader from "../components/Header/MinimalHeader";
 import AiChatButton from "../components/AiChatButton";
+import { Card, CardGroup } from "../components/Card";
 
 const contentForDiscovery = sidebarContent.filter((s) => s.desc);
 
@@ -72,35 +73,13 @@ export default function Home() {
           <h2 className="text-2xl font-bold mb-3">Discover Knock</h2>
 
           <div className="space-y-6 pt-3">
+            <CardGroup>
             {contentForDiscovery.map((s) => (
-              <div
-                className="flex flex-col lg:flex-row border-t dark:border-t-gray-700 pt-6"
-                key={s.slug}
-              >
-                <div className="lg:w-80">
-                  <h3 className="text-xl font-semibold mb-2">{s.title}</h3>
-                  <p className="text-sm text-gray-600 dark:text-gray-200">
-                    {s.desc}
-                  </p>
-                </div>
-
-                <ul className="mt-5 lg:mt-0 lg:ml-auto lg:w-40 space-y-2">
-                  {s.pages.map((p) => (
-                    <li
-                      className="text-sm text-gray-500 dark:text-gray-300"
-                      key={p.slug}
-                    >
-                      <Link
-                        href={s.slug + p.slug}
-                        className="hover:text-gray-800 dark:hover:text-gray-100"
-                      >
-                        {p.title}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
+              <div key={s.slug}>
+                <Card title={String(s.title)} linkUrl={s.slug + s.pages[0].slug} footer={<div className="flex items-center text-[14px] text-gray-500 dark:text-gray-200">{s.desc}</div>} />
               </div>
             ))}
+            </CardGroup>
           </div>
         </section>
       </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -74,11 +74,19 @@ export default function Home() {
 
           <div className="space-y-6 pt-3">
             <CardGroup>
-            {contentForDiscovery.map((s) => (
-              <div key={s.slug}>
-                <Card title={String(s.title)} linkUrl={s.slug + s.pages[0].slug} footer={<div className="flex items-center text-[14px] text-gray-500 dark:text-gray-200">{s.desc}</div>} />
-              </div>
-            ))}
+              {contentForDiscovery.map((s) => (
+                <div key={s.slug}>
+                  <Card
+                    title={String(s.title)}
+                    linkUrl={s.slug + s.pages[0].slug}
+                    footer={
+                      <div className="flex items-center text-[14px] text-gray-500 dark:text-gray-200">
+                        {s.desc}
+                      </div>
+                    }
+                  />
+                </div>
+              ))}
             </CardGroup>
           </div>
         </section>


### PR DESCRIPTION
### Description

Reformat docs homepage to use cards instead of listing a full page index.

As part of this update, I also made some tiny modifications to the `Card` component (which we may or may not like):
- Slight font-size increase to the `title` on each card (this will impact `SdkCard` instances as well)
- moved padding for the card onto the inner `<a>` tag so that the entire card is clickable

### Questions

Do we like this approach? Is it ok that mobile users will lose the ability to navigate to specific pages?