### PR TITLE
fix: update actor documentation to reflect current behavior

### DIFF
--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -201,6 +201,6 @@ Knock always deduplicates recipients when executing a notification fan out, incl
   </Accordion>
   <Accordion title="Will the actor included in the workflow trigger receive a notification if they are a subscriber?">
     No, currently the `actor` is **always** excluded from being a recipient in a
-    workflow trigger, even if they are a subscriber to an object being notified.
+    workflow trigger if they are a subscriber to an Object recipient.
   </Accordion>
 </AccordionGroup>

--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -105,7 +105,7 @@ Knock supports passing an `actor` in your workflow trigger calls, which allows y
 Calling a workflow trigger with an actor will have the following effect:
 
 - The `actor` property will be available within your message templates including the full user or object that performed this action.
-- The `actor` is **always** excluded from being a `recipient` in a workflow trigger, even if they are a [subscriber](/concepts/subscriptions) to an Object recipient. No notification will be sent to the `actor`.
+- When the `actor` is also a [subscriber](/concepts/subscriptions) to an Object recipient, they are **always** excluded from the `recipients` list. No notification will be sent to the subscribed `actor`.
 - When a workflow includes a [batch step](/designing-workflows/batch-function), the `actor` will be recorded as one actor who performed an action in the batch, which you can access via the `actors` key in your template.
 - Any workflows that contain an in-app feed channel step will produce a message that links the actor, and the actor will be loaded in any requests to this feed.
 


### PR DESCRIPTION
### Description

This PR clarifies current behavior around the `actor` on a workflow: the exclusion of an `actor` from the list of a workflow's `recipients` will only occur for the Subscriptions use case.

- https://docs-huooueii7-knocklabs.vercel.app/send-notifications/triggering-workflows#attributing-the-action-to-a-user-or-object
- https://docs-huooueii7-knocklabs.vercel.app/concepts/subscriptions#frequently-asked-questions