### PR TITLE
fix: correct EventData attributes for a `message.link_clicked` event

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -253,9 +253,9 @@ Occurs when a link is clicked by the message recipient. This is only available w
 
 <Attributes>
   <Attribute
-    name="link_clicked"
+    name="url"
     type="string"
-    description="Details about a link click event"
+    description="The target URL that was clicked"
   />
 </Attributes>
 


### PR DESCRIPTION
### Description

We currently list the extra `EventData` param that is included with a `message.link_clicked` event incorrectly. It should be a `url`, not `link_clicked`.

https://docs-fmj18zbrl-knocklabs.vercel.app/developer-tools/outbound-webhooks/event-types#messagelink_clicked

I checked this in the codebase and also confirmed with a webhook test:
```
{
.... 
"event_data": {
    "__typename": "EventData",
    "url": "https://www.google.com"
  },
  "type": "message.link_clicked"
}
```
