### PR TITLE
chore: add docs for new actionable in-app notifs

### DIFF
--- a/content/in-app-ui/api-overview.mdx
+++ b/content/in-app-ui/api-overview.mdx
@@ -281,6 +281,6 @@ In-app notification messages (`FeedItem`) are "actionable" and can be one of thr
 - **Single-action**: indicates that the notification cell has a single action button that can be clicked.
 - **Multi-action**: indicates that the notification cell has both a primary and secondary set of actions that can be clicked.
 
-Working with actionable notifications is straightforward. If you're using out-of-the-box Knock UI components, we'll handle the rendering of actionable notifications for you. 
+Working with actionable notifications is straightforward. If you're using out-of-the-box Knock UI components, we'll handle the rendering of actionable notifications for you.
 
 If you're building a custom feed implementation, you can check the `blocks` attribute for the presence of a `ButtonSetContentBlock` and render the `buttons` contained within the block accordingly.

--- a/content/in-app-ui/api-overview.mdx
+++ b/content/in-app-ui/api-overview.mdx
@@ -281,6 +281,6 @@ In-app notification messages (`FeedItem`) are "actionable" and can be one of thr
 - **Single-action**: indicates that the notification cell has a single action button that can be clicked.
 - **Multi-action**: indicates that the notification cell has both a primary and secondary set of actions that can be clicked.
 
-Working with actionable notifications is straightforward. When rendering the in-app message, you can check the `blocks` attribute for the presence of a `ButtonSetContentBlock` and render the `buttons` contained within the block accordingly.
+Working with actionable notifications is straightforward. If you're using out-of-the-box Knock UI components, we'll handle the rendering of actionable notifications for you. 
 
-If you're using out-of-the-box Knock UI components, we'll handle the rendering of actionable notifications for you.
+If you're building a custom feed implementation, you can check the `blocks` attribute for the presence of a `ButtonSetContentBlock` and render the `buttons` contained within the block accordingly.

--- a/content/in-app-ui/api-overview.mdx
+++ b/content/in-app-ui/api-overview.mdx
@@ -2,6 +2,7 @@
 title: In-app APIs and real-time service
 description: Learn more about the capabilities of Knock's in-app APIs and real-time services, and how these can power robust in-app notification experiences with little effort.
 section: Building in-app UI
+tags: ["FeedItem", "MessageContent", "actionable notifications", "real-time delivery", "in-app notifications", "in-app messages", "in-app feed", "in-app channel", "in-app API", "in-app SDK"]
 ---
 
 Knock provides a complete set of APIs to render your in-app notifications with the Knock-powered in-app channel. These APIs cover:
@@ -160,6 +161,12 @@ Requests to the feed endpoint will return an array of `FeedItems`. Each feed ite
 
 Each in-app message will contain the contents of the message template that was used to generate the message, which you can use to display your in-app notifications. You'll find this content under the `blocks` attribute on each `FeedItem` returned. Each block includes:
 
+Each `ContentBlock` is one of: `MarkdownContentBlock`, `TextContentBlock`, `ButtonSetContentBlock` defined by the `type` attribute.
+
+#### `MarkdownContentBlock`
+
+Represents a markdown content block that will have rendered HTML content.
+
 <Attributes>
   <Attribute
     name="key"
@@ -167,23 +174,90 @@ Each in-app message will contain the contents of the message template that was u
     description="A unique key for the block."
   />
   <Attribute
-    name="type"
-    type="markdown | string"
-    description="The type of block."
-  />
-  <Attribute
     name="rendered"
     type="string"
-    description="The complete rendered content for the block."
+    description="The rendered liquid content as HTML."
   />
   <Attribute
     name="content"
     type="string"
-    description="The liquid template associated with the block."
+    description="The markdown liquid template string."
+  />
+  <Attribute
+    name="type"
+    type="markdown"
+    description="The type of block."
   />
 </Attributes>
 
-**Note**: when the block type is `markdown`, the `rendered` content will always be HTML that should be rendered for the in-app message.
+#### `TextContentBlock`
+
+Represents a plaintext content block.
+
+<Attributes>
+  <Attribute
+    name="key"
+    type="string"
+    description="A unique key for the block."
+  />
+  <Attribute
+    name="rendered"
+    type="string"
+    description="The rendered liquid content as plaintext."
+  />
+  <Attribute
+    name="content"
+    type="string"
+    description="The plaintext liquid template string."
+  />
+  <Attribute
+    name="type"
+    type="text"
+    description="The type of block."
+  />
+</Attributes>
+
+#### `ButtonSetContentBlock`
+
+Represents a set of one or more buttons that can be rendered in the in-app message.
+
+<Attributes>
+  <Attribute
+    name="key"
+    type="string"
+    description="A unique key for the block."
+  />
+  <Attribute
+    name="buttons"
+    type="ActionButton[]"
+    description="A list of buttons to render in the block."
+  />
+  <Attribute
+    name="type"
+    type="button_set"
+    description="The type of block."
+  />
+</Attributes>
+
+Each button set block will contain an array of `ActionButton` objects. Each button includes:
+
+<Attributes>
+  <Attribute
+    name="name"
+    type="string"
+    description="One of primary or secondary."
+  />
+  <Attribute
+    name="label"
+    type="string"
+    description="The label to show on the button."
+  />
+  <Attribute
+    name="action"
+    type="string"
+    description="The URI for this action."
+  />
+</Attributes>
 
 ### Passing through data
 
