### PR TITLE
fix: add tsx language registration for SyntaxHighlighter

### DIFF
--- a/components/CodeBlock.tsx
+++ b/components/CodeBlock.tsx
@@ -26,6 +26,7 @@ SyntaxHighlighter.registerLanguage("javascript", javascript);
 SyntaxHighlighter.registerLanguage("jsx", javascript);
 SyntaxHighlighter.registerLanguage("js", javascript);
 SyntaxHighlighter.registerLanguage("jsweb", javascript);
+SyntaxHighlighter.registerLanguage("tsx", javascript);
 SyntaxHighlighter.registerLanguage("ruby", ruby);
 SyntaxHighlighter.registerLanguage("elixir", elixir);
 SyntaxHighlighter.registerLanguage("csharp", dotnet);

--- a/content/in-app-ui/react-native/components.mdx
+++ b/content/in-app-ui/react-native/components.mdx
@@ -190,7 +190,7 @@ export default NotificationFeedContainer;
   />
 </Attributes>
 
-### Examples
+### Example
 
 ```tsx
 import { NotificationIconButton } from "@knocklabs/react-native";

--- a/content/in-app-ui/react-native/components.mdx
+++ b/content/in-app-ui/react-native/components.mdx
@@ -119,6 +119,8 @@ const MyNotificationFeed = () => {
 };
 ```
 
+<br />
+
 ```tsx
 import { ActionButton, FeedItem } from "@knocklabs/client";
 import { NotificationFeed } from "@knocklabs/react-native";

--- a/content/in-app-ui/react-native/customization.mdx
+++ b/content/in-app-ui/react-native/customization.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Customization of Knock UI Components"
-description: How to customize the UI of our pre-built components for React Native".
+description: How to customize the UI of our pre-built components for React Native.
 section: Building in-app UI
 ---
 

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -32,14 +32,13 @@ npm install @knocklabs/react-native
 <Callout emoji="🔐"
   text={
     <>
-      <span className="font-bold">Secure your feed: </span> By default, Knock
+      <strong>Secure your feed. </strong> By default, Knock
       feeds are accessible to anyone who has the feed ID. This makes it
       easy to get started in development. To secure your feed for production,
       enable enhanced security mode in your Knock dashboard and pass a signed
       {" "}<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
-      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
-      for client-side applications.
+      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a> for client-side applications.
     </>
 
 }


### PR DESCRIPTION
### Description
I noticed that the newly added code block examples for RN components didn't have the syntax highlighting applied, so I added tsx to be registered with the `SyntaxHighlighter`. I also made some small adjustments for some little things I found (i.e., added a line break between the code blocks).