### PR TITLE
chore: update notes on webhook page to use the callout component

### DIFF
--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -26,7 +26,17 @@ To create your webhook channel, go to the Knock dashboard and navigate to **Inte
 
 Provide a name, key, and description for your webhook channel.
 
-**Note:** the name and description provided will be used in the workflow builder on steps that use this webhook channel, so be as descriptive as possible so other members of your account know how to use your webhook channel.
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <span className="font-bold">Note:</span> the name and description provided
+      will be used in the workflow builder on steps that use this webhook
+      channel, so be as descriptive as possible so other members of your account
+      know how to use your webhook channel.
+    </>
+  }
+/>
 
 Once your webhook channel has been created, you'll be able to manage its configuration on a per-environment basis. As with all Knock channels, webhooks can be used in [sandbox mode](/integrations/overview#sandbox-mode) and can be used with [channel conditions](/integrations/overview#channel-conditions).
 
@@ -93,7 +103,15 @@ In some cases, you may wish to use a **dynamic signing key** to verify your webh
 
 You can add a dynamic signing key by using liquid in the signing key input field. For example, if your signing key was stored on an object that represented the webhook you can reference the key as `{{ recipient.webhook_signing_key }}`.
 
-**Note**: if the signing key is empty the webhook request will be skipped.
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <span className="font-bold">Note:</span> if the signing key is empty the
+      webhook request will be skipped.
+    </>
+  }
+/>
 
 ### Verifying the signature
 

--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -30,10 +30,10 @@ Provide a name, key, and description for your webhook channel.
   emoji="💡"
   text={
     <>
-      <span className="font-bold">Note:</span> the name and description provided
-      will be used in the workflow builder on steps that use this webhook
-      channel, so be as descriptive as possible so other members of your account
-      know how to use your webhook channel.
+      <strong>Note:</strong> the name and description provided will be used in
+      the workflow builder on steps that use this webhook channel, so be as
+      descriptive as possible so other members of your account know how to use
+      your webhook channel.
     </>
   }
 />
@@ -107,8 +107,8 @@ You can add a dynamic signing key by using liquid in the signing key input field
   emoji="🚨"
   text={
     <>
-      <span className="font-bold">Note:</span> if the signing key is empty the
-      webhook request will be skipped.
+      <strong>Note:</strong> if the signing key is empty the webhook request
+      will be skipped.
     </>
   }
 />


### PR DESCRIPTION
### Description

Updates the **Notes:** on the webhook overview page to use the `<Callout>` component instead to draw the user's attention better.  

https://docs-git-rt-clean-up-webhook-notes-knocklabs.vercel.app/integrations/webhook/overview
