### PR TITLE
feature: add nuxt app card to example apps

### DIFF
--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -8,6 +8,7 @@ import {
   FaReact,
   FaSwift,
   FaAngular,
+  FaVuejs,
 } from "react-icons/fa";
 import { DiRuby, DiDotnet } from "react-icons/di";
 import { FaGolang } from "react-icons/fa6";
@@ -32,7 +33,8 @@ export type SupportedIcon =
   | "kotlin"
   | "flutter"
   | "reactnative"
-  | "angular";
+  | "angular"
+  | "vue";
 
 const icons = {
   default: <IoCubeOutline />,
@@ -51,6 +53,7 @@ const icons = {
   flutter: <SiFlutter />,
   reactnative: <TbBrandReactNative />,
   angular: <FaAngular />,
+  vue: <FaVuejs />,
 };
 
 type Props = {

--- a/content/getting-started/example-apps.mdx
+++ b/content/getting-started/example-apps.mdx
@@ -31,6 +31,13 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
     languages={["React", "Next.js"]}
     isExternal={true}
   />
+  <SdkCard
+    title="In-app feed & toasts"
+    linkUrl="https://github.com/knocklabs/nuxt-feed-example"
+    icon="vue"
+    languages={["Vue.js", "Nuxt"]}
+    isExternal={true}
+  />
 </SdkCardGroup>
 
 ## Slack examples


### PR DESCRIPTION
### Description
Adds an SDK card for the Vue/Next app example and adds a Vue icon to the supported icons
