### PR TITLE
fix: refactor req -> request in go snippets

### DIFF
--- a/data/code/workflows/cancel-with-recipients.ts
+++ b/data/code/workflows/cancel-with-recipients.ts
@@ -64,14 +64,14 @@ $client->workflows()->cancel('new-user-invited', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.CancelWorkflowRequest{
+request := &knock.CancelWorkflowRequest{
   Workflow:        "new-user-invited",
   CancellationKey: userInvite.ID,
 }
 
-req.AddRecipientByID("user_1")
+request.AddRecipientByID("user_1")
 
-err := knockClient.Workflows.Cancel(ctx, req)
+err := knockClient.Workflows.Cancel(ctx, request)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -97,7 +97,7 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Actor:      comment.Author.ID,
   Data: map[string]interface{}{
@@ -109,10 +109,10 @@ req := &knock.TriggerWorkflowRequest{
 }
 
 for _, f := range followerIds {
-  req.AddRecipientByID(f)
+  request.AddRecipientByID(f)
 }
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-attachment.ts
+++ b/data/code/workflows/trigger-with-attachment.ts
@@ -115,7 +115,7 @@ $client->workflows()->trigger('invoice-paid', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "invoice-paid",
   Data: map[string]interface{}{
     "attachments": []map[string]interface{
@@ -129,10 +129,10 @@ req := &knock.TriggerWorkflowRequest{
 }
 
 for _, r := range recipientIds {
-  req.AddRecipientByID(r)
+  request.AddRecipientByID(r)
 }
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 
 `,
   java: `

--- a/data/code/workflows/trigger-with-branding-tenant.ts
+++ b/data/code/workflows/trigger-with-branding-tenant.ts
@@ -91,7 +91,7 @@ for _, r := range reservationGuestIds {
   request.AddRecipientByID(r)
 }
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
   `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -172,7 +172,7 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]interface{}{"project_name": "My Project"},
   Actor: map[string]interface{}{
@@ -184,7 +184,7 @@ req := &knock.TriggerWorkflowRequest{
   }
 }
 
-req.AddRecipientByEntity(
+request.AddRecipientByEntity(
   map[string]interface{}{
     "id": "project-1",
     "collection": "projects",
@@ -194,7 +194,7 @@ req.AddRecipientByEntity(
   }
 )
 
-req.AddRecipientByEntity(
+request.AddRecipientByEntity(
   map[string]interface{}{
     "id": "2",
     "name": "Ellie Sattler",
@@ -202,7 +202,7 @@ req.AddRecipientByEntity(
   }
 )
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -147,12 +147,12 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 // Get this value in your Knock dashboard
 apnsChannelId := "some-channel-id-from-knock"
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]interface{}{"project_name": "My Project"},
 }
 
-req.AddRecipientByEntity(map[string]interface{}{
+request.AddRecipientByEntity(map[string]interface{}{
   "id": "1",
   "email": "jhammond@ingen.net",
   "channel_data": map[string]map{
@@ -162,7 +162,7 @@ req.AddRecipientByEntity(map[string]interface{}{
   },
 })
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -130,24 +130,24 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]interface{}{"project_name": "My Project"},
 }
 
-req.AddRecipientByEntity(map[string]interface{
+request.AddRecipientByEntity(map[string]interface{
   "id": "1",
   "name": "John Hammond",
   "email": "jhammond@ingen.net",
 })
 
-req.AddRecipientByEntity(map[string]interface{
+request.AddRecipientByEntity(map[string]interface{
   "id": "2",
   "name": "Ellie Sattler",
   "email": "esattler@ingen.net",
 })
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -165,12 +165,12 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
   Data: map[string]interface{}{"project_name": "My Project"},
 }
 
-req.AddRecipientByEntity(map[string]interface{}{
+request.AddRecipientByEntity(map[string]interface{}{
   "id": "1",
   "email": "jhammond@ingen.net",
   "preferences": map[string]map{
@@ -189,7 +189,7 @@ req.AddRecipientByEntity(map[string]interface{}{
   },
 })
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -94,7 +94,7 @@ $client->workflows()->trigger('new-comment', [
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
-req := &knock.TriggerWorkflowRequest{
+request := &knock.TriggerWorkflowRequest{
   Workflow:   "new-comment",
 
   // optional
@@ -108,7 +108,7 @@ for _, r := range []string{"1", "2"} {
   req.AddRecipientByID(r)
 }
 
-result, _ := knockClient.Workflows.Trigger(ctx, req, nil)
+result, _ := knockClient.Workflows.Trigger(ctx, request, nil)
 `,
   java: `
 import app.knock.api.KnockClient;

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -105,7 +105,7 @@ request := &knock.TriggerWorkflowRequest{
 }
 
 for _, r := range []string{"1", "2"} {
-  req.AddRecipientByID(r)
+  request.AddRecipientByID(r)
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, request, nil)


### PR DESCRIPTION
### Description

Matt [spotted a bug in my previous PR](https://github.com/knocklabs/docs/pull/507/files#r1604009207). I've decided to change all instances of `req` to `request` for consistency in our Go snippets.

