### PR TITLE
chore: add markAsInteracted to JS SDK reference

### DIFF
--- a/content/sdks/javascript/reference.mdx
+++ b/content/sdks/javascript/reference.mdx
@@ -419,6 +419,22 @@ Removes the `archived` status on the item or items given. Will perform the opera
 
 **Returns**: `Promise<ApiResponse>`
 
+### `markAsInteracted`
+
+Sets the `interacted` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts an `items:interacted` event.
+
+**Params**:
+
+<Attributes>
+  <Attribute
+    name="itemOrItems"
+    type="FeedItemOrItems"
+    description="A single `FeedItem` or a list of `FeedItem` to perform the update on."
+  />
+</Attributes>
+
+**Returns**: `Promise<ApiResponse>`
+
 ### `fetch`
 
 Fetches


### PR DESCRIPTION
### Description

Documents `markAsInteracted` from the [JS SDK](https://github.com/knocklabs/javascript/blob/bacf030f43a5d8cd1c17c88c672188c4a17808dd/packages/client/src/clients/feed/feed.ts#L289) 

https://docs-jq4zc2g9s-knocklabs.vercel.app/sdks/javascript/reference#markasinteracted

