### PR TITLE
chore: add info about actor being excluded from recipients

### DIFF
--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -104,7 +104,8 @@ Knock supports passing an `actor` in your workflow trigger calls, which allows y
 Calling a workflow trigger with an actor will have the following effect:
 
 - The `actor` property will be available within your message templates including the full user or object that performed this action.
-- When a workflow being triggered includes a batch step, the actor will be recorded as one actor who performed an action in the batch, which you can access via the `actors` key in your template.
+- The `actor` is **always** excluded from being a `recipient` in a workflow trigger, even if they are a [subscriber](/concepts/subscriptions) to an Object recipient. No notification will be sent to the `actor`.
+- When a workflow includes a [batch step](/designing-workflows/batch-function), the `actor` will be recorded as one actor who performed an action in the batch, which you can access via the `actors` key in your template.
 - Any workflows that contain an in-app feed channel step will produce a message that links the actor, and the actor will be loaded in any requests to this feed.
 
 ## Passing data


### PR DESCRIPTION
### Description

This PR updates the list of effects of including an `actor` on a trigger to include the fact that an `actor` is never notified as a `recipient`. Right now, this information is rather buried in the Subscriptions FAQ.

https://docs-a86l84q42-knocklabs.vercel.app/send-notifications/triggering-workflows#attributing-the-action-to-a-user-or-object