### PR TITLE
chore: address 404s 

### DIFF
--- a/content/integrations/overview.md
+++ b/content/integrations/overview.md
@@ -127,4 +127,4 @@ Here are the providers we currently support within Knock. We're adding more each
 
 ### In-app
 
-- [Knock in-app](/integrations/in-app/knock-feed)
+- [Knock in-app](/integrations/in-app/knock)

--- a/next.config.js
+++ b/next.config.js
@@ -294,6 +294,11 @@ const nextConfig = {
         destination: "/getting-started/example-apps",
         permanent: true,
       },
+      {
+        source: "/concepts",
+        destination: "/concepts/overview",
+        permanent: false,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -305,11 +305,6 @@ const nextConfig = {
         permanent: false,
       },
       {
-        source: "/SDKs/overview",
-        destination: "/sdks/overview",
-        permanent: false,
-      },
-      {
         source: "/in-app-ui/android/quick-start",
         destination: "/sdks/android/quick-start",
         permanent: false,

--- a/next.config.js
+++ b/next.config.js
@@ -304,6 +304,11 @@ const nextConfig = {
         destination: "/sdks/javascript/quick-start",
         permanent: false,
       },
+      {
+        source: "/SDKs/overview",
+        destination: "/sdks/overview",
+        permanent: false,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -309,6 +309,11 @@ const nextConfig = {
         destination: "/sdks/overview",
         permanent: false,
       },
+      {
+        source: "/in-app-ui/android/quick-start",
+        destination: "/sdks/android/quick-start",
+        permanent: false,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -299,6 +299,11 @@ const nextConfig = {
         destination: "/concepts/overview",
         permanent: false,
       },
+      {
+        source: "/in-app-ui/javascript/quick-start",
+        destination: "/sdks/javascript/quick-start",
+        permanent: false,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -314,6 +314,11 @@ const nextConfig = {
         destination: "/sdks/android/quick-start",
         permanent: false,
       },
+      {
+        source: "/in-app-ui/flutter",
+        destination: "/in-app-ui/flutter/overview",
+        permanent: false,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -277,22 +277,22 @@ const nextConfig = {
       {
         source: "/getting-started/knock-and-postman",
         destination: "/developer-tools/knock-and-postman",
-        permanent: false,
+        permanent: true,
       },
       {
         source: "/getting-started/security",
         destination: "/developer-tools/security",
-        permanent: false,
+        permanent: true,
       },
       {
         source: "/getting-started/how-knock-works",
         destination: "/getting-started/what-is-knock",
-        permanent: false,
+        permanent: true,
       },
       {
         source: "/getting-started/example-app",
         destination: "/getting-started/example-apps",
-        permanent: false,
+        permanent: true,
       },
     ];
   },


### PR DESCRIPTION
### Description
This PR does a few things:

1. changes 302 redirects to 301 from the recent 'Getting Started' updates
2. Adds redirects for any not-found URLs that appeared in the GA 404 report
3. Updates one link on integrations page
