### PR TITLE
fix: sentence fragment about email layouts

### DIFF
--- a/content/designing-workflows/template-editor/overview.mdx
+++ b/content/designing-workflows/template-editor/overview.mdx
@@ -169,7 +169,9 @@ Once you've finished editing your notification template, you can select "Preview
   emoji="🧩"
   text={
     <>
-      <span className="font-bold">Note: </span>When you enter preview mode for an email template, you'll see your email content wrapped within the template's selected <a href="/integrations/email/layouts">Layout</a>.
+      <span className="font-bold">Note: </span>When you enter preview mode for
+      an email template, you'll see your email content wrapped within the
+      template's selected <a href="/integrations/email/layouts">Layout</a>.
     </>
   }
 />

--- a/content/designing-workflows/template-editor/overview.mdx
+++ b/content/designing-workflows/template-editor/overview.mdx
@@ -163,7 +163,16 @@ When using the visual template editor, a handful of CSS styles are auto-generate
 
 ## Previewing and testing your notification template
 
-Once you've finished editing your notification template, you can select "preview" in the toggle in the top left of the template editor pane to enter preview mode. When you enter preview mode for an email template, you'll see your email content wrapped within it
+Once you've finished editing your notification template, you can select "Preview" in the toggle in the top left of the template editor pane to enter preview mode.
+
+<Callout
+  emoji="🧩"
+  text={
+    <>
+      <span className="font-bold">Note: </span>When you enter preview mode for an email template, you'll see your email content wrapped within the template's selected <a href="/integrations/email/layouts">Layout</a>.
+    </>
+  }
+/>
 
 Your notification preview is populated with the data available in the lefthand variable explorer pane. You can use the actor and recipient dropdowns to change the user data used in your preview, and you can click on any of your data variables to edit their preview value.
 


### PR DESCRIPTION
### Description

Fixes a sentence fragment about email layouts and adds it to a callout with a link to what a Layout is.

### Screenshots
<img width="1385" alt="image" src="https://github.com/user-attachments/assets/00f8f64d-3e48-489a-a732-d44b0f8271cc">


https://docs-63g33dvaf-knocklabs.vercel.app/designing-workflows/template-editor/overview#previewing-and-testing-your-notification-template
