### PR TITLE
fix: push notification channels in RN and Android quick start docs

### DIFF
--- a/content/sdks/android/quick-start.mdx
+++ b/content/sdks/android/quick-start.mdx
@@ -9,7 +9,7 @@ To get started, you will need the following:
 - [A Knock Account](https://dashboard.knock.app/signup)
 - A public API key for the Knock environment (which you'll use in the `publishableKey`)
 - An in-app feed channel with a workflow that produces in-app feed messages (optional)
-- An APNS channel with a workflow that produces push notifications (optional)
+- A Firebase Cloud Messaging channel with a workflow that produces push notifications (optional)
 
 ## Installation
 

--- a/content/sdks/react-native/quick-start.mdx
+++ b/content/sdks/react-native/quick-start.mdx
@@ -9,7 +9,7 @@ To get started, you will need the following:
 - [A Knock Account](https://dashboard.knock.app/signup)
 - A public API key for the Knock environment (which you'll use in the `publishableKey`)
 - An in-app feed channel with a workflow that produces in-app feed messages (optional)
-- An APNS channel with a workflow that produces push notifications (optional)
+- An Expo channel with a workflow that produces push notifications (optional)
 
 ## Installation
 


### PR DESCRIPTION
Looks like these quick start docs reference the wrong push notification provider. This was probably a copy-and-paste mistake from [the iOS quick start docs](https://docs.knock.app/sdks/ios/quick-start).