### PR TITLE
Fix bugs in Go docs snippets

### DIFF
--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -110,10 +110,10 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Recipients: []string{"1", "2"}
+  Recipients: []interface{"1", "2"}
 
   // optional
-  Data:            map[string]string{"project_name": "My Project"},
+  Data:            map[string]interface{"project_name": "My Project"},
   Actor:           "3",
   CancellationKey: "cancel_123"
   Tenant:          "jurassic_world_employees"

--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -110,16 +110,16 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Recipients: []interface{"1", "2"}
+  Recipients: []interface{}{"1", "2"},
 
   // optional
   Data:            map[string]interface{}{"project_name": "My Project"},
   Actor:           "3",
-  CancellationKey: "cancel_123"
-  Tenant:          "jurassic_world_employees"
+  CancellationKey: "cancel_123",
+  Tenant:          "jurassic_world_employees",
 },
 &knock.MethodOptions{
-  IdempotencyKey: "123"
+  IdempotencyKey: "123",
 })
 `,
   java: `

--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -113,7 +113,7 @@ result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
   Recipients: []interface{"1", "2"}
 
   // optional
-  Data:            map[string]interface{"project_name": "My Project"},
+  Data:            map[string]interface{}{"project_name": "My Project"},
   Actor:           "3",
   CancellationKey: "cancel_123"
   Tenant:          "jurassic_world_employees"

