### PR TITLE
chore: fix mapi formatting

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -124,10 +124,8 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
 </ExampleColumn>
 </Section>
 
-<div className="flex flex-col md:flex-row w-full py-16" id="workflows-object">
+<Section title="Workflow definition" slug="workflows-object">
 <ContentColumn>
-
-## Workflow definition
 
 ### Attributes
 
@@ -170,11 +168,13 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
   <Attribute
     name="settings"
     type="WorkflowSettings"
+    typeSlug="#workflowsettings-definition"
     description="A map of workflow settings."
   />
   <Attribute
     name="steps"
     type="WorkflowStep[]"
+    typeSlug="#workflowstep-definition"
     description="A list of workflow step objects in the workflow, which may contain any of: channel step, delay step, batch step, fetch step."
   />
   <Attribute
@@ -237,12 +237,10 @@ You can retrieve, update, or create a workflow as well as list all workflows in 
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="WorkflowSettings definition" slug="workflowsettings-definition">
 <ContentColumn>
-
-## WorkflowSettings definition
 
 Optional settings for a workflow.
 
@@ -266,12 +264,10 @@ Optional settings for a workflow.
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="WorkflowStep definition" slug="workflowstep-definition">
 <ContentColumn>
-
-## WorkflowStep definition
 
 All workflow steps, regardless of its type, share a common set of core attributes.
 
@@ -319,14 +315,12 @@ All workflow steps, regardless of its type, share a common set of core attribute
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="ChannelStep definition" slug="channelstep-definition">
 <ContentColumn>
 
-## ChannelStep definition
-
-Contains all properties of the `WorkflowStep` and additionally:
+Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`</a> and additionally:
 
 ### Attributes
 
@@ -344,11 +338,12 @@ Contains all properties of the `WorkflowStep` and additionally:
   <Attribute
     name="template"
     type="object"
-    description="The message template set up with the channel step. The shape of the template depends on the type of the channel you'll be sending to. See below for definitions."
+    description="The message template set up with the channel step. The shape of the template depends on the type of the channel you'll be sending to. See below for definitions of each channel type template: email, in-app, SMS, push, chat, and webhook."
   />
   <Attribute
     name="send_windows"
     type="SendWindow[]"
+    typeSlug="#sendwindow-definition"
     description="A list of send window objects. Must include one send window object per day of the week."
   />
 </Attributes>
@@ -570,12 +565,10 @@ Contains all properties of the `WorkflowStep` and additionally:
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="SendWindow definition" slug="sendwindow-definition">
 <ContentColumn>
-
-## SendWindow definition
 
 ### Attributes
 
@@ -630,14 +623,12 @@ Contains all properties of the `WorkflowStep` and additionally:
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="Delay step definition" slug="delay-step-definition">
 <ContentColumn>
 
-## Delay step definition
-
-Contains all properties of the `WorkflowStep` and additionally:
+Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`</a> and additionally:
 
 ### Attributes
 
@@ -683,14 +674,12 @@ Must set either `settings.delay_for` or `settings.delay_until_field_path`.
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="Batch step definition" slug="batch-step-definition">
 <ContentColumn>
 
-## Batch step definition
-
-Contains all properties of the `WorkflowStep` and additionally:
+Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`</a> and additionally:
 
 ### Attributes
 
@@ -772,14 +761,12 @@ Must set either `settings.batch_window` or `settings.batch_until_field_path`.
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="Branch step definition" slug="branch-step-definition">
 <ContentColumn>
 
-## Branch step definition
-
-Contains all properties of the `WorkflowStep`, but **cannot have `conditions`** and additionally:
+Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`</a>, but **cannot have `conditions`** and additionally:
 
 ### Attributes
 
@@ -787,6 +774,7 @@ Contains all properties of the `WorkflowStep`, but **cannot have `conditions`** 
   <Attribute
     name="branches"
     type="WorkflowBranch[]"
+    typeSlug="#workflowbranch-definition"
     description="A list of workflow branches to be evaluated."
   />
 </Attributes>
@@ -797,6 +785,7 @@ Contains all properties of the `WorkflowStep`, but **cannot have `conditions`** 
   <Attribute
     name="steps"
     type="WorkflowStep[]"
+    typeSlug="#workflowstep-definition"
     description="A list of steps that will be executed if the branch is chosen."
   />
   <Attribute name="name" type="string" description="The name of the branch." />
@@ -837,14 +826,12 @@ Contains all properties of the `WorkflowStep`, but **cannot have `conditions`** 
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
-<div className="flex flex-col md:flex-row w-full py-16">
+<Section title="Fetch step definition" slug="fetch-step-definition">
 <ContentColumn>
 
-## Fetch step definition
-
-Contains all properties of the `WorkflowStep` and additionally:
+Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`</a> and additionally:
 
 ### Attributes
 
@@ -892,7 +879,7 @@ Contains all properties of the `WorkflowStep` and additionally:
 ```
 
 </ExampleColumn>
