### PR TITLE
chore: update dashboard navigation instructions (part 1)

### DIFF
--- a/content/concepts/channels.mdx
+++ b/content/concepts/channels.mdx
@@ -46,7 +46,7 @@ Given that channel configuration is **per-environment** this makes it possible t
 
 In Knock, all notification messages are sent via a channel step configured within a [workflow](/concepts/workflows). Notifications to be delivered will be forwarded to the channel using the settings that you provide inside our message delivery service, which handles the communication to the underlying provider and the retry logic if a message delivery should fail.
 
-For most providers, you can inspect the delivery logs produced when trying to send a message from under the "Messages > Logs" page from within the Knock dashboard.
+For most providers, you can inspect the delivery logs produced when trying to send a message from under the **Messages** > **Logs** page from within the Knock dashboard.
 
 ## Setting additional, per-recipient data for a channel
 

--- a/content/concepts/environments.mdx
+++ b/content/concepts/environments.mdx
@@ -21,7 +21,7 @@ In order to prevent unintended changes to Knock resources (like a [workflow](/co
 
 By default your Knock account comes with two environments: Development and Production. If you need an additional environment in Knock to mirror your own development lifecycle (for example, a Staging environment) you can add it on the settings page of the Knock dashboard.
 
-To create a new environment, go to "Settings" then "Environments". You'll see a button to "Create environment".
+To create a new environment, go to **Settings** > **Environments**. You'll see a button to "Create environment."
 
 When you create an additional environment, it will be inserted between Development and Production. This means all changes will continue to be introduced in your Development environment and will need to be promoted through additional environments until they land in Production. Subsequent new environments will always be added one "level" lower than Production; environments cannot be re-ordered, as this would break the promotion model for previously-promoted changes.
 
@@ -33,11 +33,3 @@ There are two tools you can use to control access to your data in the Knock dash
 
 - [Roles and permissions.](/manage-your-account/roles-and-permissions) Knock offers granular roles for the different functions your team members may want to carry out in Knock, such as support team members that need to debug issues for customers but shouldn't be making changes to notification logic.
 - [Customer data obfuscation.](/manage-your-account/data-obfuscation) You can use our per-environment data obfuscation controls to configure whether you want your team members to be able to view customer data in the Knock dashboard.
-
-## Account variables and per-environment overrides
-
-You can create variables to set global values to use across your workflows and layouts. Variables are defined at the account-level in Knock, meaning they apply across all environments and are available in all workflow run scopes. When a variable is created, it is available under the `vars` namespace in any notification templates where you want to use it.
-
-You can override a variable's value at the environment-level under "Developers > Variables". As an example: if you have an account-level variable `app_url` with value `https://acme.com`, you can set an environment override that sets the value to `https://acme-dev.com` when a notification is sent from your development environment.
-
-[Read more about variables](/send-and-manage-data/variables)

--- a/content/concepts/preferences.mdx
+++ b/content/concepts/preferences.mdx
@@ -205,7 +205,7 @@ When a user is created in Knock, they are automatically opted into all channel t
 }
 ```
 
-In the event you need to update this set of default preferences, you can do so from the **Developers > Preferences** section of the dashboard. From here you can specify a default set of preferences **per environment** that will be applied to all recipients when executing a notification workflow. The default preferences set in the dashboard follow the same shape as any [preferences you set via the API](/send-notifications/setting-preferences) and will be validated before being saved.
+In the event you need to update this set of default preferences, you can do so from the **Developers** > **Preferences** section of the dashboard. From here you can specify a default set of preferences **per environment** that will be applied to all recipients when executing a notification workflow. The default preferences set in the dashboard follow the same shape as any [preferences you set via the API](/send-notifications/setting-preferences) and will be validated before being saved.
 
 Default preferences are useful when you need to roll out preferences across all your recipients or need to migrate recipients from one preference model to another. It's important to remember that for more complex preference migrations you may still need to update any stored preferences for your recipients, which you can do via the [batch preference update API](/reference#bulk-set-preferences).
 

--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -169,7 +169,7 @@ Knock always deduplicates recipients when executing a notification fan out, incl
   </Accordion>
   <Accordion title="Can I manage subscribers to an object in the dashboard?">
     Right now, you can only **view** the subscribers of an object in the
-    dashboard. You can do so under "Objects > Subscriptions".
+    dashboard. You can do so under **Objects** > **Subscriptions**.
   </Accordion>
   <Accordion title="Can I set custom properties on a Subscription?">
     Yes, you can pass a set of `properties`, which is a set of unstructured

--- a/content/concepts/variables.mdx
+++ b/content/concepts/variables.mdx
@@ -9,11 +9,11 @@ Variables within Knock let you set shared constants or secrets that you can use 
 
 ## Setting variables
 
-You can create account-wide variables under "Settings > Variables". Each variable has a `key` and a `value`. The key is how you'll reference the variable in your templates, conditions, and preference conditions when building your workflows.
+You can create account-wide variables under **Settings** > **Variables**. Each variable has a `key` and a `value`. The key is how you'll reference the variable in your templates, conditions, and preference conditions when building your workflows.
 
 ## Setting secret variables
 
-By default, any variables you set are created as public. Public variables are exposed via the [user feed endpoint](/reference#get-feed) and are always visible within the dashboard by all team members. If you're working with variables that should not be exposed you can create them as secret variables by toggling the "Set as secret" slider when creating a variable.
+By default, any variables you set are created as public. Public variables are exposed via the [user feed endpoint](/reference#get-feed) and are always visible within the dashboard by all team members. If you're working with variables that should not be exposed you can create them as secret variables by toggling the "Make variable secret" slider when creating a variable.
 
 Secret variables are _never_ revealed in the dashboard (all values are obfuscated) and are _never_ exposed via the API.
 
@@ -23,7 +23,7 @@ Variables are available to be accessed under the `vars` namespace within your te
 
 ## Overriding variables per-environment
 
-You can optionally override any existing account variables per environment to set **environment-specific variables**. To do so, go to the "Developers > Variables" section for a specific environment, click the three dots for a specific variable to select "edit variable," and set the value for the environment.
+You can optionally set environment-specific values for your variables. To do so, go to the **Settings** > **Variables** section of the dashboard, click the three dots for a specific variable to select "Edit variable," and set the value for the environment you wish to override.
 
 ## Setting JSON in variables
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -119,7 +119,7 @@ When a workflow is triggered via the API we return a `workflow_run_id` via the A
 
 For each recipient included in the workflow trigger or that the workflow should fan out to [via subscriptions](/send-and-manage-data/subscriptions), a new workflow run is enqueued. We call this the recipient workflow run.
 
-Recipient runs are visible within the Knock dashboard by going to "Developers > Logs". Each run can be inspected to view its current state as well as the steps executed for the workflow. It's also possible from a workflow run log to see the messages (notifications) produced by the run.
+Recipient runs are visible within the Knock dashboard by going to **Developers** > **Logs**. Each run can be inspected to view its current state as well as the steps executed for the workflow. It's also possible from a workflow run log to see the messages (notifications) produced by the run.
 
 ### Workflow run scope
 

--- a/content/designing-workflows/batch-function.mdx
+++ b/content/designing-workflows/batch-function.mdx
@@ -317,11 +317,10 @@ If you want to remove an item from a batch (example: a user deletes a comment), 
   <Accordion title="How do I set per-environment batch windows?">
     Often when you're testing your Knock workflows, you'll want your batch windows to be shorter in non-production environments to aid with testing. To set per-environment batch windows you can:
 
-    - Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `batchWindow`
+    - Create a new variable under **Settings** > **Variables** with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `batchWindow`. You can set per-environment values to specify a shorter or longer window as needed
     - Set your batch window to "Batch for a dynamic interval"
     - Specify that your batch window will come from an environment variable
     - Set the key to be `batchWindow`, which will resolve the batch window from the variable you created
-    - You can now override the variable per-environment to specify a shorter, or longer window as needed
 
   </Accordion>
   <Accordion title="Can I close a batch early?">

--- a/content/designing-workflows/channel-step.mdx
+++ b/content/designing-workflows/channel-step.mdx
@@ -36,4 +36,4 @@ There are a few ways to power in-app notifications in your product using Knock:
 
 ### Out-of-app channels
 
-We support notification delivery to the following out-of-app channel types: [email](/integrations/email/overview), [push](/integrations/push/overview), [SMS](/integrations/sms/overview), and 3rd-party [chat apps](/integrations/chat/overview) (such as Slack). You can see a list of which providers we support within each channel type in the {"Integrations > Channels"} page of the Knock dashboard.
+We support notification delivery to the following out-of-app channel types: [email](/integrations/email/overview), [push](/integrations/push/overview), [SMS](/integrations/sms/overview), and 3rd-party [chat apps](/integrations/chat/overview) (such as Slack). You can see a list of which providers we support within each channel type in the **Integrations** > **Channels** section of the Knock dashboard.

--- a/content/designing-workflows/delay-function.mdx
+++ b/content/designing-workflows/delay-function.mdx
@@ -127,11 +127,10 @@ If the user completes the action you were going to remind them about, cancel the
   <Accordion title="How do I set per-environment delay periods?">
     Often when you're testing your Knock workflows, you'll want your delay durations to be shorter in non-production environments to aid with testing. To set per-environment delay duration you can:
 
-    - Create a new variable under "Developers > Variables" with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `delayDuration`
+    - Create a new variable under **Settings** > **Variables** with a relative duration as JSON (`{ "unit": "seconds", "value": 30 }`) and a name of `delayDuration`. You can set per-environment values to specify a shorter or longer window as needed
     - Set your delay duration to "Wait until a dynamic interval"
     - Specify that your delay duration will come from an environment variable
     - Set the key to `delayDuration`, which will resolve the delay duration from the variable you created
-    - You can now override the variable per environment to specify a shorter, or longer window as needed
 
   </Accordion>
   <Accordion title="How can I cancel an open delay?">

--- a/content/developer-tools/api-keys.mdx
+++ b/content/developer-tools/api-keys.mdx
@@ -8,7 +8,7 @@ In Knock, all requests to the [Knock API](/reference) are issued using a API key
 
 ## Finding your API keys
 
-You can find your **environment-specific API keys** under "Developers > API keys" in the left-hand side bar. Remember: each environment has its own unique set of API keys.
+You can find your **environment-specific API keys** under **Developers** > **API keys** in the left-hand side bar. Remember: each environment has its own unique set of API keys.
 
 ## Secret vs public API keys
 
@@ -22,8 +22,11 @@ Each Knock environment will be generated with two API keys: a secret key and a p
 
 <AccordionGroup>
   <Accordion title="Can I revoke an API key once generated?">
-    If you need to revoke and regenerate a set of API keys, please [get in touch
-    with our support team](mailto:support@knock.app).
+    Yes. If you need to revoke and rotate your API keys in a given environment,
+    navigate to **Developers** > **API keys** in your dashboard, select the
+    "..." menu next to the key you want to rotate, and click "Roll API key."
+    This will prompt you to confirm the operation, which will immediately issue
+    a new key and invalidate the previous key. This action cannot be undone.
   </Accordion>
   <Accordion title="Can I further scope API key access?">
     Currently, it's not possible to reduce the scope of an API key and limit it

--- a/content/developer-tools/api-logs.mdx
+++ b/content/developer-tools/api-logs.mdx
@@ -4,7 +4,7 @@ description: Learn more about viewing and debugging API request logs in Knock.
 section: Developer tools
 ---
 
-Knock automatically captures and stores all of the API requests you make to the Knock API, and makes these requests accessible under the "Developers > Logs" section of the left-hand navigation in the Knock dashboard.
+Knock automatically captures and stores all of the API requests you make to the Knock API, and makes these requests accessible under the **Developers** > **Logs** section of the left-hand navigation in the Knock dashboard.
 
 ## Filtering API logs
 

--- a/content/guides/building-recurring-digests.mdx
+++ b/content/guides/building-recurring-digests.mdx
@@ -165,7 +165,7 @@ await knock.workflows.createSchedules("recurring-digest", {
   }
 />
 
-Once our schedules are created, they will start running on the next occurrence date. We can even see these in the Knock dashboard under "Workflows > Recurring digest > Schedules" and see when the schedules will run next for our recipients.
+Once our schedules are created, they will start running on the next occurrence date. We can even see these in the Knock dashboard under **Workflows** > **Recurring digest** > **Schedules** and see when the schedules will run next for our recipients.
 
 ![Viewing schedules in the dashboard](/images/guides/recurring-digests/viewing-schedules.png)
 

--- a/content/in-app-ui/react/custom-notifications-ui.mdx
+++ b/content/in-app-ui/react/custom-notifications-ui.mdx
@@ -21,9 +21,11 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
   text={
     <>
       <span className="font-bold">Find your channel ID.</span> To find the
-      channel ID for your in-app channel(s), go to {"Integrations > Channels"}{" "}
-      in the Knock dashboard, navigate to the channel page of your in-app
-      channel, and copy the channel ID.
+      channel ID for your in-app channel(s), go to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard,
+      navigate to the channel page of your in-app channel, and copy the channel
+      ID.
     </>
   }
 />

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -21,9 +21,11 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
   text={
     <>
       <span className="font-bold">Find your channel ID.</span> To find the
-      channel ID for your in-app channel(s), go to {"Integrations > Channels"}{" "}
-      in the Knock dashboard, navigate to the channel page of your in-app
-      channel, and copy the channel ID.
+      channel ID for your in-app channel(s), go to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard,
+      navigate to the channel page of your in-app channel, and copy the channel
+      ID.
     </>
   }
 />

--- a/content/in-app-ui/react/inbox.mdx
+++ b/content/in-app-ui/react/inbox.mdx
@@ -18,9 +18,11 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
   text={
     <>
       <span className="font-bold">Find your channel ID.</span> To find the
-      channel ID for your in-app channel(s), go to {"Integrations > Channels"}{" "}
-      in the Knock dashboard, navigate to the channel page of your in-app
-      channel, and copy the channel ID.
+      channel ID for your in-app channel(s), go to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard,
+      navigate to the channel page of your in-app channel, and copy the channel
+      ID.
     </>
   }
 />

--- a/content/in-app-ui/react/toasts.mdx
+++ b/content/in-app-ui/react/toasts.mdx
@@ -20,9 +20,11 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
   text={
     <>
       <span className="font-bold">Find your channel ID.</span> To find the
-      channel ID for your in-app channel(s), go to "Integrations &gt; Channels"
-      in the Knock dashboard, navigate to the channel page of your in-app
-      channel, and copy the channel ID.
+      channel ID for your in-app channel(s), go to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard,
+      navigate to the channel page of your in-app channel, and copy the channel
+      ID.
     </>
   }
 />

--- a/content/in-app-ui/security-and-authentication.mdx
+++ b/content/in-app-ui/security-and-authentication.mdx
@@ -89,7 +89,7 @@ backend. This means you can generate the authentication token out-of-band withou
 
 ### 1. Generate the signing key
 
-You can find the signing key in the Knock dashboard under the "Developers > API keys" page. Save the private
+You can find the signing key in the Knock dashboard under the **Developers** > **API keys** page. Save the private
 key shown to you here. Note: you won't be shown this key again, so you'll need to regenerate
 it if you lose access.
 
@@ -186,7 +186,7 @@ although we don't recommend this approach as it will add more latency for your u
 ### Errors using your Knock signing key
 
 If you are getting errors like `secretOrPrivateKey must be an asymmetric key when using RS256`,
-try using the base-64 encoded format of your signing key generated in the Knock Dashboard (under Developers > API keys > Application Signing Keys).
+try using the base-64 encoded format of your signing key generated in the Knock Dashboard (under **Developers** > **API keys** > **Application Signing Keys**).
 
 ```bash
 // .env.local

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -66,8 +66,9 @@ Take the URL you copied from the Discord webhook and set channel data on the Obj
       example above, the <code>KNOCK_DISCORD_CHANNEL_ID</code> variable is the
       id of the Knock channel you've created to represent your Discord
       integration within the Knock dashboard. You can find it by going to{" "}
-      {"Integrations > Channels"} in the Knock dashboard and then copying the id
-      of your Discord channel.
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard and
+      then copying the ID of your Discord channel.
     </>
   }
 />

