### PR TITLE
chore: add info about custom args to sendgrid docs

### DIFF
--- a/content/integrations/email/sendgrid.mdx
+++ b/content/integrations/email/sendgrid.mdx
@@ -103,6 +103,7 @@ Knock sends the following attributes along with your emails:
 
 - `custom_args.sender`: always set to `knock.app`
 - `custom_args.knock_message_id`: the ID of the message this email is associated with
+- `custom_args.knock_recipient_id`: the Knock ID of the recipient this email is being sent to
 - `tags[0]`: the key of the workflow this message was generated from
 
 You can learn about the role of these SendGrid attributes in the [SendGrid API documentation](https://docs.sendgrid.com/).


### PR DESCRIPTION
### Description

Document the `knock_recipient_id` custom arg that we send to Sendgrid.