### PR TITLE
fix: formatting on template variables table

### DIFF
--- a/content/designing-workflows/template-editor/variables.mdx
+++ b/content/designing-workflows/template-editor/variables.mdx
@@ -7,21 +7,20 @@ section: Designing workflows
 
 When you build workflows in Knock, we auto-generate certain pieces of state (as a result of batch functions and other workflow steps) that you can use to control the copy you display to your end users in your notification templates.
 
-| Variable          | Description                                                                                                                                                                                                                           |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `activities`      | A list of the activity objects included within the batch, where each activity equals the state sent across in your trigger call, and also includes the actor who performed the message and a timestamp of when the activity occurred. |
-| `actor`           | A serialized `Recipient` of the actor that triggered the workflow (may be `null`). Will include any custom properties set.                                                                                                            |
-| `actors`          | A list of up to 10 of the unique actors included within the batch.                                                                                                                                                                    |
-| `current_message` | A serialized `CurrentMessage` (see below).                                                                                                                                                                                            |
-| `data`            | The complete data passed to the workflow trigger.                                                                                                                                                                                     |
-
-| `recipient` | A serialized `Recipient` of the recipient of the workflow. Will include any custom properties set. |
-| `tenant` | A serialized `Tenant` (see below) which is set when a `tenant` is passed to the workflow trigger. |
-| `timestamp` | The time in which the activity occurred, as an ISO-8601 datetime string. |
-| `total_activities` | The count of activities associated with a workflow run. |
-| `total_actors` | The count of unique actors associated with a workflow run. |
-| `vars` | Account and environment-specific variables. |
-| `workflow` | A serialized `Workflow` (see below). |
+| Variable           | Description                                                                                                                                                                                                                           |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `activities`       | A list of the activity objects included within the batch, where each activity equals the state sent across in your trigger call, and also includes the actor who performed the message and a timestamp of when the activity occurred. |
+| `actor`            | A serialized `Recipient` of the actor that triggered the workflow (may be `null`). Will include any custom properties set.                                                                                                            |
+| `actors`           | A list of up to 10 of the unique actors included within the batch.                                                                                                                                                                    |
+| `current_message`  | A serialized `CurrentMessage` (see below).                                                                                                                                                                                            |
+| `data`             | The complete data passed to the workflow trigger.                                                                                                                                                                                     |
+| `recipient`        | A serialized `Recipient` of the recipient of the workflow. Will include any custom properties set.                                                                                                                                    |
+| `tenant`           | A serialized `Tenant` (see below) which is set when a `tenant` is passed to the workflow trigger.                                                                                                                                     |
+| `timestamp`        | The time in which the activity occurred, as an ISO-8601 datetime string.                                                                                                                                                              |
+| `total_activities` | The count of activities associated with a workflow run.                                                                                                                                                                               |
+| `total_actors`     | The count of unique actors associated with a workflow run.                                                                                                                                                                            |
+| `vars`             | Account and environment-specific variables.                                                                                                                                                                                           |
+| `workflow`         | A serialized `Workflow` (see below).                                                                                                                                                                                                  |
 
 <Callout
   emoji="🌠"


### PR DESCRIPTION
### Description

Fix formatting of template variables table (it got messed up in [latest update](https://docs.knock.app/designing-workflows/template-editor/variables))