--- a/content/integrations/chat/slack-diy/building-oauth-flow.mdx
+++ b/content/integrations/chat/slack-diy/building-oauth-flow.mdx
@@ -42,8 +42,10 @@ Here's an example of setting channel data on an `object` in Knock.
       <span className="font-bold">Potential confusion alert.</span> In the
       example above, the <code>KNOCK_SLACK_CHANNEL_ID</code> variable is the id
       of the Knock channel you've created to represent your Slack app within the
-      Knock dashboard. You can find it by going to {"Integrations > Channels"}{" "}
-      in the Knock dashboard and then copying the id of your Slack app channel.
+      Knock dashboard. You can find it by going to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard and
+      then copying the ID of your Slack app channel.
     </>
   }
 />

--- a/content/integrations/email/aws-ses.mdx
+++ b/content/integrations/email/aws-ses.mdx
@@ -24,7 +24,7 @@ You'll need to take the following steps in AWS before you can configure your SES
 1. **Verify a "From" address within AWS.** You'll need to do this before sending emails via SES through Knock.
 2. **Choose and configure an AWS Authentication Scheme.** To integrate with SES from the Knock dashboard, you can use cess Management (IAM) User Access Keys, or to improve security delegate a role to Knock [using External ID-based authentication.](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)
 
