### PR TITLE
chore: add support for JS client-side SDK in multilang block

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -74,7 +74,7 @@ const LanguageLabel = {
   curl: "cURL",
   kotlin: "Kotlin",
   swift: "Swift",
-  jsweb: "JavaScript (Web SDK)", 
+  jsweb: "JavaScript (Web SDK)",
 };
 
 export interface Props {

--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -25,6 +25,7 @@ SyntaxHighlighter.registerLanguage("node", javascript);
 SyntaxHighlighter.registerLanguage("javascript", javascript);
 SyntaxHighlighter.registerLanguage("jsx", javascript);
 SyntaxHighlighter.registerLanguage("js", javascript);
+SyntaxHighlighter.registerLanguage("jsweb", javascript);
 SyntaxHighlighter.registerLanguage("ruby", ruby);
 SyntaxHighlighter.registerLanguage("elixir", elixir);
 SyntaxHighlighter.registerLanguage("csharp", dotnet);
@@ -54,7 +55,8 @@ export type SupportedLanguage =
   | "kotlin"
   | "swift"
   | "yaml"
-  | "curl";
+  | "curl"
+  | "jsweb";
 
 const LanguageLabel = {
   javascript: "JavaScript",
@@ -72,6 +74,7 @@ const LanguageLabel = {
   curl: "cURL",
   kotlin: "Kotlin",
   swift: "Swift",
+  jsweb: "JavaScript (Web SDK)", 
 };
 
 export interface Props {

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -120,6 +120,7 @@ const DEFAULT_ORDER: SupportedLanguage[] = [
   "curl",
   "shell",
   "node",
+  "jsweb",
   "ruby",
   "python",
   "php",


### PR DESCRIPTION
### Description

This PR add's support for `jsweb` examples in a multilang block (for any client-side JS SDK examples). 
