### PR TITLE
feat: add new examples app cards

### DIFF
--- a/content/getting-started/example-apps.mdx
+++ b/content/getting-started/example-apps.mdx
@@ -38,6 +38,13 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
     languages={["Vue.js", "Nuxt"]}
     isExternal={true}
   />
+  <SdkCard
+    title="Linear-style inbox"
+    linkUrl="https://github.com/knocklabs/inbox-example-app"
+    icon="react"
+    languages={["Next.js", "React"]}
+    isExternal={true}
+  />
 </SdkCardGroup>
 
 ## Web app examples
@@ -53,6 +60,13 @@ Below you'll find a number of Knock example apps to learn from or incorporate in
   <SdkCard
     title="Webhook example"
     linkUrl="https://github.com/knocklabs/customer-facing-webhooks-example"
+    icon="react"
+    languages={["React", "Next.js"]}
+    isExternal={true}
+  />
+  <SdkCard
+    title="Alerting example"
+    linkUrl="https://github.com/knocklabs/alerting-example"
     icon="react"
     languages={["React", "Next.js"]}
     isExternal={true}


### PR DESCRIPTION
### Description

Adds cards to the example apps page for Linear-style inbox and alerting examples
