### PR TITLE
Fix: update argument name for Python set_tenant example

### DIFF
--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -36,7 +36,7 @@ client = Knock(api_key="sk_12345")
 
 client.tenants.set_tenant(
   id="tenant-1",
-  data={
+  tenant_data={
     "name": "Tenant 1",
     "settings": {
       "branding": {


### PR DESCRIPTION
### Description

Changes `data` to `tenant_data` for the `set_tenant` function to align with what is required ([SDK def](https://github.com/knocklabs/knock-python/blob/2c54be2de1cd37e26816a07d46fa82e75cd91e3d/knockapi/resources/tenants.py#L32)).

https://docs-git-rt-python-set-tenant-fix-knocklabs.vercel.app/concepts/tenants#syncing-tenant-data-to-knock