### PR TITLE
chore: update docs for new inline identify behavior

### DIFF
--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -69,7 +69,23 @@ When passing a set of recipients to be inline identified, Knock will guarantee t
 
 ## Setting properties while identifying recipients
 
-When identifying recipients you pass a set of properties for the recipient that are persisted. No properties on the recipient are required except for `id`. Generally, the best practice here is to use your internal identifier for your users as the `id`. There are some reserved property names for recipients that have special meaning:
+When identifying recipients you pass a set of properties for the recipient that are persisted. No properties on the recipient are required except for `id`. Generally, the best practice here is to use your internal identifier for your users as the `id`.
+
+<Callout
+  emoji="🙈"
+  text={
+    <>
+      <strong>Note:</strong> Although an <code>id</code> is the only required
+      recipient property, triggering a workflow for a recipient which has only
+      an <code>id</code> and no other properties can result in{" "}
+      <a href="/designing-workflows/channel-step">channel steps</a> other than
+      an In-app feed being skipped. This occurs when Knock does not have the
+      necessary recipient data to deliver a notification.
+    </>
+  }
+/>
+
+There are some reserved property names for recipients that have special meaning:
 
 - `name`: The given name of the recipient
 - `email`: A valid email address to deliver email notifications to

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -1222,11 +1222,11 @@ Workflow trigger endpoints enforce a `10MB` payload `data` limit.
 <Section title="Triggering a workflow with inline identifications" slug="trigger-workflow-inline-identify">
 <ContentColumn>
 
-In the `recipients` and `actor` fields in a trigger call, you can optionally include maps full of properties describing a user or an object. These can be properties describing a brand new user/object, or properties describing an update to an existing one. When this data is present in a notify call, Knock will persist it as part of processing the workflow. This is comparable to direct calls to the [identify user](#identify-user) or [set object](#set-object) APIs.
+In the `recipients` and `actor` fields in a trigger call, you can optionally include maps of properties describing a user or an object. These can be properties describing a brand new user/object, or properties describing an update to an existing one. When this data is present in a notify call, Knock will persist it as part of processing the workflow. This is comparable to direct calls to the [identify user](#identify-user) or [set object](#set-object) APIs.
 
 Each recipient and actor must have an `id` field set in addition to other properties (e.g. email, name, or phone number).
 
-See our guides on inline identification [for users](/send-and-manage-data/users#3-inline-identification) and [for objects](/send-and-manage-data/objects#3-set-objects-inline) for more details on this use case.
+See our guides on inline identification [for users](/managing-recipients/identifying-recipients#inline-identifying-recipients) and [for objects](/concepts/objects#3-set-objects-inline) for more details on this use case.
 
 ### Endpoint
 


### PR DESCRIPTION
### Description

This PR is meant to coincide with the update being made on KNO-5942. For the most part, the current state of the docs actually describe updated behavior (we didn't call out the currently-existing caveat for inline identification, where we do not upsert recipients that contain only an `id` when identified via that method), so there weren't many changes to make. However, I did add a callout of what can occur when a given recipient doesn't have the necessary properties to allow us to deliver a notification.

Also fixed one broken and one outdated link in the API ref.
