### PR TITLE
fix: update toast code example

### DIFF
--- a/content/in-app-ui/react/toasts.mdx
+++ b/content/in-app-ui/react/toasts.mdx
@@ -75,7 +75,13 @@ const NotificationToaster = () => {
     // Whenever we receive a new notification from our real-time stream, show a toast
     // (note here that we can receive > 1 items in a batch)
     items.forEach((notification) => {
-      toast(notification.blocks[0].rendered, { id: notification.id });
+      //Use toast.custom to render the HTML content of the notification
+      toast.custom(
+        <div
+          dangerouslySetInnerHTML={{ __html: notification.blocks[0].rendered }}
+        ></div>,
+        { id: notification.id },
+      );
     });
 
     // Optionally, you may want to mark them as "seen" as well


### PR DESCRIPTION
### Description
A user in Slack pointed out that the previous example renders the block content as an HTML string, which is the default behavior of the lib, so I made this example use `toast.custom` function to actually render the HTML of the in-app template
