### PR TITLE
fix: consistent line number styling

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -194,7 +194,14 @@ export const CodeBlock: React.FC<Props> = ({
       <SyntaxHighlighter
         showLineNumbers
         lineNumberStyle={{
+          // ensure consistent line number styles across languages
           color: "#ccc",
+          display: "inline-block",
+          minWidth: "2.25em",
+          paddingRight: "1em",
+          textAlign: "right",
+          userSelect: "none",
+          paddingLeft: "0px",
         }}
         language={lang}
         style={theme === "light" ? lightCodeTheme : darkCodeTheme}


### PR DESCRIPTION
### Description

This PR adds explicit styles for line numbers to our code blocks, as the default styling provided by the syntax highlighter doesn't seem to always be consistent across various code examples. You can check out the looms below to see what the issue looks like right now.

I just grabbed the styles as they were rendered on the page in one of the examples that looked "correct," but we can modify them to have a bit more left margin etc. if desired.

Example endpoint that I show in the videos: https://docs-bs9b7rmx6-knocklabs.vercel.app/reference#get-message-activities

### Videos

https://www.loom.com/share/fe188131c51345f7a34f091d6aba20eb
https://www.loom.com/share/75f5a7e8bc7442519bfbbed251ae7980
