### PR TITLE
chore: clarify current lack of support for Object feeds

### DIFF
--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -19,15 +19,15 @@ Objects are a powerful and flexible way to ensure Knock always has the most up-t
 
 You can use objects to:
 
-- send out-of-app notifications to non-user recipients (such as a Slack channel)
-- send in-app notifications to non-user resources in your product (the activity feed you see on a Notion page is a good example)
-- reference mutable data in your notification templates (such as when a user edits a comment before a notification is sent)
+- Send out-of-app notifications to non-user recipients (such as a Slack channel).
+- Reference mutable data in your notification templates (such as when a user edits a comment before a notification is sent).
+- **Coming soon:** send in-app notifications to non-user resources in your product (the activity feed you see on a Notion page is a good example).
 
 <Callout
   emoji="🛣"
   text={
     <>
-      <span className="font-bold">Knock roadmap alert.</span> We have objects
+      <span className="font-bold">Knock roadmap alert.</span> We have Objects
       API support for in-app notifications and mutable data referencing on our
       near-term roadmap.
       <br />


### PR DESCRIPTION
### Description

This PR updates the Objects concept page to make it clearer that support for an Object recipient of an in-app feed is not currently available but on the roadmap. Current state seems to indicate that it's possible in the list, and only mentions that it isn't yet available in the roadmap callout below.