-</div>
+</Section>
 
 <Section title="List all workflows" slug="workflows-list">
 <ContentColumn>
@@ -1450,6 +1437,7 @@ You can retrieve, update, and create email layouts as well as listing all in a g
   <Attribute
     name="footer_links"
     type="EmailLayoutFooterLink[]"
+    typeSlug="#emaillayoutfooterlink-attributes"
     description="A list of one or more items to show in the footer of the email layout."
   />
 </Attributes>
@@ -2509,11 +2497,13 @@ You can retrieve all commits in a given environment, or show the details of one 
   <Attribute
     name="resource"
     type="CommitResource"
+    typeSlug="#commitresource-attributes"
     description="The resource object associated with the commit."
   />
   <Attribute
     name="author"
     type="CommitAuthor"
+    typeSlug="#commitauthor-attributes"
     description="The author responsible for the commit."
   />
   <Attribute

--- a/layouts/MapiReferenceLayout.tsx
+++ b/layouts/MapiReferenceLayout.tsx
@@ -21,7 +21,27 @@ const sidebarData = [
     slug: "/mapi",
     pages: [
       { slug: "#workflows-overview", title: "Introduction" },
-      { slug: "#workflows-object", title: "Workflow definition" },
+      {
+        slug: "",
+        title: "Workflow definitions",
+        pages: [
+          { slug: "#workflows-object", title: "Workflow definition" },
+          {
+            slug: "#workflowsettings-definition",
+            title: "WorkflowSettings definition",
+          },
+          {
+            slug: "#workflowstep-definition",
+            title: "WorkflowStep definition",
+          },
+          { slug: "#channelstep-definition", title: "ChannelStep definition" },
+          { slug: "#sendwindow-definition", title: "SendWindow definition" },
+          { slug: "#delay-step-definition", title: "Delay step definition" },
+          { slug: "#branch-step-definition", title: "Branch step definition" },
+          { slug: "#fetch-step-definition", title: "Fetch step definition" },
+        ],
+      },
+
       { slug: "#workflows-list", title: "List workflows" },
       { slug: "#workflows-get", title: "Get workflow" },
       { slug: "#workflows-update", title: "Upsert workflow" },

--- a/layouts/MapiReferenceLayout.tsx
+++ b/layouts/MapiReferenceLayout.tsx
@@ -22,23 +22,23 @@ const sidebarData = [
     pages: [
       { slug: "#workflows-overview", title: "Introduction" },
       {
-        slug: "",
+        slug: "/",
         title: "Workflow definitions",
         pages: [
-          { slug: "#workflows-object", title: "Workflow definition" },
+          { slug: "#workflows-object", title: "Workflow" },
           {
             slug: "#workflowsettings-definition",
-            title: "WorkflowSettings definition",
+            title: "WorkflowSettings",
           },
           {
             slug: "#workflowstep-definition",
-            title: "WorkflowStep definition",
+            title: "WorkflowStep",
           },
-          { slug: "#channelstep-definition", title: "ChannelStep definition" },
-          { slug: "#sendwindow-definition", title: "SendWindow definition" },
-          { slug: "#delay-step-definition", title: "Delay step definition" },
-          { slug: "#branch-step-definition", title: "Branch step definition" },
-          { slug: "#fetch-step-definition", title: "Fetch step definition" },
+          { slug: "#channelstep-definition", title: "ChannelStep" },
+          { slug: "#sendwindow-definition", title: "SendWindow" },
+          { slug: "#delay-step-definition", title: "Delay step" },
+          { slug: "#branch-step-definition", title: "Branch step" },
+          { slug: "#fetch-step-definition", title: "Fetch step" },
         ],
       },
 


### PR DESCRIPTION
### Description

This PR does a few things to improve formatting of the mAPI reference:

1. Use the `<Section>` component where we had `<div>` tags to improve spacing and ensure consistency with the content columns
2. Add the various sub-definitions of Workflows into their own section in the sidebar menu to make them navigable and easier to find
3. Link all of the Knock `Types` in various `<Attribute>` components to their definitions

https://docs-a6x3z4evv-knocklabs.vercel.app/mapi

### Question

I noticed that the list of pages under "Workflow definitions" doesn't open and highlight the "active" page as expected, which I think is because the component really intends for these to be separate pages under a shared `/path`. I'm looking into that, but if it's something quick that someone else is already aware of re: the way that the component functions, let me know 😃 I personally think it's an acceptable compromise for organization as it is.

### Screenshots
Before:
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/b9067637-2578-4a5b-a9dd-d02fe2b5d04c">

After: 
<img width="1243" alt="image" src="https://github.com/user-attachments/assets/d481135a-04c4-4316-990f-3b6d55830188">
