### PR TITLE
fix: add missing path param for get user subscriptions

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4768,6 +4768,16 @@ Returns a paginated list of subscriptions for a single user, in descending order
 
 <RateLimit tier={4} />
 
+### Path parameters
+
+<Attributes>
+  <Attribute
+    name="id"
+    type="string"
+    description="The unique identifier of the User"
+  />
+</Attributes>
+
 ### Query parameters
 
 <Attributes>


### PR DESCRIPTION
### Description

Adds missing description for `:id` path parameter on `GET /users/:id/subscriptions` endpoint
