### PR TITLE
chore: add list preferences endpoints

### DIFF
--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -34,6 +34,7 @@ const snippets = {
     require("../data/code/users/set-preferences-per-tenant").default,
   "users.bulkSetPreferences": require("../data/code/users/bulk-set-preferences")
     .default,
+  "users.listPreferences": require("../data/code/users/list-preferences").default,
   "users.getPreferences": require("../data/code/users/get-preferences").default,
   "users.getChannelData": require("../data/code/users/get-channel-data")
     .default,

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -76,6 +76,8 @@ const snippets = {
     .default,
   "objects.getChannelData": require("../data/code/objects/get-channel-data")
     .default,
+  "objects.listPreferences": require("../data/code/objects/list-preferences")
+    .default,
   "objects.getPreferences": require("../data/code/objects/get-preferences")
     .default,
   "objects.setPreferences": require("../data/code/objects/set-preferences")

--- a/components/MultiLangCodeBlock.tsx
+++ b/components/MultiLangCodeBlock.tsx
@@ -34,7 +34,8 @@ const snippets = {
     require("../data/code/users/set-preferences-per-tenant").default,
   "users.bulkSetPreferences": require("../data/code/users/bulk-set-preferences")
     .default,
-  "users.listPreferences": require("../data/code/users/list-preferences").default,
+  "users.listPreferences": require("../data/code/users/list-preferences")
+    .default,
   "users.getPreferences": require("../data/code/users/get-preferences").default,
   "users.getChannelData": require("../data/code/users/get-channel-data")
     .default,

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4113,7 +4113,10 @@ Returns a list of `PreferenceSet` objects.
 </ContentColumn>
 <ExampleColumn>
 
-<MultiLangCodeBlock snippet="users.listPreferences" title="List a user's preferences" />
+<MultiLangCodeBlock
+  snippet="users.listPreferences"
+  title="List a user's preferences"
+/>
 
 ```json title="Response"
 [
@@ -4331,7 +4334,6 @@ Returns a `PreferenceSet`.
 </ExampleColumn>
 </Section>
 
-
 <Section title="Listing object preferences" slug="get-all-preferences-object">
 <ContentColumn>
 
@@ -4371,7 +4373,10 @@ Returns a list of `PreferenceSet` objects.
 </ContentColumn>
 <ExampleColumn>
 
-<MultiLangCodeBlock snippet="objects.listPreferences" title="List an object's preferences" />
+<MultiLangCodeBlock
+  snippet="objects.listPreferences"
+  title="List an object's preferences"
+/>
 
 ```json title="Response"
 [
@@ -4381,7 +4386,7 @@ Returns a list of `PreferenceSet` objects.
     "workflows": null,
     "channel_types": {
       "in_app_feed": true,
-      "sms": true 
+      "sms": true
     },
     "categories": {
       "park-wide": {
@@ -4411,8 +4416,6 @@ Returns a list of `PreferenceSet` objects.
 
 </ExampleColumn>
 </Section>
-
-
 
 <Section title="Getting object preferences" slug="get-preferences-object">
 <ContentColumn>

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4028,18 +4028,19 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
   <Endpoint
     name="get-all-preferences-object"
     method="GET"
-    path="/objects/:collection/:id/preferences"
+    path="/objects/:collection/:object_id/preferences"
+    withLink
   />
   <Endpoint
     name="get-preferences-object"
     method="GET"
-    path="/objects/:collection/:id/preferences/:id"
+    path="/objects/:collection/:object_id/preferences/:id"
     withLink
   />
   <Endpoint
     name="set-preferences-object"
     method="PUT"
-    path="/objects/:collection/:id/preferences/:id"
+    path="/objects/:collection/:object_id/preferences/:id"
     withLink
   />
   <Endpoint
@@ -4077,6 +4078,7 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
 
 </ExampleColumn>
 </Section>
+
 <Section title="Listing user preferences" slug="get-all-preferences-user">
 <ContentColumn>
 
@@ -4329,6 +4331,89 @@ Returns a `PreferenceSet`.
 </ExampleColumn>
 </Section>
 
+
+<Section title="Listing object preferences" slug="get-all-preferences-object">
+<ContentColumn>
+
+Retrieve all preference sets for an object. This endpoint returns a list of preference sets associated with the object.
+
+### Endpoint
+
+<Endpoint
+  name="get-all-preferences-object"
+  method="GET"
+  path="/objects/:collection/:object_id/preferences"
+/>
+
+### Rate limit
+
+<RateLimit tier={4} />
+
+### Path parameters
+
+<Attributes>
+  <Attribute
+    name="collection"
+    type="string"
+    description="The parent collection of the object to lookup"
+  />
+  <Attribute
+    name="object_id"
+    type="string"
+    description="The id of the object to lookup"
+  />
+</Attributes>
+
+### Response
+
+Returns a list of `PreferenceSet` objects.
+
+</ContentColumn>
+<ExampleColumn>
+
+<MultiLangCodeBlock snippet="objects.listPreferences" title="List an object's preferences" />
+
+```json title="Response"
+[
+  {
+    "__typename": "PreferenceSet",
+    "id": "default",
+    "workflows": null,
+    "channel_types": {
+      "in_app_feed": true,
+      "sms": true 
+    },
+    "categories": {
+      "park-wide": {
+        "sms": false
+      }
+    }
+  },
+  {
+    "__typename": "PreferenceSet",
+    "id": "tenant-1",
+    "workflows": {
+      "new-comment": {
+        "channel_types": {
+          "email": true,
+          "in_app_feed": false
+        }
+      }
+    },
+    "channel_types": {
+      "in_app_feed": true,
+      "sms": false
+    },
+    "categories": null
+  }
+]
+```
+
+</ExampleColumn>
+</Section>
+
+
+
 <Section title="Getting object preferences" slug="get-preferences-object">
 <ContentColumn>
 
@@ -4351,14 +4436,14 @@ even if it does not currently exist for the object.
 
 <Attributes>
   <Attribute
-    name="object_id"
-    type="string"
-    description="The id of the object to lookup"
-  />
-  <Attribute
     name="collection"
     type="string"
     description="The parent collection of the object to lookup"
+  />
+  <Attribute
+    name="object_id"
+    type="string"
+    description="The id of the object to lookup"
   />
   <Attribute
     name="id"
@@ -4442,14 +4527,14 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
 
 <Attributes>
   <Attribute
-    name="object_id"
-    type="string"
-    description="The id of the object to lookup"
-  />
-  <Attribute
     name="collection"
     type="string"
     description="The parent collection of the object to lookup"
+  />
+  <Attribute
+    name="object_id"
+    type="string"
+    description="The id of the object to lookup"
   />
   <Attribute
     name="id"

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -4011,11 +4011,7 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
     name="get-all-preferences-user"
     method="GET"
     path="/users/:user_id/preferences"
-  />
-  <Endpoint
-    name="get-all-preferences-object"
-    method="GET"
-    path="/objects/:collection/:id/preferences"
+    withLink
   />
   <Endpoint
     name="get-preferences-user"
@@ -4024,15 +4020,20 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
     withLink
   />
   <Endpoint
-    name="get-preferences-object"
-    method="GET"
-    path="/objects/:collection/:id/preferences/:id"
-    withLink
-  />
-  <Endpoint
     name="set-preferences-user"
     method="PUT"
     path="/users/:user_id/preferences/:id"
+    withLink
+  />
+  <Endpoint
+    name="get-all-preferences-object"
+    method="GET"
+    path="/objects/:collection/:id/preferences"
+  />
+  <Endpoint
+    name="get-preferences-object"
+    method="GET"
+    path="/objects/:collection/:id/preferences/:id"
     withLink
   />
   <Endpoint
@@ -4072,6 +4073,80 @@ The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more 
     }
   }
 }
+```
+
+</ExampleColumn>
+</Section>
+<Section title="Listing user preferences" slug="get-all-preferences-user">
+<ContentColumn>
+
+Retrieve all preference sets for a user. This endpoint returns a list of preference sets associated with the user.
+
+### Endpoint
+
+<Endpoint
+  name="get-all-preferences-user"
+  method="GET"
+  path="/users/:user_id/preferences"
+/>
+
+### Rate limit
+
+<RateLimit tier={4} />
+
+### Path parameters
+
+<Attributes>
+  <Attribute
+    name="user_id"
+    type="string"
+    description="Unique identifier for the user"
+  />
+</Attributes>
+
+### Response
+
+Returns a list of `PreferenceSet` objects.
+
+</ContentColumn>
+<ExampleColumn>
+
+<MultiLangCodeBlock snippet="users.listPreferences" title="List a user's preferences" />
+
+```json title="Response"
+[
+  {
+    "__typename": "PreferenceSet",
+    "id": "default",
+    "workflows": null,
+    "channel_types": {
+      "in_app_feed": true,
+      "sms": true
+    },
+    "categories": {
+      "park-wide": {
+        "sms": false
+      }
+    }
+  },
+  {
+    "__typename": "PreferenceSet",
+    "id": "tenant-1",
+    "workflows": {
+      "new-comment": {
+        "channel_types": {
+          "email": false,
+          "in_app_feed": true
+        }
+      }
+    },
+    "channel_types": {
+      "in_app_feed": true,
+      "sms": false
+    },
+    "categories": null
+  }
+]
 ```
 
 </ExampleColumn>
@@ -4129,7 +4204,7 @@ Returns a `PreferenceSet`.
 
 <MultiLangCodeBlock
   snippet="users.getPreferences"
-  title="Get a users preferences"
+  title="Get a user's preferences"
 />
 
 ```json title="Response"
@@ -4225,7 +4300,7 @@ Returns a `PreferenceSet`.
 
 <MultiLangCodeBlock
   snippet="users.setPreferences"
-  title="Set a users preferences"
+  title="Set a user's preferences"
 />
 
 ```json title="Response"
@@ -4248,92 +4323,6 @@ Returns a `PreferenceSet`.
       "sms": false
     }
   }
-}
-```
-
-</ExampleColumn>
-</Section>
-
-<Section title="Bulk set preferences" slug="bulk-set-preferences">
-<ContentColumn>
-
-Bulk sets the preferences for up to 1000 users at a time. Returns a `BulkOperation` that executes the job asynchronously. Progress can be tracked via the [BulkOperation API](#bulk-operations).
-
-The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about [per-tenant preferences](/preferences/tenant-preferences).
-
-Please note: This is a destructive operation and will replace any existing users' preferences with the preferences sent.
-
-### Endpoint
-
-<Endpoint
-  name="bulk-set-preferences"
-  method="POST"
-  path="/users/bulk/preferences"
-/>
-
-### Rate limit
-
-<RateLimit tier={1} />
-
-### Body parameters
-
-<Attributes>
-  <Attribute
-    name="user_ids"
-    type="string[]"
-    description="A list of user ids to set preferences for"
-  />
-  <Attribute
-    name="preferences.id"
-    type="string"
-    description="The id of the preference set"
-  />
-  <Attribute
-    name="preferences.channel_types"
-    type="object"
-    description="A set of channel type preferences to set"
-  />
-  <Attribute
-    name="preferences.workflows"
-    type="object"
-    description="A set of workflow preferences, can be a boolean or an object containing channel type preferences"
-  />
-  <Attribute
-    name="preferences.categories"
-    type="object"
-    description="A set of categories preferences, can be a boolean or an object containing channel type preferences"
-  />
-</Attributes>
-
-### Response
-
-Returns a `BulkOperation`.
-
-</ContentColumn>
-<ExampleColumn>
-
-<MultiLangCodeBlock
-  snippet="users.bulkSetPreferences"
-  title="Bulk set many users preferences"
-/>
-
-```json title="Response"
-{
-  "__typename": "BulkOperation",
-  "completed_at": "2021-03-05T12:00:00Z",
-  "error_count": 0,
-  "error_items": [],
-  "estimated_total_rows": 42,
-  "failed_at": null,
-  "id": "50d2847b-c738-466a-a3d7-e68e4bb1cedd",
-  "inserted_at": "2021-03-05T12:00:00Z",
-  "name": "users.set_preferences",
-  "processed_rows": 42,
-  "progress_path": "/v1/bulk_operations/50d2847b-c738-466a-a3d7-e68e4bb1cedd",
-  "started_at": "2021-03-05T12:00:00Z",
-  "status": "completed",
-  "success_count": 42,
-  "updated_at": "2021-03-05T12:00:00Z"
 }
 ```
 
@@ -4397,7 +4386,7 @@ Returns a `PreferenceSet`.
 
 <MultiLangCodeBlock
   snippet="objects.getPreferences"
-  title="Get an objects preferences"
+  title="Get an object's preferences"
 />
 
 ```json title="Response"
@@ -4498,7 +4487,7 @@ Returns a `PreferenceSet`.
 
 <MultiLangCodeBlock
   snippet="objects.setPreferences"
-  title="Set an objects preferences"
+  title="Set an object's preferences"
 />
 
 ```json title="Response"
@@ -4521,6 +4510,92 @@ Returns a `PreferenceSet`.
       "sms": false
     }
   }
+}
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="Bulk set user preferences" slug="bulk-set-preferences">
+<ContentColumn>
+
+Bulk sets the preferences for up to 1000 users at a time. Returns a `BulkOperation` that executes the job asynchronously. Progress can be tracked via the [BulkOperation API](#bulk-operations).
+
+The preference set `:id` can be either `"default"` or a `tenant.id`. Learn more about [per-tenant preferences](/preferences/tenant-preferences).
+
+Please note: This is a destructive operation and will replace any existing users' preferences with the preferences sent.
+
+### Endpoint
+
+<Endpoint
+  name="bulk-set-preferences"
+  method="POST"
+  path="/users/bulk/preferences"
+/>
+
+### Rate limit
+
+<RateLimit tier={1} />
+
+### Body parameters
+
+<Attributes>
+  <Attribute
+    name="user_ids"
+    type="string[]"
+    description="A list of user ids to set preferences for"
+  />
+  <Attribute
+    name="preferences.id"
+    type="string"
+    description="The id of the preference set"
+  />
+  <Attribute
+    name="preferences.channel_types"
+    type="object"
+    description="A set of channel type preferences to set"
+  />
+  <Attribute
+    name="preferences.workflows"
+    type="object"
+    description="A set of workflow preferences, can be a boolean or an object containing channel type preferences"
+  />
+  <Attribute
+    name="preferences.categories"
+    type="object"
+    description="A set of categories preferences, can be a boolean or an object containing channel type preferences"
+  />
+</Attributes>
+
+### Response
+
+Returns a `BulkOperation`.
+
+</ContentColumn>
+<ExampleColumn>
+
+<MultiLangCodeBlock
+  snippet="users.bulkSetPreferences"
+  title="Bulk set many users' preferences"
+/>
+
+```json title="Response"
+{
+  "__typename": "BulkOperation",
+  "completed_at": "2021-03-05T12:00:00Z",
+  "error_count": 0,
+  "error_items": [],
+  "estimated_total_rows": 42,
+  "failed_at": null,
+  "id": "50d2847b-c738-466a-a3d7-e68e4bb1cedd",
+  "inserted_at": "2021-03-05T12:00:00Z",
+  "name": "users.set_preferences",
+  "processed_rows": 42,
+  "progress_path": "/v1/bulk_operations/50d2847b-c738-466a-a3d7-e68e4bb1cedd",
+  "started_at": "2021-03-05T12:00:00Z",
+  "status": "completed",
+  "success_count": 42,
+  "updated_at": "2021-03-05T12:00:00Z"
 }
 ```
 

--- a/data/apiReferenceSidebar.ts
+++ b/data/apiReferenceSidebar.ts
@@ -113,11 +113,13 @@ const sidebarContent: SidebarSection[] = [
     slug: "/reference",
     pages: [
       { slug: "#preferences", title: "Overview" },
+      { slug: "#get-all-preferences-user", title: "List user preferences" },
       { slug: "#get-preferences-user", title: "Get user preferences" },
       { slug: "#set-preferences-user", title: "Set user preferences" },
-      { slug: "#bulk-set-preferences", title: "Bulk set user preferences" },
+      { slug: "#get-all-preferences-object", title: "List object preferences" },
       { slug: "#get-preferences-object", title: "Get object preferences" },
       { slug: "#set-preferences-object", title: "Set object preferences" },
+      { slug: "#bulk-set-preferences", title: "Bulk set user preferences" },
     ],
   },
 

--- a/data/code/objects/get-preferences.ts
+++ b/data/code/objects/get-preferences.ts
@@ -11,14 +11,14 @@ knock_client = MyApp.Knock.client()
 
 # If no preference set id is provided, the SDK will return the object's "default" preferences
 Knock.Objects.get_preferences(knock_client, "projects", "project-1", preference_set: "tenant-1")
-  `,
+`,
   python: `
 from knockapi import Knock
 client = Knock(api_key="sk_12345")
 
 # If no preference set id is provided, the SDK will return the object's "default" preferences
 client.objects.get_preferences(collection="projects", id="project-1", options={"preference_set": "tenant-1"})
-  `,
+`,
   ruby: `
 require "knock"
 Knock.key = "sk_12345"

--- a/data/code/objects/get-preferences.ts
+++ b/data/code/objects/get-preferences.ts
@@ -3,24 +3,28 @@ const languages = {
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 
-await knockClient.objects.getPreferences("projects", "project-1");
+// If no preference set id is provided, the SDK will return the object's "default" preferences
+await knockClient.objects.getPreferences("projects", "project-1", { preferenceSet: "tenant-1" });
 `,
   elixir: `
 knock_client = MyApp.Knock.client()
 
-Knock.Objects.get_preferences(knock_client, "projects", "project-1")
+# If no preference set id is provided, the SDK will return the object's "default" preferences
+Knock.Objects.get_preferences(knock_client, "projects", "project-1", preference_set: "tenant-1")
   `,
   python: `
 from knockapi import Knock
 client = Knock(api_key="sk_12345")
 
-client.objects.get_preferences(collection="projects", id="project-1")
+# If no preference set id is provided, the SDK will return the object's "default" preferences
+client.objects.get_preferences(collection="projects", id="project-1", options={"preference_set": "tenant-1"})
   `,
   ruby: `
 require "knock"
 Knock.key = "sk_12345"
 
-Knock::Objects.get_preferences(collection: "projects", id: "project-1")  
+# If no preference set id is provided, the SDK will return the object's "default" preferences
+Knock::Objects.get_preferences(collection: "projects", id: "project-1", preference_set: "tenant-1")
 `,
   csharp: `
 var knockClient = new KnockClient(
@@ -33,15 +37,18 @@ use Knock\\KnockSdk\\Client;
     
 $client = new Client('sk_12345');
 
-$client->objects()->getPreferences('projects', 'project-1');
+// The preference set id must be "default" or the id of a tenant you have created
+$client->objects()->getPreference('projects', 'project-1', 'default');
 `,
   go: `
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
+// If no preference set id is provided, the SDK will return the object's "default" preferences
 preferenceSet, _ := knockClient.Objects.GetPreferences(ctx, &knock.GetObjectPreferencesRequest{
-  Collection: "projects",
-  ID:         "project-1"
+  Collection:   "projects",
+  ID:           "project-1",
+  PreferenceID: "tenant-1",
 })
 `,
   java: `
@@ -52,6 +59,7 @@ KnockClient client = KnockClient.builder()
     .apiKey("sk_12345")
     .build();
 
+// The preference set id must be "default" or the id of a tenant you have created
 PreferenceSet prefs = client.objects().getPreferencesById("projects", "project-1", "default");
 `,
 };

--- a/data/code/objects/get-preferences.ts
+++ b/data/code/objects/get-preferences.ts
@@ -30,7 +30,8 @@ Knock::Objects.get_preferences(collection: "projects", id: "project-1", preferen
 var knockClient = new KnockClient(
   new KnockOptions { ApiKey = "sk_12345" });
 
-await knockClient.Objects.GetPreferences("projects", "project-1");
+// If no preference set id is provided, the SDK will return the object's "default" preferences
+await knockClient.Objects.GetPreferences("projects", "project-1", preferenceSetId: "tenant-1");
 `,
   php: `
 use Knock\\KnockSdk\\Client;

--- a/data/code/objects/list-preferences.ts
+++ b/data/code/objects/list-preferences.ts
@@ -1,0 +1,54 @@
+const languages = {
+  node: `
+import { Knock } from "@knocklabs/node";
+const knockClient = new Knock("sk_12345");
+
+const allPreferences = await knockClient.objects.getAllPreferences("projects", "project-1");
+`,
+  elixir: `
+knock_client = MyApp.Knock.client()
+
+all_preferences = Knock.Objects.get_all_preferences(knock_client, "projects", "project-1")
+`,
+  python: `
+from knockapi import Knock
+client = Knock(api_key="sk_12345")
+
+all_preferences = client.objects.get_all_preferences(collection="projects", id="project-1")
+`,
+  ruby: `
+require "knock"
+Knock.key = "sk_12345"
+
+all_preferences = Knock::Objects.get_all_preferences(collection: "projects", id: "project-1")
+`,
+  csharp: `
+var knockClient = new KnockClient(
+  new KnockOptions { ApiKey = "sk_12345" });
+
+var allPreferences = await knockClient.Objects.GetAllPreferences("projects", "project-1");
+`,
+  php: `
+use Knock\\KnockSdk\\Client;
+    
+$client = new Client('sk_12345');
+
+$allPreferences = $client->objects()->getPreferences('projects', 'project-1');
+`,
+  go: `
+// This endpoint is not yet supported in the Go SDK
+
+`,
+  java: `
+import app.knock.api.KnockClient;
+import app.knock.api.model.*;
+
+KnockClient client = KnockClient.builder()
+    .apiKey("sk_12345")
+    .build();
+
+List<PreferenceSet> allPreferences = client.objects().getPreferences("projects", "project-1");
+`,
+};
+
+export default languages;

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -26,7 +26,7 @@ require "knock"
 Knock.key = "sk_12345"
 
 # If no preference set id is provided, the SDK will return the user's "default" preferences
-Knock::Users.get_preferences(id: user.id, preference_set: "tenant-1")
+Knock::Users.get_preferences(user.id, preference_set: "tenant-1")
 `,
   csharp: `
 var knockClient = new KnockClient(

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -40,8 +40,8 @@ use Knock\\KnockSdk\\Client;
 
 $client = new Client('sk_12345');
 
-// If no preference set id is provided, the SDK will return the user's "default" preferences
-$client->users()->getPreference($user->id(), 'tenant-1');
+// The preference set id must be "default" or the id of a tenant you have created
+$client->users()->getPreference($user->id(), 'default');
 `,
   go: `
 ctx := context.Background()

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -13,14 +13,14 @@ knock_client = MyApp.Knock.client()
 
 # If no preference set id is provided, the SDK will return the user's "default" preferences
 Knock.Users.get_preferences(knock_client, user.id, preference_set: "tenant-1")
-  `,
+`,
   python: `
 from knockapi import Knock
 client = Knock(api_key="sk_12345")
 
 # If no preference set id is provided, the SDK will return the user's "default" preferences
 client.users.get_preferences(user.id, options={"preference_set": "tenant-1"})
-  `,
+`,
   ruby: `
 require "knock"
 Knock.key = "sk_12345"

--- a/data/code/users/get-preferences.ts
+++ b/data/code/users/get-preferences.ts
@@ -3,44 +3,54 @@ const languages = {
 import { Knock } from "@knocklabs/node";
 const knockClient = new Knock("sk_12345");
 
-const preferences = await knockClient.users.getPreferences(user.id);
+// If no preference set id is provided, the SDK will return the user's "default" preferences
+const preferences = await knockClient.users.getPreferences(user.id, {
+  preferenceSet: "tenant-1"
+});
 `,
   elixir: `
 knock_client = MyApp.Knock.client()
 
-Knock.Users.get_preferences(knock_client, user.id)
+# If no preference set id is provided, the SDK will return the user's "default" preferences
+Knock.Users.get_preferences(knock_client, user.id, preference_set: "tenant-1")
   `,
   python: `
 from knockapi import Knock
 client = Knock(api_key="sk_12345")
 
-client.users.get_preferences(user.id)
+# If no preference set id is provided, the SDK will return the user's "default" preferences
+client.users.get_preferences(user.id, options={"preference_set": "tenant-1"})
   `,
   ruby: `
 require "knock"
 Knock.key = "sk_12345"
 
-Knock::Users.get_preferences(id: user.id)  
+# If no preference set id is provided, the SDK will return the user's "default" preferences
+Knock::Users.get_preferences(id: user.id, preference_set: "tenant-1")
 `,
   csharp: `
 var knockClient = new KnockClient(
   new KnockOptions { ApiKey = "sk_12345" });
 
-await knockClient.Users.GetPreferences(user.Id);
+// If no preference set id is provided, the SDK will return the user's "default" preferences
+await knockClient.Users.GetPreferences(user.Id, preferenceSetId: "tenant-1");
 `,
   php: `
 use Knock\\KnockSdk\\Client;
 
 $client = new Client('sk_12345');
 
-$client->users()->getPreferences($user->id());
+// If no preference set id is provided, the SDK will return the user's "default" preferences
+$client->users()->getPreference($user->id(), 'tenant-1');
 `,
   go: `
 ctx := context.Background()
 knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
+// If no preference set id is provided, the SDK will return the user's "default" preferences
 preferences, _ := knockClient.Users.GetPreferences(ctx, &knock.GetUserPreferencesRequest{
   UserID: user.ID,
+  PreferenceID: "tenant-1",
 })
 `,
   java: `
@@ -51,7 +61,11 @@ KnockClient client = KnockClient.builder()
     .apiKey("sk_12345")
     .build();
 
+// Request a user's "default" preferences
 PreferenceSet preferences = client.users().getDefaultPreferences(user.getId());
+
+// Request tenant-specific preferences for a user
+PreferenceSet preferences = client.users().getPreferencesById(user.getId(), "tenant-1");
 `,
 };
 

--- a/data/code/users/list-preferences.ts
+++ b/data/code/users/list-preferences.ts
@@ -1,0 +1,57 @@
+const languages = {
+  node: `
+import { Knock } from "@knocklabs/node";
+const knockClient = new Knock("sk_12345");
+
+const allPreferences = await knockClient.users.getAllPreferences(user.id);
+`,
+  python: `
+from knockapi import Knock
+client = Knock(api_key="sk_12345")
+
+all_preferences = client.users.get_all_preferences(user.id)
+`,
+  elixir: `
+knock_client = MyApp.Knock.client()
+
+all_preferences = Knock.Users.get_all_preferences(knock_client, user.id)
+`,
+  ruby: `
+require "knock"
+Knock.key = "sk_12345"
+
+all_preferences = Knock::Users.get_all_preferences(user.id)
+`,
+  csharp: `
+var knockClient = new KnockClient(
+  new KnockOptions { ApiKey = "sk_12345" });
+
+var allPreferences = await knockClient.Users.GetAllPreferences(user.Id);
+`,
+  php: `
+use Knock\\KnockSdk\\Client;
+
+$client = new Client('sk_12345');
+
+$allPreferences = $client->users()->getPreferences($user->id());
+`,
+  go: `
+ctx := context.Background()
+knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
+
+allPreferences, _ := knockClient.Users.GetAllPreferences(ctx, &knock.GetAllPreferencesRequest{
+    UserID: user.ID,
+})
+`,
+  java: `
+import app.knock.api.KnockClient;
+import app.knock.api.model.*;
+
+KnockClient client = KnockClient.builder()
+    .apiKey("sk_12345")
+    .build();
+
+List<PreferenceSet> allPreferences = client.users().getPreferences(user.getId());
+`,
+}
+export default languages;

--- a/data/code/users/list-preferences.ts
+++ b/data/code/users/list-preferences.ts
@@ -53,5 +53,5 @@ KnockClient client = KnockClient.builder()
 
 List<PreferenceSet> allPreferences = client.users().getPreferences(user.getId());
 `,
-}
+};
 export default languages;


### PR DESCRIPTION
### Description

This PR adds documentation for the endpoints to list User and Object preferences. This includes:
- New code examples for these two endpoints
- Corrections to the existing "Get preferences" code examples (some were using the wrong methods, etc.)
- Modifications to the existing "Get preferences" code examples to make usage related to "default" preferences clearer
- Re-ordering the Preferences endpoints and sidebar 

https://docs-fl95gty42-knocklabs.vercel.app/reference#get-all-preferences-user
https://docs-fl95gty42-knocklabs.vercel.app/reference#get-all-preferences-object