--- a/data/code/workflows/cancel-with-recipients.ts
+++ b/data/code/workflows/cancel-with-recipients.ts
@@ -64,11 +64,14 @@ $client->workflows()->cancel('new-user-invited', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Cancel(ctx, &knock.CancelWorkflowRequest{
+req := &knock.CancelWorkflowRequest{
   Workflow:        "new-user-invited",
   CancellationKey: userInvite.ID,
-  Recipients:      []string{"user_1"},
-})
+}
+
+req.AddRecipientByID("user_1")
+
+err := knockClient.Workflows.Cancel(ctx, req)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -99,13 +99,13 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Actor:      comment.Author.ID
+  Actor:      comment.Author.ID,
   Data: map[string]interface{}{
     "document_id":   document.ID,
     "document_name": document.Name,
     "comment_id":    comment.ID,
     "comment_text":  comment.Text,
-  }
+  },
 }
 
 for _, f := range followerIds {

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -97,17 +97,22 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Actor:      comment.Author.ID
-  Recipients: followerIds,
   Data: map[string]interface{}{
     "document_id":   document.ID,
     "document_name": document.Name,
     "comment_id":    comment.ID,
     "comment_text":  comment.Text,
-  },
-})
+  }
+}
+
+for _, f := range followerIds {
+  req.AddRecipientByID(f)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-attachment.ts
+++ b/data/code/workflows/trigger-with-attachment.ts
@@ -115,9 +115,8 @@ $client->workflows()->trigger('invoice-paid', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "invoice-paid",
-  Recipients: recipientIds,
   Data: map[string]interface{}{
     "attachments": []map[string]interface{
       {
@@ -127,7 +126,14 @@ result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
       }
     },
   },
-})
+}
+
+for _, r := range recipientIds {
+  req.AddRecipientByID(r)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-branding-tenant.ts
+++ b/data/code/workflows/trigger-with-branding-tenant.ts
@@ -79,14 +79,19 @@ $client->workflows()->trigger('reservation-reminder-email', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "reservation-reminder-email",
   Data: map[string]interface{}{
       "reservation_id": reservation.ID
   },
-  Recipients: reservationGuestIds,
   Tenant: "black-lodge"
-  })
+}
+
+for _, r := range reservationGuestIds {
+  request.AddRecipientByID(r)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
   `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -174,7 +174,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]string{"project_name": "My Project"},
+  Data: map[string]interface{"project_name": "My Project"},
   Actor: map[string]interface{}{
     "id": "1",
     "name": "John Hammond",

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -174,7 +174,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]interface{"project_name": "My Project"},
+  Data: map[string]interface{}{"project_name": "My Project"},
   Actor: map[string]interface{}{
     "id": "1",
     "name": "John Hammond",

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -172,7 +172,7 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]string{"project_name": "My Project"},
   Actor: map[string]interface{}{
@@ -181,20 +181,28 @@ result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
     "email": "jhammond@ingen.net"
   },
   Recipients: []map[string]interface{}{
-    map[string]interface{}{
-      "id": "project-1",
-      "collection": "projects",
-      "name": "My project",
-      "total_assets": 10,
-      "tags": []string{"cool", "fun", "project"},
-    },
-    map[string]interface{}{
-      "id": "2",
-      "name": "Ellie Sattler",
-      "email": "esattler@ingen.net"
-    },
   }
-})
+}
+
+req.AddRecipientByEntity(
+  map[string]interface{}{
+    "id": "project-1",
+    "collection": "projects",
+    "name": "My project",
+    "total_assets": 10,
+    "tags": []string{"cool", "fun", "project"},
+  }
+)
+
+req.AddRecipientByEntity(
+  map[string]interface{}{
+    "id": "2",
+    "name": "Ellie Sattler",
+    "email": "esattler@ingen.net",
+  }
+)
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-object-as-actor.ts
+++ b/data/code/workflows/trigger-with-object-as-actor.ts
@@ -69,12 +69,16 @@ request := &knock.TriggerWorkflowRequest{
   Recipients: followerIds,
 }
 
+for _, f := range followerIds {
+  request.AddRecipientByID(f)
+}
+
 request.AddActorByEntity(map[string]interface{}{
   "collection": "projects",
   "id":         project.ID 
 })
 
-result, _ := knockClient.Workflows.Trigger(ctx, request)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-object-as-actor.ts
+++ b/data/code/workflows/trigger-with-object-as-actor.ts
@@ -75,7 +75,7 @@ for _, f := range followerIds {
 
 request.AddActorByEntity(map[string]interface{}{
   "collection": "projects",
-  "id":         project.ID 
+  "id":         project.ID, 
 })
 
 result, _ := knockClient.Workflows.Trigger(ctx, request, nil)

--- a/data/code/workflows/trigger-with-object-as-recipient.ts
+++ b/data/code/workflows/trigger-with-object-as-recipient.ts
@@ -76,7 +76,7 @@ request := &knock.TriggerWorkflowRequest{
 
 request.AddRecipientByEntity(map[string]interface{}{
   "collection": "projects",
-  "id":         project.ID 
+  "id":         project.ID,
 })
 
 result, _ := knockClient.Workflows.Trigger(ctx, request, nil)

--- a/data/code/workflows/trigger-with-object-as-recipient.ts
+++ b/data/code/workflows/trigger-with-object-as-recipient.ts
@@ -70,9 +70,6 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-ctx := context.Background()
-knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
-
 request := &knock.TriggerWorkflowRequest{
   Workflow: "new-comment",
 }
@@ -82,7 +79,7 @@ request.AddRecipientByEntity(map[string]interface{}{
   "id":         project.ID 
 })
 
-result, _ := knockClient.Workflows.Trigger(ctx, request)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -156,7 +156,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]interface{"project_name": "My Project"},
+  Data: map[string]interface{}{"project_name": "My Project"},
 }
 
 request.AddRecipientByEntity(

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -154,26 +154,32 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]string{"project_name": "My Project"},
-  Recipients: []map[string]interface{}{
-    map[string]interface{}{
-      "id": "project-1",
-      "collection": "projects",
-      "name": "My project",
-      "total_assets": 10,
-      "tags": []string{"cool", "fun", "project"},
-    },
-    map[string]interface{}{
-      "id": "project-2",
-      "collection": "projects",
-      "name": "My second project",
-      "total_assets": 5,
-      "tags": []string{"very", "cool", "project"},
-    },
+}
+
+request.AddRecipientByEntity(
+  map[string]interface{}{
+    "id": "project-1",
+    "collection": "projects",
+    "name": "My project",
+    "total_assets": 10,
+    "tags": []string{"cool", "fun", "project"},
   }
-})
+)
+
+request.AddRecipientByEntity(
+  map[string]interface{}{
+    "id": "project-2",
+    "collection": "projects",
+    "name": "My second project",
+    "total_assets": 5,
+    "tags": []string{"very", "cool", "project"},
+  }
+)
+
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -156,7 +156,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]string{"project_name": "My Project"},
+  Data: map[string]interface{"project_name": "My Project"},
 }
 
 request.AddRecipientByEntity(

--- a/data/code/workflows/trigger-with-tenant.ts
+++ b/data/code/workflows/trigger-with-tenant.ts
@@ -97,9 +97,8 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Recipients: followerIds,
   Data: map[string]interface{}{
     "document_id":   document.ID,
     "document_name": document.Name,
@@ -107,7 +106,13 @@ result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
     "comment_text":  comment.Text,
   },
   Tenant: workspace.ID
-})
+}
+
+for _, f := range followerIds {
+  request.AddRecipientByID(f)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -147,21 +147,22 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 // Get this value in your Knock dashboard
 apnsChannelId := "some-channel-id-from-knock"
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]string{"project_name": "My Project"},
-  Recipients: []map[string]string{
-    map[string]string{
-      "id": "1",
-      "email": "jhammond@ingen.net",
-      "channel_data": map[string]map{
-        apnsChannelId: map[string]string {
-          "tokens": ["apns-push-token"]
-        }
-      }
-    },
-  }
+}
+
+req.AddRecipientByEntity(map[string]interface{}{
+  "id": "1",
+  "email": "jhammond@ingen.net",
+  "channel_data": map[string]map{
+    apnsChannelId: map[string]string {
+      "tokens": ["apns-push-token"]
+    }
+  },
 })
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -149,16 +149,16 @@ apnsChannelId := "some-channel-id-from-knock"
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]string{"project_name": "My Project"},
+  Data: map[string]interface{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{}{
   "id": "1",
   "email": "jhammond@ingen.net",
   "channel_data": map[string]map{
-    apnsChannelId: map[string]string {
+    apnsChannelId: map[string]interface {
       "tokens": ["apns-push-token"]
-    }
+    },
   },
 })
 

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -149,7 +149,7 @@ apnsChannelId := "some-channel-id-from-knock"
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]interface{"project_name": "My Project"},
+  Data: map[string]interface{}{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{}{

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -130,22 +130,26 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]string{"project_name": "My Project"},
   Recipients: []map[string]string{
-    map[string]string{
-      "id": "1",
-      "name": "John Hammond",
-      "email": "jhammond@ingen.net"
-    },
-    map[string]string{
-      "id": "2",
-      "name": "Ellie Sattler",
-      "email": "esattler@ingen.net"
-    },
   }
+}
+
+req.AddRecipientByEntity(map[string]interface{
+  "id": "1",
+  "name": "John Hammond",
+  "email": "jhammond@ingen.net",
 })
+
+req.AddRecipientByEntity(map[string]interface{
+  "id": "2",
+  "name": "Ellie Sattler",
+  "email": "esattler@ingen.net"
+})
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -132,7 +132,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]interface{"project_name": "My Project"},
+  Data: map[string]interface{}{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -132,9 +132,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]string{"project_name": "My Project"},
-  Recipients: []map[string]string{
-  }
+  Data: map[string]interface{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{
@@ -146,7 +144,7 @@ req.AddRecipientByEntity(map[string]interface{
 req.AddRecipientByEntity(map[string]interface{
   "id": "2",
   "name": "Ellie Sattler",
-  "email": "esattler@ingen.net"
+  "email": "esattler@ingen.net",
 })
 
 result, _ := knockClient.Workflows.Trigger(ctx, req, nil)

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -165,30 +165,33 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]string{"project_name": "My Project"},
   Recipients: []map[string]string{
-    map[string]string{
-      "id": "1",
-      "email": "jhammond@ingen.net",
-      "preferences": map[string]map{
-        "default": map[string]map {
-          "channel_types": map[string]boolean {
-            "email": true,
-            "sms": true
-          }
-        },
-        "{{ tenant.id }}": map[string]map {
-          "channel_types": map[string]boolean {
-            "email": false,
-            "sms": false
-          }
-        }
+  }
+}
+
+req.AddRecipientByEntity(map[string]interface{}{
+  "id": "1",
+  "email": "jhammond@ingen.net",
+  "preferences": map[string]map{
+    "default": map[string]map {
+      "channel_types": map[string]boolean {
+        "email": true,
+        "sms": true
       }
     },
-  }
+    "{{ tenant.id }}": map[string]map {
+      "channel_types": map[string]boolean {
+        "email": false,
+        "sms": false
+      }
+    }
+  },
 })
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -167,9 +167,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]string{"project_name": "My Project"},
-  Recipients: []map[string]string{
-  }
+  Data: map[string]interface{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{}{
@@ -180,13 +178,13 @@ req.AddRecipientByEntity(map[string]interface{}{
       "channel_types": map[string]boolean {
         "email": true,
         "sms": true
-      }
+      },
     },
     "{{ tenant.id }}": map[string]map {
       "channel_types": map[string]boolean {
         "email": false,
         "sms": false
-      }
+      },
     }
   },
 })

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -167,7 +167,7 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Data: map[string]interface{"project_name": "My Project"},
+  Data: map[string]interface{}{"project_name": "My Project"},
 }
 
 req.AddRecipientByEntity(map[string]interface{}{

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -98,9 +98,9 @@ req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
 
   // optional
-  Data:            map[string]string{"project_name": "My Project"},
+  Data:            map[string]interface{"project_name": "My Project"},
   Actor:           "3",
-  CancellationKey: "cancel_123"
+  CancellationKey: "cancel_123",
   Tenant:          "jurassic_world_employees",
 }
 

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -94,16 +94,21 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-result, _ := knockClient.Workflows.Trigger(ctx, &knock.TriggerWorkflowRequest{
+req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
-  Recipients: []string{"1", "2"}
 
   // optional
   Data:            map[string]string{"project_name": "My Project"},
   Actor:           "3",
   CancellationKey: "cancel_123"
-  Tenant:          "jurassic_world_employees"
-})
+  Tenant:          "jurassic_world_employees",
+}
+
+for _, r := range []string{"1", "2"} {
+  req.AddRecipientByID(r)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -98,7 +98,7 @@ req := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
 
   // optional
-  Data:            map[string]interface{"project_name": "My Project"},
+  Data:            map[string]interface{}{"project_name": "My Project"},
   Actor:           "3",
   CancellationKey: "cancel_123",
   Tenant:          "jurassic_world_employees",


### PR DESCRIPTION
### Description
Brings the docs improvements from the go sdk readme into our docs site (https://github.com/knocklabs/knock-go/pull/33)

Also fixes some other compilation errors in our go docs snippets. Most of my focus in this PR was on snippets related to workflow triggering, we should also audit the remaining go snippets.
