### PR TITLE
chore: create trigger data validation page

### DIFF
--- a/content/developer-tools/validating-trigger-data.mdx
+++ b/content/developer-tools/validating-trigger-data.mdx
@@ -13,6 +13,7 @@ Trigger data validation lets you define a [JSON schema](https://json-schema.org/
 You can enable and configure trigger data validation in two ways:
 
 1. **Via the Workflow Builder:**
+
    - Navigate to the "Trigger step" in the workflow builder
    - Under the "API params" section, click "Edit schema"
    - Supply a valid JSON schema

--- a/content/developer-tools/validating-trigger-data.mdx
+++ b/content/developer-tools/validating-trigger-data.mdx
@@ -1,0 +1,51 @@
+---
+title: Validating workflow trigger data
+description: Learn how to validate the data passed to your Knock workflows using JSON schemas to ensure accuracy and prevent errors in your notifications.
+section: Developer tools
+---
+
+Workflow trigger data is critical for ensuring your notifications have the right content and context. To help prevent errors and maintain data integrity, Knock offers a trigger data validation feature that allows you to specify the expected structure of the data passed to your workflows.
+
+Trigger data validation lets you define a [JSON schema](https://json-schema.org/) that describes the expected shape and types of data passed to your workflow. If the incoming data doesn't match the specified schema, the trigger endpoint will return a `422 Unprocessable Entity` error with details about where the validation failed.
+
+## How to set up trigger data validation
+
+You can enable and configure trigger data validation in two ways:
+
+1. **Via the Workflow Builder:**
+   - Navigate to the "Trigger step" in the workflow builder
+   - Under the "API params" section, click "Edit schema"
+   - Supply a valid JSON schema
+   - Commit your changes for the schema to take effect
+
+2. **Via the Management API or CLI:**
+   - Use the `trigger_data_json_schema` field to provide your schema
+
+## Example schema
+
+Here's an example of a simple schema that expects a `name` property in the trigger data:
+
+```json title="Trigger data validation schema"
+{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  },
+  "required": ["name"]
+}
+```
+
+With this schema in place, if the `name` property is missing or not a string, the trigger endpoint will return a `422` error.
+
+## Error handling
+
+When the incoming data fails validation, the API will respond with:
+
+- Status code: `422 Unprocessable Entity`
+- Response body: A list of validation errors, indicating where the data failed to meet the schema requirements
+
+This ensures that your workflows are not executed with incorrect or incomplete data, helping to maintain the integrity of your notification system.
+
+## Availability
+
+Trigger data validation is available to all Knock customers. We recommend implementing it for all critical workflows to ensure data consistency and prevent potential issues in your notification pipeline.

--- a/content/developer-tools/validating-trigger-data.mdx
+++ b/content/developer-tools/validating-trigger-data.mdx
@@ -6,7 +6,7 @@ section: Developer tools
 
 Workflow trigger data is critical for ensuring your notifications have the right content and context. To help prevent errors and maintain data integrity, Knock offers a trigger data validation feature that allows you to specify the expected structure of the data passed to your workflows.
 
-Trigger data validation lets you define a [JSON schema](https://json-schema.org/) that describes the expected shape and types of data passed to your workflow. If the incoming data doesn't match the specified schema, the trigger endpoint will return a `422 Unprocessable Entity` error with details about where the validation failed.
+Trigger data validation lets you define a <a href="https://json-schema.org/" target="_blank">JSON schema</a> that describes the expected shape and types of data passed to your workflow. If the incoming data doesn't match the specified schema, the trigger endpoint will return a `422 Unprocessable Entity` error with details about where the validation failed.
 
 ## How to set up trigger data validation
 

--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -115,6 +115,20 @@ You can also pass the schema data required by the workflow into the `trigger` ca
 
 The data requirements for the payload are determined in the workflow builder, including indicating which keys are required.
 
+<Callout
+  emoji="💡"
+  text={
+    <>
+      For more information on validating trigger data and working with JSON
+      schemas, see our guide on{" "}
+      <a href="/developer-tools/validating-trigger-data">
+        validating trigger data
+      </a>
+      .
+    </>
+  }
+/>
+
 ## Generating a cancellation key
 
 Each `trigger` call can optionally include a `cancellation_key` that allows you to uniquely identify
@@ -228,25 +242,3 @@ In some situations, you may want to limit the number of times that a recipient c
 Workflow trigger frequency lets you control the number of times that a recipient can run through a workflow, controlling if the workflow should trigger every time, or at most once for the recipient. By default, a workflow will trigger every time for a recipient.
 
 If you specify a workflow trigger frequency of "Once per recipient", then you can also optionally choose to include the tenant in the frequency control. When set, your workflow will only trigger once per-recipient, per-tenant.
-
-## Validating workflow trigger data
-
-Given how critical the data is that's passed to your workflow via the trigger API call, you may wish to validate the trigger data sent to Knock before a workflow is run. This is where the trigger data validation feature comes in to play.
-
-Trigger data validation lets you specify a [JSON schema](https://json-schema.org/) that describes the shape of the data that's passed to your workflow. If the data doesn't match the schema, then the trigger endpoint will return a `422` error with details of where the data failed validation.
-
-As an example, let's specify a schema for a workflow that expects a `name` property in the trigger data:
-
-```json title="Trigger data validation schema"
-{
-  "type": "object",
-  "properties": {
-    "name": { "type": "string" }
-  },
-  "required": ["name"]
-}
-```
-
-Now, when the `name` property is not included, or is an invalid type, the trigger endpoint will return a `422` error.
-
-You can enable trigger data validation under the "API params" portion of the trigger step in the workflow builder. To set the schema, you'll need to click "Edit schema" and supply a valid JSON schema. You will also need to commit your changes for the schema to take effect.

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -222,6 +222,7 @@ const sidebarContent: SidebarSection[] = [
           { slug: "/event-types", title: "Event types" },
         ],
       },
+      { slug: "/validating-trigger-data", title: "Validating trigger data" },
     ],
   },
 


### PR DESCRIPTION
### Description

Moves validating workflow trigger data into its own page under the developer tools section.

New page: https://docs-git-rt-move-trigger-validation-knocklabs.vercel.app/developer-tools/validating-trigger-data

Added a callout under the passing data section of the triggering workflows page: https://docs-git-rt-move-trigger-validation-knocklabs.vercel.app/send-notifications/triggering-workflows#passing-data#passing-data