### PR TITLE
chore: remove complex js -> node replacement logic and update code examples

### DIFF
--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -122,6 +122,7 @@ const DEFAULT_ORDER: SupportedLanguage[] = [
   "curl",
   "shell",
   "node",
+  "javascript",
   "jsweb",
   "ruby",
   "python",
@@ -161,7 +162,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet }) => {
     const snippetCode = snippets[snippet];
     return DEFAULT_ORDER.filter(
       (key) =>
-        key in snippetCode || (key === "node" && "javascript" in snippetCode),
+        key in snippetCode
     );
   }, [snippet]);
 
@@ -174,8 +175,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet }) => {
     const code =
       (snippetCode && snippetCode[language]) ||
       (snippetCode &&
-        listedLanguage &&
-        (snippetCode[listedLanguage] ?? snippetCode["javascript"])) ||
+        listedLanguage && snippetCode[listedLanguage]) ||
       "\n";
 
     return {

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -157,25 +157,19 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet }) => {
   }, [language, eventEmitter]);
 
   // Set the list of languages in the switcher according to the languages in the snippet and ordered by the DEFAULT_ORDER
-  // If the language in the snippet is "javascript", we need to display "node" in the switcher
   const languages = useMemo(() => {
     const snippetCode = snippets[snippet];
-    return DEFAULT_ORDER.filter(
-      (key) =>
-        key in snippetCode
-    );
+    return DEFAULT_ORDER.filter((key) => key in snippetCode);
   }, [snippet]);
 
   const content = useMemo(() => {
     const snippetCode = snippets[snippet];
 
-    // When a given block does not include any example code for the language that is currently stored in localstorage, we want to display the code that matches the first language in its switcher (which is what will be "selected" and displayed on the switcher by default)
-    // When that first language in the switcher is "node", we once again need to reference the "javascript" code example.
+    // When a given block does not include any example code for the language that is currently stored in localstorage, we want to display the code that matches the first listed language in its switcher (which is what will be "selected" and displayed on the switcher by default)
     const listedLanguage = languages && languages[0];
     const code =
       (snippetCode && snippetCode[language]) ||
-      (snippetCode &&
-        listedLanguage && snippetCode[listedLanguage]) ||
+      (snippetCode && listedLanguage && snippetCode[listedLanguage]) ||
       "\n";
 
     return {

--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/messages/get-activities.ts
+++ b/data/code/messages/get-activities.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/messages/get-content.ts
+++ b/data/code/messages/get-content.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/messages/get-events.ts
+++ b/data/code/messages/get-events.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/messages/get.ts
+++ b/data/code/messages/get.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/messages/list.ts
+++ b/data/code/messages/list.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/objects/bulk-delete.ts
+++ b/data/code/objects/bulk-delete.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock("sk_example_12345679");
 

--- a/data/code/objects/bulk-set.ts
+++ b/data/code/objects/bulk-set.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock("sk_example_12345679");
 

--- a/data/code/objects/delete.ts
+++ b/data/code/objects/delete.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/get-channel-data.ts
+++ b/data/code/objects/get-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/objects/get-preferences.ts
+++ b/data/code/objects/get-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/objects/get.ts
+++ b/data/code/objects/get.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/messages.ts
+++ b/data/code/objects/messages.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/objects/set-channel-data-discord-bot.ts
+++ b/data/code/objects/set-channel-data-discord-bot.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/set-channel-data-discord-webhook.ts
+++ b/data/code/objects/set-channel-data-discord-webhook.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/set-channel-data-ms-teams.ts
+++ b/data/code/objects/set-channel-data-ms-teams.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/set-channel-data-slack.ts
+++ b/data/code/objects/set-channel-data-slack.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/set-preferences.ts
+++ b/data/code/objects/set-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/objects/set.ts
+++ b/data/code/objects/set.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/objects/unset-channel-data.ts
+++ b/data/code/objects/unset-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/sdks/install.ts
+++ b/data/code/sdks/install.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
     npm install @knocklabs/node
   `,
   python: `

--- a/data/code/tenants/delete.ts
+++ b/data/code/tenants/delete.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/tenants/get.ts
+++ b/data/code/tenants/get.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/tenants/list.ts
+++ b/data/code/tenants/list.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/bulk-delete.ts
+++ b/data/code/users/bulk-delete.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock("sk_example_123456789");
 

--- a/data/code/users/bulk-identify.ts
+++ b/data/code/users/bulk-identify.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/bulk-set-preferences.ts
+++ b/data/code/users/bulk-set-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/delete.ts
+++ b/data/code/users/delete.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/get-channel-data.ts
+++ b/data/code/users/get-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/get.ts
+++ b/data/code/users/get.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/identify-channel-data.ts
+++ b/data/code/users/identify-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/identify.ts
+++ b/data/code/users/identify.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/merge.ts
+++ b/data/code/users/merge.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/users/messages.ts
+++ b/data/code/users/messages.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-channel-data-one-signal.ts
+++ b/data/code/users/set-channel-data-one-signal.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-channel-data-push.ts
+++ b/data/code/users/set-channel-data-push.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-channel-data.ts
+++ b/data/code/users/set-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-preferences-per-tenant.ts
+++ b/data/code/users/set-preferences-per-tenant.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-preferences-with-conditions.ts
+++ b/data/code/users/set-preferences-with-conditions.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/set-preferences.ts
+++ b/data/code/users/set-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/users/unset-channel-data.ts
+++ b/data/code/users/unset-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 

--- a/data/code/workflows/cancel-with-recipients.ts
+++ b/data/code/workflows/cancel-with-recipients.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/cancel.ts
+++ b/data/code/workflows/cancel.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/playground.ts
+++ b/data/code/workflows/playground.ts
@@ -64,6 +64,35 @@ curl -X POST 'https://api.knock.app/v1/workflows/new-comment/trigger' \\ \n\
          }'
 
 `,
+  node: `
+import { Knock } from "@knocklabs/node";
+const knock = new Knock(process.env.KNOCK_API_KEY);
+
+await knock.workflows.trigger("new-comment", {
+  recipients: ["1", "2"],
+
+  // optional
+  data: { "project_name": "My Project" },
+  actor: "3",
+  cancellationKey: "cancel_123",
+  tenant: "jurassic_world_employees"
+});
+`,
+  javascript: `
+// You can use "javascript" when you don't want to make your JS example Node-specific
+
+const knock = new Knock(process.env.KNOCK_API_KEY);
+
+await knock.workflows.trigger("new-comment", {
+  recipients: ["1", "2"],
+
+  // optional
+  data: { "project_name": "My Project" },
+  actor: "3",
+  cancellationKey: "cancel_123",
+  tenant: "jurassic_world_employees"
+});
+`,
 };
 
 export default languages;

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-attachment.ts
+++ b/data/code/workflows/trigger-with-attachment.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 import fs from "fs";
 

--- a/data/code/workflows/trigger-with-branding-tenant.ts
+++ b/data/code/workflows/trigger-with-branding-tenant.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-identification.ts
+++ b/data/code/workflows/trigger-with-identification.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-object-as-actor.ts
+++ b/data/code/workflows/trigger-with-object-as-actor.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-object-as-recipient.ts
+++ b/data/code/workflows/trigger-with-object-as-recipient.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-tenant.ts
+++ b/data/code/workflows/trigger-with-tenant.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -1,5 +1,5 @@
 const languages = {
-  javascript: `
+  node: `
 import { Knock } from "@knocklabs/node";
 const knock = new Knock(process.env.KNOCK_API_KEY);
 


### PR DESCRIPTION
### Description

Because the `MultiLangCodeBlock` block now references the code examples to populate its switcher, we don't need to have the complex logic to make sure syntax highlighting and the language stored in localstorage reference `javascript` examples for the Node SDK; we already have both `javascript` (for Vanilla JS) and `node` as registered languages using `javascript` highlighting, so it's much less confusing to just reference one or the other in the code examples depending on whether it's for the Node SDK or vanilla JS.

This PR removes all of the complicated logic around the above, and updates all of the code examples that reference the Node SDK to use `node` instead of `javascript`.

- The playground page has an updated code block with both `node` and `javascript` to show the difference: https://docs-kcs6p0uhr-knocklabs.vercel.app/playground
- The API reference should appear unchanged: https://docs-kcs6p0uhr-knocklabs.vercel.app/reference