### PR TITLE
fix(KNO-6369): fix typo for inline identify link

### DIFF
--- a/content/concepts/recipients.mdx
+++ b/content/concepts/recipients.mdx
@@ -29,7 +29,8 @@ A recipient identifier can be one of:
 - A string user ID for a previously identified user (`user-1`)
 - An object reference dictionary (`{ "collection": "my-collection", "id": "object-1" }`) for a previously identified object
 - A dictionary containing a recipient to be [identified inline](/managing-recipients/identifying-recipients#inline-identifying-recipients)
-  This can be expressed as the following type:
+
+This can be expressed as the following type:
 
 ```typescript
 type RecipientIdentifier =

--- a/content/concepts/recipients.mdx
+++ b/content/concepts/recipients.mdx
@@ -28,9 +28,8 @@ A recipient identifier can be one of:
 
 - A string user ID for a previously identified user (`user-1`)
 - An object reference dictionary (`{ "collection": "my-collection", "id": "object-1" }`) for a previously identified object
-- A dictionary containing a recipient to be [identified inline](managing-recipients/identifying-recipients#inline-identifying-recipients)
-
-This can be expressed as the following type:
+- A dictionary containing a recipient to be [identified inline](/managing-recipients/identifying-recipients#inline-identifying-recipients)
+  This can be expressed as the following type:
 
 ```typescript
 type RecipientIdentifier =


### PR DESCRIPTION
### Description

Fixes typo that is resulting in a 404. Confirmed fix with preview URL by going to https://docs-git-rt-fix-inline-identify-404-knocklabs.vercel.app/concepts/recipients#recipientidentifier-definiton and clicking on the "identified inline" hyperlink.