### PR TITLE
fix: remove 404 link

### DIFF
--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -38,7 +38,7 @@ You can use the individual identification API to upsert a single recipient's dat
 
 ### Bulk identifying recipients
 
-While identifying individual recipients is useful, you may also need to identify multiple recipients at once. This can be useful when you're [importing data](/managing-recipients/importing-recipient) into Knock to get started.
+While identifying individual recipients is useful, you may also need to identify multiple recipients at once. This can be useful when you're importing data into Knock to get started.
 
 <MultiLangCodeBlock snippet="users.bulkIdentify" title="Bulk identify users" />
 

--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -131,9 +131,9 @@ Below we discuss some common scenarios to consider.
 
 ### Initial setup: inline vs. bulk identification
 
-When you're first getting started with Knock, you'll likely have a number of existing recipients that you want to migrate into Knock. If you're looking to get started with Knock quickly, you can use [inline identification](#3-inline-identification) to start calling your workflows without any prerequisite calls to the Knock API.
+When you're first getting started with Knock, you'll likely have a number of existing recipients that you want to migrate into Knock. If you're looking to get started with Knock quickly, you can use [inline identification](#inline-identifying-recipients) to start calling your workflows without any prerequisite calls to the Knock API.
 
-If you first want to get all your recipients into Knock, the easiest path forward would be via our [bulk identification flow](#2-bulk-identification).
+If you first want to get all your recipients into Knock, the easiest path forward would be via our [bulk identification flow](#bulk-identifying-recipients).
 
 ### Identifying recipients on an ongoing basis: jobs vs. inline identification
 


### PR DESCRIPTION
### Description
User called out a 404 with this link, looks like it's pointing to an old page in the same section that should have been redirected, so just removed it
