### PR TITLE
feat(pla-330): expand docs on data retention policies + enforcement

### DIFF
--- a/components/ApiSections.tsx
+++ b/components/ApiSections.tsx
@@ -7,6 +7,7 @@ export const Section = ({
   children,
   headingClassName = "",
   isIdempotent = false,
+  isRetentionSubject = false,
 }) => (
   <section className="api-docs-section border-b border-gray-200 dark:border-gray-800 py-8 lg:py-16">
     {title && (
@@ -19,6 +20,18 @@ export const Section = ({
           <div className="mb-2">
             <span className="text-xs font-medium text-gray-600 dark:text-gray-300 border border-transparent font-mono rounded p-1 center mr-3 bg-yellow-100 dark:bg-transparent dark:border-yellow-500">
               <a href="#idempotent-requests">Idempotent</a>
+            </span>
+          </div>
+        )}
+        {isRetentionSubject && (
+          <div className="mb-2">
+            <span className="text-xs font-medium text-gray-600 dark:text-gray-300 border border-transparent font-mono rounded p-1 center mr-3 bg-orange-100 dark:bg-transparent dark:border-orange-600">
+              <a
+                href="#data-retention"
+                style={{ color: "inherit", textDecoration: "none" }}
+              >
+                Retention policy applied
+              </a>
             </span>
           </div>
         )}

--- a/content/concepts/messages.mdx
+++ b/content/concepts/messages.mdx
@@ -7,6 +7,20 @@ section: Concepts
 
 ## An overview
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 A Message in Knock represents a notification delivered to a [User](/send-and-manage-data/users) or an [Object](/send-and-manage-data/objects) on a particular channel. This is the core Knock data entity that your recipients will interact with when receiving notifications.
 
 Knock exposes a set of [Message APIs](/reference#messages) via which you can query for notifications and update messages individually or in batches. The Knock [Feeds API](/reference#feeds) is a specialized view of messages delivered to an in-app feed channel.

--- a/content/developer-tools/api-logs.mdx
+++ b/content/developer-tools/api-logs.mdx
@@ -6,6 +6,20 @@ section: Developer tools
 
 Knock automatically captures and stores all of the API requests you make to the Knock API, and makes these requests accessible under the **Developers** > **Logs** section of the left-hand navigation in the Knock dashboard.
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 ## Filtering API logs
 
 You can filter API logs in your Knock account using the following filters:

--- a/content/developer-tools/outbound-webhooks/overview.mdx
+++ b/content/developer-tools/outbound-webhooks/overview.mdx
@@ -161,6 +161,20 @@ Once you receive a webhook request and return a `2xx` status code, you can make 
 
 ### Reading webhook delivery logs
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 When you visit a webhook's page, if it has begun to send data to your endpoint you'll see a log for every POST request. This will give you the following information:
 
 - **Status code:** your server's response to the webhook request

--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -155,10 +155,26 @@ To ensure that the user is notified, we'd change the id reference in `recipients
 }
 ```
 
+## Logs
+
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 ### Event logs
 
-Event logs show the contents of each event sent into Knock. Knock retains event Logs according to our data retention policy.
+Event logs show the contents of each event sent into Knock.
 
 ### Action logs
 
-Action logs describe what (if any) action was taken after an event was received. Action logs are a helpful starting point when troubleshooting workflows or auditing what actions Knock has taken for any given event. Knock retains action logs according to our data retention policy.
+Action logs describe what (if any) action was taken after an event was received. Action logs are a helpful starting point when troubleshooting workflows or auditing what actions Knock has taken for any given event.

--- a/content/manage-your-account/audit-logs.mdx
+++ b/content/manage-your-account/audit-logs.mdx
@@ -9,12 +9,21 @@ Search your account's audit log to review member actions and events.
 
 ## Overview
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 The account audit log lets you review actions performed by individual members of the account. In addition, each audit log includes events detailing who performed the action, when it happened, and information about the originating IP address and location of the action.
-
-Audit log retention is based on your plan:
-
-- **Enterprise**: 90 days
-- **All other plans**: 30 days
 
 **Note**: accessing an account's audit log is restricted to admins and account owners.
 

--- a/content/manage-your-account/data-retention.mdx
+++ b/content/manage-your-account/data-retention.mdx
@@ -1,0 +1,55 @@
+---
+title: Data retention
+description: How Knock enforces data retention policies on your account.
+tags: ["data", "retention"]
+section: Manage your account
+---
+
+Knock applies a retention policy to some of the data within your account. Once data exceeds its retention period, it will no longer be accessible in the Knock Dashboard, the Management API, or the V1 API. Knock will eventually prune data that has aged out of its retention period.
+
+## Data retention policies
+
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Custom retention policies are not currently supported.
+      </span>{" "}
+      If custom retention windows are critical to your usage of Knock, please
+      use the "Help" dropdown at the top of this page to contact support.
+    </>
+  }
+/>
+
+Some Knock data is subject to a retention policy based on your account plan. These policies are:
+
+- **Enterprise plans**: 90 days
+- **All other plans**: 30 days
+
+Knock applies this plan-based retention policy to the following data:
+
+- [Audit logs](/manage-your-account/audit-logs)
+- [Message log data](/concepts/messages)
+- [Outbound webhook delivery logs](/developer-tools/outbound-webhooks/overview#reading-webhook-delivery-logs)
+- [Source event and action logs](/integrations/sources/overview#logs)
+- [Workflow run logs](/send-notifications/debugging-workflows)
+
+Additionally, Knock applies a universal, 30-day retention policy to the following data:
+
+- [API logs](/developer-tools/api-logs)
+
+## Message log data retention details
+
+Message log data subject to your account's retention policy includes both the message log itself and associated metadata, including:
+
+- Message contents
+- Message events
+- Delivery logs
+- Activities
+
+However, this does not mean that the associated notification has been completely removed from Knock's systems. Your recipients can still interact with these older notifications, and you can still take some specific actions on them.
+
+1. **In-app feed notifications are available indefinitely.** Even once your message log data has expired, you can still fetch the associated `FeedItem` data from the [Show feed endpoint](/reference#get-feed) to deliver in-app notifications to your recipients.
+2. **Message status updates are allowed indefinitely.** You can still call the [Update message status](/reference#update-message-status), [Remove message status](/reference#undo-message-status), and [Batch change message status](/reference#batch-update-message-status) endpoints to update the status of an older message, either directly or via a Knock SDK. These status updates will still generate new message events and trigger your [outbound webhooks](/developer-tools/outbound-webhooks/overview), even though you will not be able to view the data in the Knock Dashboard any longer.
+3. **Tracking behavior will persist.** Your recipients can still click [tracked-links](/send-notifications/tracking#link-click-tracking), and Knock will still register read events for your notifications using [email-open tracking](/send-notifications/tracking#email-open-tracking).

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -246,6 +246,16 @@ If you are making calls to Knock from a job queue, the ID of the job can be a go
 </ExampleColumn>
 </Section>
 
+<Section title="Data retention" slug="data-retention">
+<ContentColumn>
+
+Several V1 API endpoints return data that is subject to deletion according to the data retention policy associated with your account. These endpoints are tagged with the `Retention policy applied` badge.
+
+For more information, see the [data retention docs](/manage-your-account/data-retention).
+
+</ContentColumn>
+</Section>
+
 <Section title="Bulk endpoints" slug="bulk-endpoints">
 <ContentColumn>
 
@@ -876,7 +886,7 @@ A message is a notification delivered on a particular channel to a user.
 </ExampleColumn>
 </Section>
 
-<Section title="Listing messages" slug="list-messages">
+<Section isRetentionSubject title="Listing messages" slug="list-messages">
 <ContentColumn>
 
 Returns a paginated list of messages.
@@ -888,6 +898,10 @@ Returns a paginated list of messages.
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Messages outside the account retention window will not be included in the results.
 
 ### Query parameters
 
@@ -1028,7 +1042,7 @@ A paginated list of Message records
 </ExampleColumn>
 </Section>
 
-<Section title="Fetching a message" slug="get-a-message">
+<Section isRetentionSubject title="Fetching a message" slug="get-a-message">
 <ContentColumn>
 
 Retrieve a message by the id.
@@ -1040,6 +1054,10 @@ Retrieve a message by the id.
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Path parameters
 
@@ -1059,7 +1077,7 @@ A Message
 
 </Section>
 
-<Section title="Events" slug="get-message-events">
+<Section isRetentionSubject title="Events" slug="get-message-events">
 <ContentColumn>
 
 Returns a paginated list of events for a message.
@@ -1071,6 +1089,10 @@ Returns a paginated list of events for a message.
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Path parameters
 
@@ -1133,7 +1155,7 @@ A paginated list of MessageEvent records
 </ExampleColumn>
 </Section>
 
-<Section title="Activities" slug="get-message-activities">
+<Section isRetentionSubject title="Activities" slug="get-message-activities">
 <ContentColumn>
 
 Returns a paginated list of activities associated with the message. Note: for non batched messages this will always return a single activity. For messages produced after a batch step, this will contain one or more activities.
@@ -1145,6 +1167,10 @@ Returns a paginated list of activities associated with the message. Note: for no
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Path parameters
 
@@ -1233,7 +1259,7 @@ A paginated list of Activity records
 </ExampleColumn>
 </Section>
 
-<Section title="Message content" slug="get-message-content">
+<Section isRetentionSubject title="Message content" slug="get-message-content">
 <ContentColumn>
 
 Retrieves the contents of a message, as generated and sent to the end provider.
@@ -1245,6 +1271,10 @@ Retrieves the contents of a message, as generated and sent to the end provider.
 ### Rate limit
 
 <RateLimit tier={3} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Path parameters
 
@@ -1288,7 +1318,7 @@ of message being sent (email, chat, in-app feed, sms, and push).**
 </ExampleColumn>
 </Section>
 
-<Section title="Batch message content" slug="batch-get-message-content">
+<Section isRetentionSubject title="Batch message content" slug="batch-get-message-content">
 <ContentColumn>
 
 Retrieves the contents of a list of messages, as generated and sent to the end provider.
@@ -1300,6 +1330,10 @@ Retrieves the contents of a list of messages, as generated and sent to the end p
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Query parameters
 
@@ -1365,7 +1399,7 @@ of message being sent (email, chat, in-app feed, sms, and push).**
 </ExampleColumn>
 </Section>
 
-<Section title="Delivery logs" slug="get-message-delivery-logs">
+<Section isRetentionSubject title="Delivery logs" slug="get-message-delivery-logs">
 <ContentColumn>
 
 Retrieves the delivery logs of a message, generated while sending and checking the delivery status of the message sent to an end provider. Note: for in-app channels, the delivery logs will always be an empty list.
@@ -1377,6 +1411,10 @@ Retrieves the delivery logs of a message, generated while sending and checking t
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Returns a `404 Not Found` error for a message outside the account retention window.
 
 ### Path parameters
 
@@ -1581,7 +1619,7 @@ A list of Messages that were mutated during the call.
 </ContentColumn>
 </Section>
 
-<Section title="Bulk changing message statuses in a channel" slug="bulk-update-channel-message-status">
+<Section isRetentionSubject title="Bulk changing message statuses in a channel" slug="bulk-update-channel-message-status">
 <ContentColumn>
 
 Apply the given `status` to a set of messages for the given channel. Will modify all valid messages, or a subset based on the filters provided.
@@ -1595,6 +1633,10 @@ Returns a `BulkOperation` that executes the job asynchronously. Progress can be 
 ### Rate limit
 
 <RateLimit tier={2} />
+
+### Data retention rule
+
+Messages outside the account retention window will not be updated as part of this operation.
 
 ### Path parameters
 
@@ -2289,7 +2331,7 @@ A User.
 </ExampleColumn>
 </Section>
 
-<Section title="User messages" slug="get-user-messages">
+<Section isRetentionSubject title="User messages" slug="get-user-messages">
 <ContentColumn>
 
 Retrieve a paginated list of messages for a user. Will return most recent messages first.
@@ -2301,6 +2343,10 @@ Retrieve a paginated list of messages for a user. Will return most recent messag
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Messages outside the account retention window will not be included in the results.
 
 ### Path parameters
 
@@ -2910,7 +2956,7 @@ Returns an `Object`.
 </ExampleColumn>
 </Section>
 
-<Section title="Object messages" slug="get-object-messages">
+<Section isRetentionSubject title="Object messages" slug="get-object-messages">
 <ContentColumn>
 
 Returns a paginated list of messages for an object. Will return newest messages first.
@@ -2922,6 +2968,10 @@ Returns a paginated list of messages for an object. Will return newest messages 
 ### Rate limit
 
 <RateLimit tier={4} />
+
+### Data retention rule
+
+Messages outside the account retention window will not be included in the results.
 
 ### Path parameters
 

--- a/content/send-notifications/debugging-workflows.mdx
+++ b/content/send-notifications/debugging-workflows.mdx
@@ -33,6 +33,20 @@ You can see a video of our workflow debugger in action here:
 
 ## Accessing the workflow debugger
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">
+        Data subject to retention policy enforcement.
+      </span>{" "}
+      See the{" "}
+      <a href="/manage-your-account/data-retention">data retention docs</a> for
+      more details on how Knock enforces this policy.
+    </>
+  }
+/>
+
 You can access the workflow debugger from our "Logs" page, which you'll find in the left hand environment sidebar in the dashboard. From there:
 
 1. Find an API log that triggered a workflow run (**hint**: you can use the filters to find only workflow API requests)

--- a/data/apiReferenceSidebar.ts
+++ b/data/apiReferenceSidebar.ts
@@ -12,6 +12,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "#rate-limits", title: "Rate limits" },
       { slug: "#batch-rate-limits", title: "Batch rate limits" },
       { slug: "#idempotent-requests", title: "Idempotent requests" },
+      { slug: "#data-retention", title: "Data retention" },
       { slug: "#bulk-endpoints", title: "Bulk endpoints" },
       { slug: "#pagination", title: "Pagination" },
       { slug: "#errors", title: "Errors" },

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -293,6 +293,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/audit-logs", title: "Audit logs" },
       { slug: "/data-obfuscation", title: "Data obfuscation" },
       { slug: "/account-timezone", title: "Account timezone" },
+      { slug: "/data-retention", title: "Data retention" },
     ],
   },
 


### PR DESCRIPTION
### Description

- Adds a new page covering data retention policies
- Adds links back to the data retention page from relevant guides
- Adds a section on retention enforcement in the V1 API reference + info to each endpoint affected by retention rules

### Tasks

[PLA-330: Write docs on message retention enforcement](https://linear.app/knock/issue/PLA-330/write-docs-on-message-retention-enforcement)