### PR TITLE
feat(pla-443): add docs on trigger data filtering + warehouse export

### DIFF
--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -4,10 +4,21 @@ const Attributes = ({ children }) => (
   </div>
 );
 
-const Attribute = ({ name, type, description, typeSlug }) => (
+const Attribute = ({ name, type, description, typeSlug, nameSlug }) => (
   <div className="attribute border-b dark:border-b-gray-800 py-2">
     <span>
-      <span className="font-mono text-xs">{name}</span>
+      <span className="font-mono text-xs">
+        {!!nameSlug ? (
+          <a
+            href={nameSlug}
+            className="not-prose transition-colors hover:text-gray-900 dark:hover:text-gray-100 text-brand hover:!text-brand-dark"
+          >
+            {name}
+          </a>
+        ) : (
+          name
+        )}
+      </span>
       <span className="font-semibold text-gray-500 dark:text-gray-300 text-xs ml-2 py-0.5 px-1 border border-gray-100 bg-gray-50 dark:bg-gray-800 dark:border-gray-700">
         {/* Pass an optional `typeSlug` to link the `type` to its definition in the docs*/}
         {!!typeSlug ? (

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -321,5 +321,6 @@ Below is a description of the columns included in the table and the data type of
         ["timestamp", "timestamp", "The timestamp of when the event was emitted."]
       ]}
     />
+
   </Accordion>
 </AccordionGroup>

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -44,6 +44,7 @@ Below is a description of the columns included in the table and the data type of
             channel_provider character varying(65535) ENCODE lzo,
             workflow_id character varying(65535) ENCODE lzo,
             workflow_key character varying(65535) ENCODE lzo,
+            combined_trigger_data character varying(32768) ENCODE lzo,
             step_ref character varying(65535) ENCODE lzo,
             recipient_id character varying(65535) ENCODE lzo,
             recipient_type character varying(65535) ENCODE lzo,
@@ -109,6 +110,13 @@ Below is a description of the columns included in the table and the data type of
           "The unique key of the workflow the message belongs to",
         ],
         [
+          "combined_trigger_data",
+          "json",
+          <div key="combined_trigger_data_body">
+            Combined and truncated trigger data for the workflow run that generated the message, at the time the message was created. See the <a target="_blank" rel="noreferrer" href="/reference#trigger-data-filtering">trigger data filtering guide</a> for more info.
+          </div>
+        ],
+        [
           "step_ref",
           "string",
           "The reference of the step on the workflow that the message belongs to",
@@ -122,7 +130,7 @@ Below is a description of the columns included in the table and the data type of
             <a
               target="_blank"
               rel="noreferrer"
-              href="https://docs.knock.app/send-and-manage-data/recipients"
+              href="/send-and-manage-data/recipients"
             >
               type of recipient for the message
             </a>
@@ -162,7 +170,7 @@ Below is a description of the columns included in the table and the data type of
             <a
               target="_blank"
               rel="noreferrer"
-              href="https://docs.knock.app/send-notifications/message-statuses#delivery-status"
+              href="/send-notifications/message-statuses#delivery-status"
             >
               delivery status of a message
             </a>
@@ -296,7 +304,7 @@ Below is a description of the columns included in the table and the data type of
                 <li><code>recipient.snapshot</code> - is emitted every time a recipient properties or preferences are updated, and contains the complete set of properties and preferences at that moment in time</li>
                 <li><code>recipient.deleted</code> - contains no properties or preferences, but indicates when a recipient was deleted. A recipient may be re-identified after being deleted, which will generate another recipient.created event</li>
               </ul>
-              
+
               A manual snapshot of the current state of all or a subset of recipients (by ID) can be made by contacting support.
             </div>,
         ],

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -258,6 +258,23 @@ See the [Bulk operations section](#bulk-operations) for more information on pars
 </ContentColumn>
 </Section>
 
+<Section title="Trigger data filtering" slug="trigger-data-filtering">
+<ContentColumn>
+
+Some V1 API endpoints that return lists of message data accept a `trigger_data` parameter. Knock uses this parameter to scope results it returns down to messages generated with the trigger data you provide.
+
+The trigger data that Knock filters against is the _**combined and truncated data from the time the message was generated**_.
+
+If a batch step preceded the creation of your message, the trigger data available for filtering will be the combined data for all the workflow triggers bundled into your batch. If a fetch step preceded, then the filterable data will include any data pulled in via the fetch step request.
+
+Knock truncates trigger data for filtering to ensure it can efficiently process your request. The current data truncation rules are:
+
+- Nested data structures are removed. Trigger data for filtering will be a JSON object with a single level of key-value pairs.
+- String values are limited to 256 characters in length. Strings that exceed this limit are truncated to the maximum.
+
+</ContentColumn>
+</Section>
+
 <Section title="Pagination" slug="pagination">
 <ContentColumn>
 
@@ -1006,6 +1023,7 @@ Returns a paginated list of messages.
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
+    nameSlug="#trigger-data-filtering"
   />
   <Attribute
     name="inserted_at.gt"
@@ -1234,6 +1252,7 @@ Returns a paginated list of activities associated with the message. Note: for no
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
+    nameSlug="#trigger-data-filtering"
   />
 </Attributes>
 
@@ -2005,6 +2024,7 @@ along with a user token to make this request**
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
+    nameSlug="#trigger-data-filtering"
   />
 </Attributes>
 
@@ -2439,6 +2459,7 @@ Retrieve a paginated list of messages for a user. Will return most recent messag
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
+    nameSlug="#trigger-data-filtering"
   />
   <Attribute
     name="inserted_at.gt"
@@ -3065,6 +3086,7 @@ Returns a paginated list of messages for an object. Will return newest messages 
     name="trigger_data"
     type="JSON string (optional)"
     description="Limits the results to only items that were generated with the given data"
+    nameSlug="#trigger-data-filtering"
   />
   <Attribute
     name="inserted_at.gt"

--- a/data/apiReferenceSidebar.ts
+++ b/data/apiReferenceSidebar.ts
@@ -13,6 +13,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "#batch-rate-limits", title: "Batch rate limits" },
       { slug: "#idempotent-requests", title: "Idempotent requests" },
       { slug: "#bulk-endpoints", title: "Bulk endpoints" },
+      { slug: "#trigger-data-filtering", title: "Trigger data filtering" },
       { slug: "#pagination", title: "Pagination" },
       { slug: "#errors", title: "Errors" },
       { slug: "#error-codes", title: "Common error codes" },


### PR DESCRIPTION
### Description

- Adds a top section to the reference on how Knock manages trigger data for filtering
- Updates endpoints that accept `trigger_data` filters to point to this reference
- Adds note on trigger data exported to warehouse connections

### Tasks

[PLA-443: Write docs on `searchable_trigger_data` filter usage + warehouse export](https://linear.app/knock/issue/PLA-443/write-docs-on-searchable-trigger-data-filter-usage-warehouse-export)