### PR TITLE
feat(kno-5483): update docs on the 1k recipient limit

### DIFF
--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -68,6 +68,25 @@ After configuring a source in Knock and in the source itself (e.g. adding Knock 
 
 You can then select the event you want to trigger actions in Knock, and configure it accordingly.
 
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <span className="font-bold">
+        For workflow trigger action mappings, no more than 1000 recipients can
+        be included in each event.
+      </span>{" "}
+      If you exceed this limit, Knock will not process your action mappings and
+      instead generate an error log. <br />
+      <br />
+      If you need to manage a large list of recipients you might want to
+      consider using our{" "}
+      <a href="/send-and-manage-data/subscriptions">subscriptions feature</a> to
+      have Knock manage the set of recipients who need to be notified instead.
+    </>
+  }
+/>
+
 ### Identifying users
 
 For sources that support identifying users (such as Segment or Rudderstack with their `identify` calls), each environment configuration for that source includes a setting to enable or disable identifying users. After creating an integration source, enable identifying users for that environment.

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -1227,7 +1227,10 @@ A trigger calls a workflow created via the Knock dashboard.
 
 ### Payload size limit
 
-Workflow trigger endpoints enforce a `10MB` payload `data` limit.
+The workflow trigger endpoint enforces the following payload size limits:
+
+- The `data` payload must be no more than `10MB`
+- The `recipients` list must not exceed 1000 entries
 
 ### Path parameters
 
@@ -1312,7 +1315,10 @@ See our guides on inline identification [for users](/managing-recipients/identif
 
 ### Payload size limit
 
-Workflow trigger endpoints enforce a `10MB` payload `data` limit.
+The workflow trigger endpoint enforces the following payload size limits:
+
+- The `data` payload must be no more than `10MB`
+- The `recipients` list must not exceed 1000 entries
 
 ### Path parameters
 
@@ -1395,6 +1401,12 @@ Cancel a delayed workflow for one or more recipients.
 ### Rate limit
 
 <RateLimit tier={5} />
+
+### Payload size limit
+
+The workflow cancelation endpoint enforces the following payload size limits:
+
+- The `recipients` list must not exceed 1000 entries
 
 ### Path parameters
 

--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -78,12 +78,13 @@ Triggering a workflow will always return a unique UUID v4 representing the workf
 
 You can always pass an array of **multiple recipients** to Knock, which will cause Knock to execute a **workflow run for each recipient** that you've passed in.
 
-Please note: there's a maximum of 1000 recipients that can be passed to a workflow trigger at a time.
-
 <Callout
-  emoji="💡"
+  emoji="🚨"
   text={
     <>
+      <span className="font-bold">
+        No more than 1000 recipients can be passed to each workflow trigger.
+      </span>{" "}
       If you need to manage a large list of recipients you might want to
       consider using our{" "}
       <a href="/send-and-manage-data/subscriptions">subscriptions feature</a> to


### PR DESCRIPTION
### Description

- Updates text for the triggering workflows guide
- Adds a note to source events guide
- Updates the API reference to note the limit

### Tasks

[KNO-6483 : \[Docs\] Fill in docs gaps for the 1k recipient per trigger limit](https://linear.app/knock/issue/KNO-6483/[docs]-fill-in-docs-gaps-for-the-1k-recipient-per-trigger-limit)