### PR TITLE
fix: typos in API ref

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -2857,7 +2857,7 @@ Returns a paginated list of messages.
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
-    name="messge_ids[]"
+    name="message_ids[]"
     type="string[] (optional)"
     description="Limits the results to only the message ids given (max 50). Note: when using this option, the results will be subject to any other filters applied to the query."
   />
@@ -3986,7 +3986,7 @@ Returns a paginated list of messages for an object. Will return newest messages 
     description="Limits the results to only items that belong to the channel"
   />
   <Attribute
-    name="messge_ids[]"
+    name="message_ids[]"
     type="string[] (optional)"
     description="Limits the results to only the message ids given (max 50). Note: when using this option, the results will be subject to any other filters applied to the query."
   />


### PR DESCRIPTION
### Description

Two more instances of `messge` instead of `message`