@@ -198,3 +272,15 @@ It's also possible to override the response of the in-app API to hide sensitive 
 ## Message statuses
 
 All messages returned from the in-app channel adhere to our message status and engagement APIs. That means it's possible to programmatically mark the messages as seen, read, interacted with, or archived. You can read more in our [message status documentation](/send-notifications/message-statuses), or read more on how we use these message statuses [on the in-app channel](/integrations/in-app/knock#how-the-knock-in-app-feed-uses-status).
+
+## Working with actionable notifications
+
+In-app notification messages (`FeedItem`) are "actionable" and can be one of three types:
+
+- **Standard**: indicates that the entire cell is potentially actionable (e.g., clicking anywhere on the cell will trigger an action).
+- **Single-action**: indicates that the notification cell has a single action button that can be clicked.
+- **Multi-action**: indicates that the notification cell has both a primary and secondary set of actions that can be clicked.
+
+Working with actionable notifications is straightforward. When rendering the in-app message, you can check the `blocks` attribute for the presence of a `ButtonSetContentBlock` and render the `buttons` contained within the block accordingly.
+
+If you're using out-of-the-box Knock UI components, we'll handle the rendering of actionable notifications for you.

--- a/content/in-app-ui/api-overview.mdx
+++ b/content/in-app-ui/api-overview.mdx
@@ -2,7 +2,19 @@
 title: In-app APIs and real-time service
 description: Learn more about the capabilities of Knock's in-app APIs and real-time services, and how these can power robust in-app notification experiences with little effort.
 section: Building in-app UI
-tags: ["FeedItem", "MessageContent", "actionable notifications", "real-time delivery", "in-app notifications", "in-app messages", "in-app feed", "in-app channel", "in-app API", "in-app SDK"]
+tags:
+  [
+    "FeedItem",
+    "MessageContent",
+    "actionable notifications",
+    "real-time delivery",
+    "in-app notifications",
+    "in-app messages",
+    "in-app feed",
+    "in-app channel",
+    "in-app API",
+    "in-app SDK",
+  ]
 ---
 
 Knock provides a complete set of APIs to render your in-app notifications with the Knock-powered in-app channel. These APIs cover:
@@ -183,11 +195,7 @@ Represents a markdown content block that will have rendered HTML content.
     type="string"
     description="The markdown liquid template string."
   />
-  <Attribute
-    name="type"
-    type="markdown"
-    description="The type of block."
-  />
+  <Attribute name="type" type="markdown" description="The type of block." />
 </Attributes>
 
 #### `TextContentBlock`
@@ -210,11 +218,7 @@ Represents a plaintext content block.
     type="string"
     description="The plaintext liquid template string."
   />
-  <Attribute
-    name="type"
-    type="text"
-    description="The type of block."
-  />
+  <Attribute name="type" type="text" description="The type of block." />
 </Attributes>
 
 #### `ButtonSetContentBlock`
@@ -232,11 +236,7 @@ Represents a set of one or more buttons that can be rendered in the in-app messa
     type="ActionButton[]"
     description="A list of buttons to render in the block."
   />
-  <Attribute
-    name="type"
-    type="button_set"
-    description="The type of block."
-  />
+  <Attribute name="type" type="button_set" description="The type of block." />
 </Attributes>
 
 Each button set block will contain an array of `ActionButton` objects. Each button includes:

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -124,7 +124,9 @@ You can add a button click handler to respond to clicks on the buttons in the no
 ```jsx
 import { NotificationFeed } from "@knocklabs/react";
 
-<NotificationFeed onNotificationButtonClick={(item, button) => doSomething()} />;
+<NotificationFeed
+  onNotificationButtonClick={(item, button) => doSomething()}
+/>;
 ```
 
 ### Rendering a different notification cell in the feed
@@ -199,7 +201,7 @@ import { KnockFeedProvider } from "@knocklabs/react";
 
 For more advanced use cases, you may need to render custom components as part of the notification cell, but don't need to override the cell entirely. For this use case, you can use the `children` prop to render custom components inside the notification cell.
 
