### PR TITLE
chore: include recipient limit on adding subscriptions

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4752,7 +4752,7 @@ Adds one or more recipients as subscribers to the object by creating subscriptio
   <Attribute
     name="recipients"
     type="RecipientIdentifier[]"
-    description="A list of recipient identifers"
+    description="A list of recipient identifiers. You can subscribe up to 100 recipients to an object at a time."
   />
   <Attribute
     name="properties"


### PR DESCRIPTION
### Description

Adds info about the limit of the number of recipients you can subscribe to an object with each request (this is specified [here](https://docs.knock.app/concepts/subscriptions#subscribing-recipients-to-an-object), but adding it to the API docs for increased visibility).

https://docs-git-rt-add-recipient-limit-api-docs-knocklabs.vercel.app/reference#add-subscriptions