### PR TITLE
fix: hot reloading and hydration errors when editing docs locally

### DIFF
--- a/components/SupportModal.tsx
+++ b/components/SupportModal.tsx
@@ -95,9 +95,9 @@ const SupportModal: React.FC<Props> = ({ currentUser, currentAccount }) => {
         </Dialog.Trigger>
 
         <Dialog.Portal>
-          <Dialog.Overlay className="fixed inset-0 bg-black/50 " />
+          <Dialog.Overlay className="fixed inset-0 z-10 bg-black/50 " />
           <Dialog.Title />
-          <Dialog.Content className="text-gray-900 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md shadow-sm">
+          <Dialog.Content className="text-gray-900 z-50 fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md shadow-sm">
             <div className="py-4 px-6">
               <Dialog.Title>
                 <div className="flex flex-column items-center justify-between">

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -320,7 +320,7 @@ You can learn more about automating translation management in the [Knock CLI ref
 
 ## Supported locales
 
-Below is a list of the available locales to choose from for your translations. If you need one added, contact us at <a href="mailto:support@knock.app">support@knock.app</a>.
+Below is a list of the available locales to choose from for your translations. If you need one added, contact us at support@knock.app.
 
 <AccordionGroup>
   <Accordion title="Supported locales">

--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -75,8 +75,8 @@ You can add a **track event** as a trigger to your workflow directly from the wo
         </pre>
       </div>
       and you wanted the commenter from the action to appear as the{" "}
-      <text className="font-bold">Actor</text> in the workflow, then in the{" "}
-      <text className="font-bold">Actor</text> field you would write{" "}
+      <span className="font-bold">Actor</span> in the workflow, then in the{" "}
+      <span className="font-bold">Actor</span> field you would write{" "}
       <code>data.commenter.id</code> to supply their ID as the actor.
     </>
   }

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,10 @@
+const path = require("path");
+
+// Refresh the site when content changes
+const withRemoteRefresh = require("next-remote-refresh")({
+  paths: [path.resolve(__dirname, "content")],
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
@@ -323,4 +330,4 @@ const nextConfig = {
   },
 };
 
-module.exports = nextConfig;
+module.exports = withRemoteRefresh(nextConfig);

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^7.31.0",
+    "next-remote-refresh": "^0.10.0",
     "postcss": "^8.4.31",
     "prettier": "^2.3.2",
     "rehype-autolink-headings": "^7.0.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React, { useRouter } from "next/router";
 import { ThemeProvider } from "next-themes";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import * as analytics from "../lib/analytics";
 import {
   EventEmitterContext,
@@ -9,12 +9,16 @@ import {
 
 import * as gtag from "../lib/gtag";
 import { setClearbitPath } from "../lib/clearbit";
+import { useRemoteRefresh } from "next-remote-refresh/hook";
 
 import "../styles/index.css";
 
 function App({ Component, pageProps }) {
   const router = useRouter();
   const eventEmitter = useEventEmitterInstance();
+
+  // Refresh when content pages change
+  useRemoteRefresh();
 
   useEffect(() => {
     const handleRouteChange = (url: URL) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3653,6 +3653,21 @@ chokidar@^3.4.0, chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@^3.5.2:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 classnames@^2.2.6:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
@@ -5771,11 +5786,6 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-unicode-supported@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz#d824984b616c292a2e198207d4a609983842f714"
-  integrity sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==
-
 is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
@@ -7179,6 +7189,14 @@ next-mdx-remote@^4.4.1:
     "@mdx-js/react" "^2.2.1"
     vfile "^5.3.0"
     vfile-matter "^3.0.1"
+
+next-remote-refresh@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/next-remote-refresh/-/next-remote-refresh-0.10.0.tgz#fd25079ad71bcfaddb8a0d10dee6bb81bf087fd6"
+  integrity sha512-x+JjCdH9bjjn5VjBpwnkdWTNXDNzENduZCy1gQJn9J5Ndl5eKlx4M9YQSjH3ywBfKCyLvOa5dstwUrOwNykjuA==
+  dependencies:
+    chokidar "^3.5.2"
+    ws "^8.2.3"
 
 next-remote-watch@^2.0.0:
   version "2.0.0"
@@ -9406,6 +9424,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.2.3:
+  version "8.17.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.0.tgz#d145d18eca2ed25aaf791a183903f7be5e295fea"
+  integrity sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==
 
 xregexp@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
### Description
- Hot reloads docs when editing content in the `/content` folder
- Fixes a hydration error on the translations page caused by nested anchor tags. I clicked through every page and didn't see any other hydration errors pop up. 
- Fixes an issue with the support overlay where the sidebar was rendering on top of the overlay where it should be behind it. 


### Tasks
[KNO-6060](https://linear.app/knock/issue/KNO-6060/%5Bdocs%5D-fix-hydration-errors-when-editing-docs-locally)