### PR TITLE
fix: remove growth plan from SAML 2.0 SSO documentation

### DIFF
--- a/content/manage-your-account/authentication-methods.mdx
+++ b/content/manage-your-account/authentication-methods.mdx
@@ -25,4 +25,4 @@ Users can authenticate with their chosen corporate identity provider (i.e. Okta)
 
 Once SSO is enabled for an account, all members are redirected through that identity provider's authentication flow. Moving forward, they must pass through SSO to access their Knock account.
 
-**Note**: SAML 2.0 SSO is only available to **Growth** and **Enterprise** plan customers. Enabling SAML 2.0 SSO will force all members of your account on a matching domain to authenticate via your identity provider.
+**Note**: SAML 2.0 SSO is only available to **Enterprise** plan customers. Enabling SAML 2.0 SSO will force all members of your account on a matching domain to authenticate via your identity provider.


### PR DESCRIPTION
### Description

SAML 2.0 SSO is only available on Enterprise-level plans.