### PR TITLE
Fix typo

### DIFF
--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -5,7 +5,7 @@ tags: ["recipients", "inline identify", "identify"]
 section: Managing recipients
 ---
 
-To send notifications to a recipient (or to reference a recipient as an actor in a notification), Knock need the recipient's data to be stored in Knock. This process is known as **identifying** and works across user and object recipients.
+To send notifications to a recipient (or to reference a recipient as an actor in a notification), Knock needs the recipient's data to be stored in Knock. This process is known as **identifying** and works across user and object recipients.
 
 There are three different methods to identify recipients:
 


### PR DESCRIPTION
Corrected a small typo in the first sentence

### Description

Pluralized the word "need" in the first sentence

### Todos


### Screenshots


![Screenshot 2024-07-15 122926](https://github.com/user-attachments/assets/fc822003-2d4a-4a53-bece-14afbdb2abf3)
