### PR TITLE
chore: extend clickable link area to full card size

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -28,12 +28,12 @@ const Card: React.FC<Props> = ({
   linkUrl,
   isExternal = false,
 }) => (
-  <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors p-3">
+  <div className="rounded-md border border-gray-200 hover:border-gray-400 dark:border-gray-600 hover:dark:border-gray-400 transition-colors h-full flex">
     <a
       target={isExternal ? "_blank" : undefined}
       href={linkUrl}
       title={title}
-      className="!no-underline !text-inherit"
+      className="!no-underline !text-inherit w-full p-3"
     >
       <>
         {emoji && <div className="mb-1">{emoji}</div>}


### PR DESCRIPTION
### Description

Extends the "clickable" area of the `Card` component to the edge of the card. Right now, the padding is between the "link" area and the border of the card, so you can hover on the edge of the button and not be able to click it.

Old: https://docs.knock.app/sdks/overview
New: https://docs-git-mk-sdk-card-click-area-knocklabs.vercel.app/sdks/overview