### PR TITLE
chore: update tenant return values for accuracy

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4479,7 +4479,7 @@ Use tenants when sending a notification to user(s) that you want to configure sp
   <Attribute
     name="settings"
     type="object"
-    description="An object of key-value pairs for configurable settings on a tenant. Currently settings only contain a branding key which points to the following configurable values: primary_color, primary_color_contrast, icon_url, and logo_url."
+    description="An object of key-value pairs for configurable settings on a tenant. Currently contains a preference_set key for tenant-specific default preferences, as well as a branding key which points to the following configurable values: primary_color, primary_color_contrast, icon_url, and logo_url."
   />
 </Attributes>
 
@@ -4506,7 +4506,8 @@ Use tenants when sending a notification to user(s) that you want to configure sp
       "primary_color_contrast": "#ffffff",
       "logo_url": "www.example.com/path-to-logo-asset-url",
       "icon_url": "www.example.com/path-to-icon-asset-url"
-    }
+    },
+    "preference_set": null
   },
   "created_at": null,
   "updated_at": "2021-03-05T12:00:00Z"
@@ -4542,25 +4543,35 @@ Returns a list of `Tenant` objects.
 />
 
 ```json title="Response"
-[
-  {
-    "__typename": "Tenant",
-    "id": "tenant-1",
-    "properties": {
-      "name": "Tenant 1"
-    },
-    "settings": {
-      "branding": {
-        "primary_color": "#33FF5B",
-        "primary_color_contrast": "#ffffff",
-        "logo_url": "www.example.com/path-to-logo-asset-url",
-        "icon_url": "www.example.com/path-to-icon-asset-url"
-      }
-    },
-    "created_at": null,
-    "updated_at": "2021-03-05T12:00:00Z"
+{
+  "entries": [
+    {
+      "__typename": "Tenant",
+      "id": "tenant-1",
+      "properties": {
+        "name": "Tenant 1"
+      },
+      "settings": {
+        "branding": {
+          "primary_color": "#33FF5B",
+          "primary_color_contrast": "#ffffff",
+          "logo_url": "www.example.com/path-to-logo-asset-url",
+          "icon_url": "www.example.com/path-to-icon-asset-url"
+        },
+        "preference_set": null
+      },
+      "created_at": null,
+      "updated_at": "2021-03-05T12:00:00Z"
+    }
+  ],
+  "page_info": {
+    "__typename": "PageInfo",
+    "after": null,
+    "before": null,
+    "page_size": 50,
+    "total_count": 1
   }
-]
+}
 ```
 
 </ExampleColumn>
@@ -4614,7 +4625,8 @@ Returns a `Tenant`.
       "primary_color_contrast": "#ffffff",
       "logo_url": "www.example.com/path-to-logo-asset-url",
       "icon_url": "www.example.com/path-to-icon-asset-url"
-    }
+    },
+    "preference_set": null
   },
   "created_at": null,
   "updated_at": "2021-03-05T12:00:00Z"
@@ -4688,7 +4700,8 @@ Returns a `Tenant`.
       "primary_color_contrast": "#ffffff",
       "logo_url": "www.example.com/path-to-logo-asset-url",
       "icon_url": "www.example.com/path-to-icon-asset-url"
-    }
+    },
+    "preference_set": null
   },
   "created_at": null,
   "updated_at": "2021-03-05T12:00:00Z"


### PR DESCRIPTION
### Description

This PR updates the Tenants portion of the API reference for accuracy:
- Adds `entries` and `page_info` keys to account for pagination on the "List tenants" endpoint
- Adds `preference_set` to the description for the `settings` attribute and to the example responses

https://docs-oknin15lr-knocklabs.vercel.app/reference#tenants