### PR TITLE
chore(kno-6592): add docs on log truncation

### DIFF
--- a/content/developer-tools/api-logs.mdx
+++ b/content/developer-tools/api-logs.mdx
@@ -14,6 +14,12 @@ You can filter API logs in your Knock account using the following filters:
 - **Status**: filter for failed and succeeded requests.
 - **Endpoint type**: filter for requests to particular sets of endpoints.
 
+## Log truncation
+
+Knock truncates logs with long binaries, lists, and maps to prevent the logs from becoming too large. The truncation is done at the top level of the JSON object, and the truncation is indicated by the presence of the `__knock_truncated__` key in the JSON object.
+
+Knock does not store response bodies for the `/feeds` endpoint.
+
 ## Frequently asked questions
 
 <AccordionGroup>


### PR DESCRIPTION
### Description
Tells users when and why we truncate logs. I didn't add specific numbers on what size we truncate at, but we can if we think that would be helpful. 

### Tasks
[kno-6592](https://linear.app/knock/issue/KNO-6592/[docs]-docs-on-log-truncation)