### PR TITLE
chore: update description for override webhook configurations

### DIFF
--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -66,7 +66,7 @@ Webhook channels are added to Knock workflows the same way as any other channel.
 
 ### Overriding webhook configurations
 
-When you add your webhook channel to a workflow, it will use the webhook request you built in your channel by default. You can override this on a per-step basis.
+When you add your webhook channel to a workflow, it will use the webhook request you built in your channel configuration by default. You can override this on a per-step basis.
 
 Editing a webhook step's template, such as changing the URL or body, creates 'channel setting overrides,' replacing the default environment settings with your changes. Any template modifications will include the entire template (URL, headers, params, and body) in the overrides. These overrides apply to all environments where the step is promoted.
 

--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -66,7 +66,11 @@ Webhook channels are added to Knock workflows the same way as any other channel.
 
 ### Overriding webhook configurations
 
-When you add your webhook channel to a workflow, by default it will use the webhook request you built in your channel. You can override this as you see fit on a per-step basis. If at any time you want to reset a webhook step back to its channel default, just click "Reset to default channel settings."
+When you add your webhook channel to a workflow, it will use the webhook request you built in your channel by default. You can override this on a per-step basis.
+
+Editing a webhook step's template, such as changing the URL or body, creates 'channel setting overrides,' replacing the default environment settings with your changes. Any template modifications will include the entire template (URL, headers, params, and body) in the overrides. These overrides apply to all environments where the step is promoted.
+
+To reset a webhook step to its channel default, click "Reset to default channel settings."
 
 ## Securing your webhooks
 


### PR DESCRIPTION
### Description

Adds some clarification to the override webhook configurations section: https://docs-git-rt-clarify-webhook-channel-override-knocklabs.vercel.app/integrations/webhook/overview#overriding-webhook-configurations

### Screenshots

I opted to not use a callout. Here is the version I went with:
![Screenshot 2024-08-01 at 5 08 56 PM](https://github.com/user-attachments/assets/4ad0053f-daba-447d-8e1f-8319cb4867b7)

Here is it with a callout (it looked awkward to just callout "these overrides apply to all environments where the step is promoted":
![Screenshot 2024-08-01 at 5 09 32 PM](https://github.com/user-attachments/assets/01f1eae3-7ce6-4e3f-be5f-6606e97404b0)


Also, I noticed that this page has a lot of "Note:" throughout. I'm going to work on cleaning that up in a separate PR, and update anything that feels as though it should be a callout to use the `<Callout>` component.