### PR TITLE
chore: add missing workflow step types to mapi ref

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -305,7 +305,7 @@ All workflow steps, regardless of its type, share a common set of core attribute
   <Attribute
     name="type"
     type="string"
-    description="The type of the workflow step. One of: ”channel”, “delay”, “batch”, or “http_fetch”."
+    description="The type of the workflow step. One of: ”channel”, “delay”, “batch”, ”branch”, ”throttle”, or “http_fetch”."
   />
   <Attribute
     name="ref"


### PR DESCRIPTION
### Description

This PR adds some missing types to the `WorkflowStep` definition. These are for function steps that have been added (branch and throttle)

https://docs-cx6w3hryj-knocklabs.vercel.app/mapi#workflowstep-definition