### PR TITLE
chore: clarify note on fetchNextPage

### DIFF
--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -426,8 +426,6 @@ Emits `items.received.page` events on a successful fetch.
 
 Note: this will apply any current feed filters and append returned items to the end of the current set of items.
 
-**Returns**: `Promise<void>`
-
 ---
 
 ## `Preferences`

--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -426,7 +426,7 @@ Emits `items.received.page` events on a successful fetch.
 
 Note: this will apply any current feed filters and append returned items to the end of the current set of items.
 
-**Returns**: `Promise<ApiResponse>`
+**Returns**: `Promise<void>`
 
 ---
 

--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -420,7 +420,7 @@ Emits `items.received.page` events on a successful fetch.
 
 ### `fetchNextPage`
 
-Fetches the next page of the feed items (if there are any more to fetch). Note: this will
+Fetches the next page of the feed items (if there are any more to fetch). Note: this will apply any current feed filters and append returned items to the end of the current set of items.
 
 ---
 

--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -426,6 +426,8 @@ Emits `items.received.page` events on a successful fetch.
 
 Note: this will apply any current feed filters and append returned items to the end of the current set of items.
 
+**Returns**: `Promise<ApiResponse>`
+
 ---
 
 ## `Preferences`

--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -420,7 +420,11 @@ Emits `items.received.page` events on a successful fetch.
 
 ### `fetchNextPage`
 
-Fetches the next page of the feed items (if there are any more to fetch). Note: this will apply any current feed filters and append returned items to the end of the current set of items.
+Fetches the next page of the feed items (if there are any more to fetch).
+
+Emits `items.received.page` events on a successful fetch.
+
+Note: this will apply any current feed filters and append returned items to the end of the current set of items.
 
 ---
 


### PR DESCRIPTION
### Description
clarifies an existing note on the `fetchNextPage` method on the JS reference
