### PR TITLE
chore: callout prefs ids in a few additional places

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -1405,6 +1405,8 @@ Cancel a delayed workflow for one or more recipients.
 A preference determines whether a recipient should receive a particular type of notification. By default
 all preferences are opted in unless a preference explicitly opts the recipient out of the notification.
 
+The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about [per-tenant preferences](/preferences/tenant-preferences).
+
 [Read more about Preferences](/send-and-manage-data/preferences).
 
 ### Attributes
@@ -1682,6 +1684,8 @@ Returns a `PreferenceSet`.
 <ContentColumn>
 
 Bulk sets the preferences for up to 1000 users at a time. Returns a `BulkOperation` that executes the job asynchronously. Progress can be tracked via the [BulkOperation API](#bulk-operations).
+
+The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about [per-tenant preferences](/preferences/tenant-preferences).
 
 Please note: This is a destructive operation and will replace any existing users' preferences with the preferences sent.
 


### PR DESCRIPTION
### Description

Explicitly call out need for `PreferenceSet` id to be `default` or `tenant.id` in a few additional places in the API ref

