### PR TITLE
fix: typo on `message_ids` filter

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -887,7 +887,7 @@ Retrieve a paginated list of messages for a user. Will return most recent messag
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
-    name="messge_ids[]"
+    name="message_ids[]"
     type="string[] (optional)"
     description="Limits the results to only the message ids given (max 50). Note: when using this option, the results will be subject to any other filters applied to the query."
   />


### PR DESCRIPTION
### Description

fix "message" typo.
