### PR TITLE
fix: typo in Android SDK push notifications doc

### DIFF
--- a/content/sdks/android/push-notifications.mdx
+++ b/content/sdks/android/push-notifications.mdx
@@ -96,7 +96,7 @@ section: SDKs
   }
   ```
 
-## 5. Reveive push notifications
+## 5. Receive push notifications
 
 To detect when a push notification is received in the foreground:
 


### PR DESCRIPTION
“Reveive” should be “receive”.