### PR TITLE
chore: add `message.interacted` webhook event

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -218,6 +218,19 @@ Occurs when a message is unarchived by its recipient.
   />
 </Attributes>
 
+### `message.interacted`
+
+Occurs when a message is interacted with by its recipient. For the Knock in-app feed, this indicates that your recipient has explicitly clicked on the notification cell in their feed.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="Message"
+    description="The associated message"
+    typeSlug="/reference#messages"
+  />
+</Attributes>
+
 ### `message.link_clicked`
 
 Occurs when a link is clicked by the message recipient. This is only available when Knock link tracking is enabled.


### PR DESCRIPTION
### Description

Add `message.interacted` to the list of available outbound webhook events.

https://docs-fnjtf7ixc-knocklabs.vercel.app/developer-tools/outbound-webhooks/event-types#messageinteracted