### PR TITLE
feature: add video and card

### DIFF
--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -9,6 +9,7 @@ import {
   FaSwift,
   FaAngular,
   FaVuejs,
+  FaYoutube,
 } from "react-icons/fa";
 import { DiRuby, DiDotnet } from "react-icons/di";
 import { FaGolang } from "react-icons/fa6";
@@ -34,7 +35,8 @@ export type SupportedIcon =
   | "flutter"
   | "reactnative"
   | "angular"
-  | "vue";
+  | "vue"
+  | "youtube";
 
 const icons = {
   default: <IoCubeOutline />,
@@ -54,6 +56,7 @@ const icons = {
   reactnative: <TbBrandReactNative />,
   angular: <FaAngular />,
   vue: <FaVuejs />,
+  youtube: <FaYoutube />,
 };
 
 type Props = {

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -95,6 +95,14 @@ There are two methods available to you to translate your message templates: the 
 
 We cover how to use the `t` filter and `t` tag in more detail below.
 
+<SdkCard
+  title="Video walkthrough"
+  linkUrl="https://www.youtube.com/watch?v=8VAFqj5qqPI"
+  icon="youtube"
+  languages={["Explore Knock's translation model", "5 min. watch time"]}
+  isExternal={true}
+/>
+
 ## Using the `t` filter
 
 You can use `t` filter to reference your translations from within a message template. The `t` filter also allows you to use variables, other filters, and special pluralization rules.


### PR DESCRIPTION
### Description
<img width="773" alt="Screenshot 2024-05-31 at 9 20 30 AM" src="https://github.com/knocklabs/docs/assets/7818951/67b660ea-937e-4432-9fff-e47be5be2938">

This adds a new icon option to the SDK card and uses it to call out videos where we have them. I think embedding most videos it too disruptive, but in some cases where the concept is complex a link might not be suggestive enough, so this is a nice-looking middle ground. 

Open to feedback here though cause it's still somewhat in your face

