### PR TITLE
update code blocks

### DIFF
--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -201,11 +201,8 @@ import { KnockFeedProvider } from "@knocklabs/react";
 
 For more advanced use cases, you may need to render custom components as part of the notification cell, but don't need to override the cell entirely. For this use case, you can use the `children` prop to render custom components inside the notification cell.
 
-````jsx
-import {
-  NotificationFeed,
-  NotificationCell,
-} from "@knocklabs/react";
+```jsx
+import { NotificationFeed, NotificationCell } from "@knocklabs/react";
 
 <NotificationFeed
   renderItem={({ item, ...props }) => (
@@ -214,6 +211,7 @@ import {
     </NotificationCell>
   )}
 />;
+```
 
 ### Handling cross-browser feed synchronization
 
@@ -251,7 +249,7 @@ import { KnockFeedProvider } from "@knocklabs/react";
     auto_manage_socket_connection_delay: 2500,
   }}
 />;
-````
+```
 
 ### Customizing the feed styling
 


### PR DESCRIPTION
### Description

looks like the formatting of these sections got messed up. It was like this:

<img width="800" alt="Screenshot 2024-10-07 at 10 07 06 AM" src="https://github.com/user-attachments/assets/4fe6ebe8-3d72-4fdb-8531-b273c9512ed9">

But should be 
<img width="902" alt="Screenshot 2024-10-07 at 10 09 15 AM" src="https://github.com/user-attachments/assets/f2483295-2bc1-4e4d-b3b1-099a51d6cc12">

