### PR TITLE
chore: add video card to quickstart

### DIFF
--- a/content/in-app-ui/react/preferences.mdx
+++ b/content/in-app-ui/react/preferences.mdx
@@ -6,6 +6,13 @@ section: Building in-app UI
 
 In this guide we'll build a `PreferenceCenter` React component with Knock's preference APIs. This component should be flexible enough to handle most of your needs and can easily be customized or extended for more specific use cases.
 
+<SdkCard
+  title="Video walkthrough"
+  linkUrl="https://www.youtube.com/watch?v=FCQGquTJlL0"
+  icon="youtube"
+  languages={["Explore Knock's preferences API", "17 min. watch time"]}
+  isExternal={true}
+/>
 ## Getting started
 
 Before beginning this tutorial, we'd recommend reading the [preferences overview docs](/preferences/overview) and creating a [default `PreferenceSet`](/preferences/overview#create-a-default-preferenceset) for your environment. The [API reference for preferences](/reference#preferences) can also be helpful, but is not required for this tutorial.


### PR DESCRIPTION
### Description
Adds a video card to the preferences quickstart page
<img width="788" alt="Screenshot 2024-06-10 at 4 50 37 PM" src="https://github.com/knocklabs/docs/assets/7818951/fab6570a-f80d-4505-abe0-65d28fb59cfe">