-Once you've completed both of those steps, you'll be able to configure an AWS SES channel in the Knock dashboard under the {"Integrations > Channels"} section.
+Once you've completed both of those steps, you'll be able to configure an AWS SES channel in the Knock dashboard under the **Integrations** {">"} **Channels** section.
 
 ### 1. Verify a "From" address within AWS SES
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -42,7 +42,7 @@ Here's a quick overview of the system-level variables Knock provides for use in 
 
 Your Knock account starts with a pre-built default layout. If you navigate into the layouts page of the sidebar, you'll find this default layout. This default layout will be used by all new email templates when they're initially created, so if you want to change the default layout used by your emails, this is the layout to update.
 
-Click on the "Default" layout in your layouts list to enter the layout editor. You'll start by looking at the pre-built layout that Knock gives you out of the box. You'll find a footer design option in this visual builder where you can add footer links to this pre-built layout for HTML emails. You can update the logo, icon, and brand color of your email layout by going to "Settings > Branding" and updating these attributes.
+Click on the "Default" layout in your layouts list to enter the layout editor. You'll start by looking at the pre-built layout that Knock gives you out of the box. You'll find a footer design option in this visual builder where you can add footer links to this pre-built layout for HTML emails. You can update the logo, icon, and brand color of your email layout by going to **Settings** > **Branding** and updating these attributes.
 
 If you'd rather create your own layout from scratch, you can click "Edit in code editor" in the top right corner of the layout editor to enter our custom layout editor. You can learn more about custom layouts in the [custom layouts and styling section](/integrations/email/layouts#custom-layouts-and-styling) of this guide.
 