-```jsx
+````jsx
 import {
   NotificationFeed,
   NotificationCell,
@@ -249,7 +251,7 @@ import { KnockFeedProvider } from "@knocklabs/react";
     auto_manage_socket_connection_delay: 2500,
   }}
 />;
-```
+````
 
 ### Customizing the feed styling
 

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -117,7 +117,17 @@ import { NotificationFeed } from "@knocklabs/react";
 
 Both the `NotificationFeed` and the `NotificationFeedPopover` take a `onNotificationClick` prop.
 
-#### Rendering a different notification cell in the feed
+### Add an `onButtonClick` handler to the notification cell
+
+You can add a button click handler to respond to clicks on the buttons in the notification cell. The `onNotificationButtonClick` prop is available on the `NotificationFeed` component:
+
+```jsx
+import { NotificationFeed } from "@knocklabs/react";
+
+<NotificationFeed onNotificationButtonClick={(item, button) => doSomething()} />;
+```
+
+### Rendering a different notification cell in the feed
 
 You can customize the rendering of a notification cell in the feed by overriding the `renderItem` prop.
 
@@ -185,18 +195,12 @@ import { KnockFeedProvider } from "@knocklabs/react";
 <KnockFeedProvider colorMode="dark" />;
 ```
 
-### Adding inline actions
+### Rendering custom components in a notification cell
 
-For more advanced use cases, you may need to provide inline actions on your notifications. The `NotificationCell` component accepts a `children` prop in order for you to render actions. You'll need to override the `renderItem` prop on the `NotificationFeed` or `NotificationFeedPopover` to render the custom notification cell.
-
-#### Using action buttons
-
-We ship `Button` and `ButtonGroup` components, which have a complementary set of styling for the rest of the feed. You can render the buttons in a button group so that they'll be grouped together, or can render them individually.
+For more advanced use cases, you may need to render custom components as part of the notification cell, but don't need to override the cell entirely. For this use case, you can use the `children` prop to render custom components inside the notification cell.
 
 ```jsx
 import {
-  ButtonGroup,
-  Button,
   NotificationFeed,
   NotificationCell,
 } from "@knocklabs/react";
@@ -204,48 +208,10 @@ import {
 <NotificationFeed
   renderItem={({ item, ...props }) => (
     <NotificationCell {...props} item={item}>
-      <ButtonGroup>
-        <Button variant="primary" onClick={myAcceptHandler}>
-          Accept
-        </Button>
-        <Button variant="secondary" onClick={myRejectHandler}>
-          Reject
-        </Button>
-      </ButtonGroup>
+      <MyCustomComponent />
     </NotificationCell>
   )}
 />;
-```
-
-**Note**: remember to call `event.stopPropagation` in your `onClick` handler to stop the notification `onClick` handler from being invoked.
-
-#### Targeting a specific workflow to have buttons
-
-A common use case is to only show action buttons for certain workflows. You can achieve this via the `item.source` property, which exposes a `WorkflowSource`:
-
-```jsx
-import {
-  ButtonGroup,
-  Button,
-  NotificationFeed,
-  NotificationCell,
-} from "@knocklabs/react";
-
-<NotificationFeed
-  renderItem={({ item, ...props }) => (
-    <NotificationCell {...props} item={item}>
-      {item.source.key === "approval-workflow" && (
-        <ButtonGroup>
-          <Button variant="primary">Accept</Button>
-          <Button variant="secondary">Reject</Button>
-        </ButtonGroup>
-      )}
-    </NotificationCell>
-  )}
-/>;
-```
-
-You can find a full list of the props available for the [`Button` component here](/in-app-ui/react/reference#button).
 
 ### Handling cross-browser feed synchronization
 

--- a/content/sdks/react/reference.mdx
+++ b/content/sdks/react/reference.mdx
@@ -401,6 +401,11 @@ A provider to inject translations into components.
     description="A custom function to be invoked when a notification cell is clicked."
   />
   <Attribute
+    name="onNotificationButtonClick"
+    type="function"
+    description="A custom function to be invoked when an action button in a notification cell is clicked."
+  />
+  <Attribute
     name="onMarkAllAsReadClick"
     type="function"
     description="A custom function to be invoked when the `Mark all as read` button is clicked."
@@ -461,7 +466,12 @@ Accepts the same base props as `NotificationFeed`, and overrides with the follow
   <Attribute
     name="onItemClick"
     type="function"
-    description="The function to be invoked when the row is clicked"
+    description="The function to be invoked when the notification cell is clicked"
+  />
+  <Attribute
+    name="onButtonClick"
+    type="function"
+    description="The function to be invoked when a button rendered in the notification cell is clicked"
   />
   <Attribute
     name="avatar"


### PR DESCRIPTION
### Description

- Adds reference for types for new block types
- Removes inline actions callout
- Adds reference for new `onNotificationButtonClick` events

### Tasks

KNO-6136
