### PR TITLE
chore: update expo links

### DIFF
--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -6,21 +6,22 @@ section: Integrations
 layout: integrations
 ---
 
+
 In this guide we'll walk through how to configure an Expo provider in Knock to send push notifications. This guide assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
 
-If you're new to setting up push in your Expo enabled React Native project, you can follow the [excellent setup guide in the Expo documentation](https://docs.expo.dev/push-notifications/overview/).
+If you're new to setting up push in your Expo enabled React Native project, you can follow the <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">excellent setup guide in the Expo documentation</a>.
 
 ## How to configure Expo with Knock
 
-To configure Expo with Knock, you'll need your Expo project name (sometimes referred to as an `experience_id`) and if you've enabled enhanced push security, you'll also need an auth token. You can read more about [Enhanced Push Security in the Expo docs](https://docs.expo.dev/push-notifications/sending-notifications/#additional-security).
+To configure Expo with Knock, you'll need your Expo project name (sometimes referred to as an `experience_id`) and if you've enabled enhanced push security, you'll also need an auth token. You can read more about <a href="https://docs.expo.dev/push-notifications/sending-notifications/#additional-security" target="_blank">Enhanced Push Security in the Expo docs</a>.
 
-You can get both of these by logging into the [Expo console](https://expo.dev/). Once you have them, go back to the environment configuration for your Expo channel, complete the configuration, and you're good to go.
+You can get both of these by logging into the <a href="https://expo.dev/" target="_blank">Expo console</a>. Once you have them, go back to the environment configuration for your Expo channel, complete the configuration, and you're good to go.
 
 ## Using Expo with Knock
 
 In order to use Expo with Knock you'll need to synchronize your users device tokens retrieved from the Expo SDK in either Android, iOS, or on the Web to Knock by [setting channel data](/send-notifications/setting-channel-data) for your recipient.
 
-You can follow the appropriate [quickstart guide for your platform](https://docs.expo.dev/push-notifications/overview/) on Expo to see how to get the device token.
+You can follow the appropriate <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">quickstart guide for your platform</a> on Expo to see how to get the device token.
 
 <MultiLangCodeBlock
   snippet="users.setChannelData-push"
@@ -50,11 +51,11 @@ When silent push is enabled, we'll no longer pass through the content payload an
 
 We have full support for overriding the payload sent to Expo for adding things like badge counts, extra data properties, and sound files. You can set the push overrides on the template settings modal, open it by clicking on the "Manage template settings" button. Push overrides support liquid for injecting data properties and referencing attributes on your recipients.
 
-The overrides set are merged into the notification payload sent to Expo. See the [Expo documentation for details](https://docs.expo.dev/versions/latest/sdk/notifications/#notificationcontent).
+The overrides set are merged into the notification payload sent to Expo. See the <a href="https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format" target="_blank">Expo documentation for details</a>.
 
 ## Channel data requirements
 
-In order to use a configured Expo channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the guide on the [Expo developer documentation](https://docs.expo.dev/push-notifications/push-notifications-setup/).
+In order to use a configured Expo channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the guide on the <a href="https://docs.expo.dev/push-notifications/push-notifications-setup/" target="_blank">Expo developer documentation</a>.
 
 | Property | Type     | Description               |
 | -------- | -------- | ------------------------- |

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -6,7 +6,6 @@ section: Integrations
 layout: integrations
 ---
 
-
 In this guide we'll walk through how to configure an Expo provider in Knock to send push notifications. This guide assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
 
 If you're new to setting up push in your Expo enabled React Native project, you can follow the <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">excellent setup guide in the Expo documentation</a>.


### PR DESCRIPTION
### Description

This PR does two things:
1. Update link under payload override section to reference Expo's notification send API docs rather than the client-side `NotificationContent` (not all of the front-end params are supported by Expo API).
2. Update all Expo links to use `<a>` tags that open in a new tab rather than redirecting away from Knock documentation.

https://docs-nopm4mqaq-knocklabs.vercel.app/integrations/push/expo