### PR TITLE
fix(kno-6920): fix extra hash in links within API reference

### DIFF
--- a/components/SectionHeading.tsx
+++ b/components/SectionHeading.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useRouter } from "next/router";
 import useClipboard from "react-use-clipboard";
 import cn from "classnames";
 import { usePathname } from "next/navigation";

--- a/components/SectionHeading.tsx
+++ b/components/SectionHeading.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useRouter } from "next/router";
 import useClipboard from "react-use-clipboard";
 import cn from "classnames";
+import { usePathname } from "next/navigation";
 
 const CLASS_SELECTOR = "section-heading";
 
@@ -18,8 +19,8 @@ const SectionHeading: React.FC<Props> = ({
   className,
   ...rest
 }) => {
-  const { asPath } = useRouter();
-  const targetPath = id ? `${asPath}#${id}` : asPath;
+  const pathname = usePathname() ?? "/";
+  const targetPath = id ? `${pathname}#${id}` : pathname;
 
   const targetUrl = global.window ? window.location.origin + targetPath : "";
   const [, onCopy] = useClipboard(targetUrl, { successDuration: 2000 });


### PR DESCRIPTION
### Description

If the user clicks on a linked section heading within the API reference when the current URL already contains a `#` fragment, the URL in their browser bar will update to contain a second `#` fragment, which is invalid. (See _Before_ video included below.)

This bug occurs because `SectionHeading` gets the URL path from [the `asPath` string returned by the `useRouter` hook](https://nextjs.org/docs/pages/api-reference/functions/use-router#router-object), which includes search params and fragments, and does not strip out any existing `#` fragment.

Instead of manually stripping out the `#` fragment, we can instead use the `usePathname` hook, which [returns the URL pathname without query params and fragments](https://nextjs.org/docs/app/api-reference/functions/use-pathname#returns).

The `usePathname` hook is part of Next.js’s new App Router, which the docs codebase is not yet using. But `usePathname` can be used in a “compatibility mode” with the Pages Router, and from my testing, I didn’t encounter any issues.

### Tasks

[KNO-6920](https://linear.app/knock/issue/KNO-6920/[docs]-duplicate-hashs-on-docs)

### Videos

#### Before

Notice the URL in the browser bar: http://localhost:3002/reference#get-feed#rate-limit-14

https://github.com/user-attachments/assets/cee70102-7c63-4bbd-86b7-44a771117ba3

#### After

Notice the URL in the browser bar: http://localhost:3002/reference#rate-limit-14

https://github.com/user-attachments/assets/630cf958-0dab-4dbe-a404-7973d0a50036

