### PR TITLE
chore: add trigger validation and frequency to workflow definition

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -227,9 +227,7 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
         "type": "string"
       }
     },
-    "required": [
-      "name"
-    ],
+    "required": ["name"],
     "type": "object"
   },
   "trigger_frequency": "every_trigger",

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -206,6 +206,7 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
   "environment": "development",
   "key": "december-16-demo",
   "name": "december-16-demo",
+  "sha": "f7e9d3b2a1c8e6m4k5j7h9g0i2l3n4p6q8r0t1u3v5w7x9y",
   "settings": { "override_preferences": true },
   "steps": [
     {
@@ -220,6 +221,18 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
       "type": "channel"
     }
   ],
+  "trigger_data_json_schema": {
+    "properties": {
+      "name": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "name"
+    ],
+    "type": "object"
+  },
+  "trigger_frequency": "every_trigger",
   "updated_at": "2023-02-08T22:15:19.846681Z",
   "valid": true
 }


### PR DESCRIPTION
### Description

This PR adds fields for workflow trigger validation, commit `sha`, and workflow frequency to the example workflow definition in the MAPI

https://docs-no0a8ced6-knocklabs.vercel.app/mapi#workflows-object