### PR TITLE
chore: add `scheduled_at` to Schedules reference

### DIFF
--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -71,15 +71,15 @@ const schedules = await knock.workflows.createSchedules("park-alert", {
 
 ### Schedule properties
 
-| Variable       | Type                  | Description                                                                                                                                     |
-| -------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `recipients`   | RecipientIdentifier[] | One or more recipient identifiers, or complete recipients to be upserted.                                                                       |
-| `workflow`     | string                | The workflow to trigger.                                                                                                                        |
-| `repeats`      | ScheduleRepeat[]      | A list of one or more repeats (see below). Required if you're creating a recurring schedule.                                                    |
-| `data`         | map                   | Custom data to pass to every workflow trigger.                                                                                                  |
-| `tenant`       | string                | A tenant to pass to the workflow trigger.                                                                                                       |
-| `actor`        | RecipientIdentifier   | An identifier of an actor, or a complete actor to be upserted.                                                                                  |
-| `scheduled_at` | utc_datetime          | A UTC datetime representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule. |
+| Variable       | Type                  | Description                                                                                                                                                        |
+| -------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `recipients`   | RecipientIdentifier[] | One or more recipient identifiers, or complete recipients to be upserted.                                                                                          |
+| `workflow`     | string                | The workflow to trigger.                                                                                                                                           |
+| `repeats`      | ScheduleRepeat[]      | A list of one or more repeats (see below). Required if you're creating a recurring schedule.                                                                       |
+| `data`         | map                   | Custom data to pass to every workflow trigger.                                                                                                                     |
+| `tenant`       | string                | A tenant to pass to the workflow trigger.                                                                                                                          |
+| `actor`        | RecipientIdentifier   | An identifier of an actor, or a complete actor to be upserted.                                                                                                     |
+| `scheduled_at` | utc_datetime          | A UTC datetime in ISO-8601 format representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule. |
 
 ### ScheduleRepeat properties
 

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -5734,6 +5734,11 @@ Creates new schedules for the recipients given using. Up to 100 recipients may b
     type="ScheduleRepeat[]"
     description="A list of one or more repeat definitions that determine when this schedule should run."
   />
+  <Attribute
+    name="scheduled_at"
+    type="string"
+    description="A UTC datetime in ISO-8601 format representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule."
+  />
 </Attributes>
 
 ### Response
@@ -5758,7 +5763,8 @@ The list of created `Schedule` entities.
       "hours": 8,
       "minutes": 30
     }
-  ]
+  ],
+  "scheduled_at": "2025-04-17T08:30:00Z"
 }
 ```
 
@@ -5771,8 +5777,8 @@ The list of created `Schedule` entities.
     "data": {
       "custom_key": "custom_value"
     },
-    "next_occurrence_at": "2023-04-17T08:30:00Z",
-    "next_occurrence_at": "2023-04-24T08:30:00Z",
+    "last_occurrence_at": null,
+    "next_occurrence_at": "2025-04-17T08:30:00Z",
     "recipient": {
       "__typename": "User",
       "id": "dnedry",
@@ -5792,8 +5798,8 @@ The list of created `Schedule` entities.
     ],
     "workflow": "digest-workflow",
     "tenant": null,
-    "inserted_at": "2023-04-23T22:29:17.216686Z",
-    "updated_at": "2023-04-23T22:29:17.216686Z"
+    "inserted_at": "2024-04-23T22:29:17.216686Z",
+    "updated_at": "2024-04-23T22:29:17.216686Z"
   }
 ]
 ```
@@ -5841,6 +5847,11 @@ Updates the schedules for the `schedule_ids` given. Can update up to 100 schedul
     name="repeats"
     type="ScheduleRepeat[]"
     description="A list of one or more repeat definitions that determine when this schedule should run."
+  />
+  <Attribute
+    name="scheduled_at"
+    type="string"
+    description="A UTC datetime in ISO-8601 format representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule."
   />
 </Attributes>
 


### PR DESCRIPTION
### Description

- Add the `scheduled_at` parameter to the API reference for Schedules ([here](https://docs-git-mk-update-schedules-knocklabs.vercel.app/reference#create-schedules) and [here](https://docs-git-mk-update-schedules-knocklabs.vercel.app/reference#update-schedules))
- Clarify that the `scheduled_at` timestamp must be a UTC datetime in ISO-8601 format ([here](https://docs-git-mk-update-schedules-knocklabs.vercel.app/concepts/schedules#schedule-properties))