--- a/content/integrations/overview.md
+++ b/content/integrations/overview.md
@@ -67,7 +67,7 @@ Sandbox mode is supported across all channel types and can be enabled from the e
 
 You can use channel conditions to place a [condition](/send-and-manage-data/conditions) on all instances of a channel within a given environment. As an example, if you want to ensure that your email channel only sends to recipients from your domain when it's executing in your staging environment, a channel-level condition would be great way to do that.
 
-To add a condition to a channel's environment configuration, navigate to that channel under "Integrations > Channels" and then click "edit configuration".
+To add a condition to a channel's environment configuration, navigate to **Integrations** > **Channels** in your dashboard, click on the channel you'd like to update, then click "Manage configuration" next to the relevant environment. Select "Conditions" in the modal that is opened.
 
 ![Managing channel conditions in Knock.](/images/integrations/channel-conditions-editor.png)
 


### PR DESCRIPTION
### Description

The main thrust of this PR is to update mentions of navigating in the dashboard to be consistent in their styling: 
- a **Page** in the dashboard is bolded, and a series of page navigations will look like **Page One** > **Page Two**
- a "Button" label (or other clickable entity) will have quotes 

Along the way, I'm also fixing information which is outdated or no longer fully accurate. Examples:
- We changed the way that Variables are set (they now live in **Settings** rather than under the **Developers** menu)
- Related to the above, you no longer need to switch environments to change environment-level variable overrides (all of your environments are listed under each variable). Because of this, I removed the mention of Variables from the Environments concept page altogether (it was redundant to the explanation on the Variables concept page)
- Customers now have the ability to self-serve rotating their API keys 
 
It turns out there are lots of mentions of how to navigate the dashboard in our docs (😄), so I'm breaking this into at least 2 PRs since this one is getting very long.