### PR TITLE
Chore: add info for specifying the response path on fetch steps

### DIFF
--- a/content/designing-workflows/fetch-function.mdx
+++ b/content/designing-workflows/fetch-function.mdx
@@ -79,7 +79,7 @@ The example below illustrates how this could look in practice.
 
 You can specify where in the trigger data the response from the fetch step should be placed. To do so, click on "Manage Settings" from the fetch step within your workflow template editor. From there, you can specify the response path.
 
-The response path can be any string. To create nested keys within the trigger data, use the dot (`.`) notation. For example, specifying `foo.bar` will place the response under the `bar` key within the `foo` object.
+The response path can be any string. To create nested keys within the trigger data, use dot (`.`) notation. For example, specifying `foo.bar` will place the response under the `bar` key within the `foo` object.
 
 ### Error handling
 

--- a/content/designing-workflows/fetch-function.mdx
+++ b/content/designing-workflows/fetch-function.mdx
@@ -75,6 +75,12 @@ The example below illustrates how this could look in practice.
 }
 ```
 
+### Specifying the Response Path
+
+You can specify where in the trigger data the response from the fetch step should be placed. To do so, click on "Manage Settings" within the fetch step. From there, you can specify the response path.
+
+The response path can be any string. To create nested keys within the trigger data, use the dot (`.`) notation. For example, specifying `foo.bar` will place the response under the `bar` key within the `foo` object.
+
 ### Error handling
 
 Knock will automatically retry request execution for a fetch function following certain types of errors. The first retry will be delayed by 30 seconds, and the second by 60 seconds. These retryable errors are:

--- a/content/designing-workflows/fetch-function.mdx
+++ b/content/designing-workflows/fetch-function.mdx
@@ -77,7 +77,7 @@ The example below illustrates how this could look in practice.
 
 ### Specifying the Response Path
 
-You can specify where in the trigger data the response from the fetch step should be placed. To do so, click on "Manage Settings" within the fetch step. From there, you can specify the response path.
+You can specify where in the trigger data the response from the fetch step should be placed. To do so, click on "Manage Settings" from the fetch step within your workflow template editor. From there, you can specify the response path.
 
 The response path can be any string. To create nested keys within the trigger data, use the dot (`.`) notation. For example, specifying `foo.bar` will place the response under the `bar` key within the `foo` object.
 


### PR DESCRIPTION
### Description

Updates the fetch function docs to add information regarding specifying the response path.

FYI - I opted to leave the "Merge data" section as is since I believe that is still the default behavior, but let me know if we think this should be reworked 👍 