### PR TITLE
Update documentation link

### DIFF
--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -50,7 +50,7 @@ When silent push is enabled, we'll no longer pass through the content payload an
 
 We have full support for overriding the payload sent to Expo for adding things like badge counts, extra data properties, and sound files. You can set the push overrides on the template settings modal, open it by clicking on the "Manage template settings" button. Push overrides support liquid for injecting data properties and referencing attributes on your recipients.
 
-The overrides set are merged into the notification payload sent to Expo. See the [Expo documentation for details](https://docs.expo.dev/versions/latest/sdk/notifications/#notificationcontent).
+The overrides set are merged into the notification payload sent to Expo. See the [Expo documentation for details](https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format).
 
 ## Channel data requirements
 


### PR DESCRIPTION
### Description
Hi there, I believe the documentation on overriding Expo payloads through the template editor might be linking to wrong expo docs. Instead of the Push API docs it links to client side types and so there's a bit of a mismatch in terms of fields that can be specified :))
