### PR TITLE
fix(KNO-6356): fix recipient inline identify broken link

### DIFF
--- a/content/concepts/recipients.mdx
+++ b/content/concepts/recipients.mdx
@@ -28,7 +28,7 @@ A recipient identifier can be one of:
 
 - A string user ID for a previously identified user (`user-1`)
 - An object reference dictionary (`{ "collection": "my-collection", "id": "object-1" }`) for a previously identified object
-- A dictionary containing a recipient to be [identified inline](#inline-identifying-recipients)
+- A dictionary containing a recipient to be [identified inline](managing-recipients/identifying-recipients#inline-identifying-recipients)
 
 This can be expressed as the following type:
 


### PR DESCRIPTION
### Description

Found a broken link while perusing the inline identify docs for Recipients.

### Tasks

KNO-6356

