### PR TITLE
Chore: add callout for customizing promotion permissions

### DIFF
--- a/content/manage-your-account/roles-and-permissions.mdx
+++ b/content/manage-your-account/roles-and-permissions.mdx
@@ -29,8 +29,10 @@ For a complete overview of which permissions are available to which roles, see o
   emoji="✨"
   text={
     <>
-      <span className="font-bold">Customizing commit permissions.</span> This
-      advanced feature is available on our Enterprise plan.{" "}
+      <span className="font-bold">
+        Customizing commit promotion permissions.
+      </span>{" "}
+      This advanced feature is available on our Enterprise plan.{" "}
       <a href="https://knock.app/contact-sales">Contact our sales team</a> to
       learn more.
     </>

--- a/content/manage-your-account/roles-and-permissions.mdx
+++ b/content/manage-your-account/roles-and-permissions.mdx
@@ -24,3 +24,15 @@ For a complete overview of which permissions are available to which roles, see o
 ## Roles and permissions lookup table
 
 ![Knock roles and permissions grid](/images/permissions-grid.png)
+
+<Callout
+  emoji="✨"
+  text={
+    <>
+      <span className="font-bold">Customizing promotion permissions:</span> This
+      advanced feature is available on our Enterprise plan.{" "}
+      <a href="https://knock.app/contact-sales">Contact our sales team</a> to
+      learn more.
+    </>
+  }
+/>

--- a/content/manage-your-account/roles-and-permissions.mdx
+++ b/content/manage-your-account/roles-and-permissions.mdx
@@ -29,7 +29,7 @@ For a complete overview of which permissions are available to which roles, see o
   emoji="✨"
   text={
     <>
-      <span className="font-bold">Customizing promotion permissions:</span> This
+      <span className="font-bold">Customizing commit permissions.</span> This
       advanced feature is available on our Enterprise plan.{" "}
       <a href="https://knock.app/contact-sales">Contact our sales team</a> to
       learn more.


### PR DESCRIPTION
### Description

Adds a callout to the roles and permissions page about customizing promotion permissions being an enterprise feature that interested customers can contact our sales team about to learn more:
https://docs-git-rt-add-enterprise-promotion-callout-knocklabs.vercel.app/manage-your-account/roles-and-permissions
<img width="668" alt="Screenshot 2024-07-16 at 5 52 59 PM" src="https://github.com/user-attachments/assets/57b9e5fa-5018-4598-9374-8def85e5c884">
