### PR TITLE
chore: restructure slack docs

### DIFF
--- a/content/integrations/chat/slack/building-a-slack-app.mdx
+++ b/content/integrations/chat/slack/building-a-slack-app.mdx
@@ -17,6 +17,70 @@ If you are new to Slack apps, a few key concepts to understand:
 - Your Slack app is installed to a customer's workspace through the [Slack OAuth flow](https://api.slack.com/authentication/oauth-v2). In this flow, your app requests scopes and the user installing the app confirms which scopes to grant. You’ll need to surface this OAuth flow to your users wherever you want them to install your Slack app.
 - A Slack app can have bot token scopes and user token scopes. For almost all use cases, you’ll be using bot token scopes. ([This Slack doc explains why.](https://api.slack.com/authentication/basics)) When you add bot token scopes to an app, you will **also** need to make sure your app has its display information configured. You can do this under the **App Home** sidebar on the [app management page](https://api.slack.com/apps).
 
-## Next steps
+In this section we'll complete the steps for setting up your Knock account and Slack app to enable SlackKit.
 
-Now you're ready to integrate Slack and Knock with [SlackKit](/integrations/chat/slack-kit/overview) or if you prefer, you can follow the documentation to build the OAuth integration yourself with our [Slack DIY guide](/integrations/chat/slack-diy/slack-apps-and-scopes).
+<Steps titleSize="h2">
+  <Step title="Set up Slack app">
+    See [Build a Slack app](/integrations/chat/slack/building-a-slack-app) to create the bot that you'll use to post notifications.
+
+    <Callout
+      emoji="🤖"
+      text={
+        <>
+          <strong>Prepare existing Slackbot</strong>
+          <br />
+          <br />
+          If you already have a Slackbot you want to use, you'll just need to
+          make sure it has its redirect URL set and that it's publicly distributed, which
+          is described below.
+        </>
+      }
+    />
+
+    The following steps will be completed in the **OAuth & Permissions** sidebar of your Slack app's [management page](https://api.slack.com/apps):
+
+    <AccordionGroup>
+      <Accordion title="Add a scope">
+        Although SlackKit manages your scopes, you have to add one in your Slack application's settings to start with so that it exposes the form for you to add a redirect URL.
+
+        Add `channels:read` to the scopes section. For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need. Here is the list of scopes and the reasons they're required:
+
+        - `chat:write`: This scope allows your bot to send messages to channels that the bot has been explicitly invited to, including private channels. It doesn't grant the ability to send messages to public channels without an invite.
+        - `chat:write.public`: This scope extends the bot's capabilities to send messages to public channels without needing a specific invitation to those channels. It's an addition to the chat:write scope, offering broader access for the bot to interact within the workspace.
+        - `channels:read`: This scope allows your bot to list all channels in a workspace and view details about specific channels (like name, topic, purpose, members), but does not grant access to private channels.
+        - `groups:read`: This scope allows your app to list all private channels that the bot or user is a member of and to view details about those channels.
+
+        You can read more about scopes in general in [building a slack app](/integrations/chat/slack/building-a-slack-app).
+      </Accordion>
+      <Accordion title="Add redirect URL">
+        Under **OAuth & Permissions** in the **Features** sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
+
+        Copy and paste this redirect URL:
+
+        <CopyableText
+          label="https://api.knock.app/providers/slack/authenticate"
+          content="https://api.knock.app/providers/slack/authenticate"
+        />
+      </Accordion>
+      <Accordion title="Set up public distribution">
+        Under **Manage Distribution**, click the "Distribute app" button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for "Remove hard coded information."
+
+        Check the box and then click "Activate Public Distribution."
+      </Accordion>
+    </AccordionGroup>
+
+  </Step>
+  <Step title="Add Slack app to Knock Slack channel">
+    Now that your Slack app is set up, you'll want to reference three attributes in the **Basic Information** section:
+
+    1. App ID
+    2. Client ID
+    3. Client secret
+
+    You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click **Manage configuration**. You'll see where to paste these three strings under **Provider settings**. Click "Update settings" to save.
+
+  </Step>
+  <Step title="Use Slack channel in a workflow">
+    In order to test this flow, you'll want to set up a workflow with a Slack channel step. Later on we'll discuss how you can [design your notification templates for Slack](/integrations/chat/slack/designing-slack-templates), but for now you can just add the channel step to a workflow.
+  </Step>
+</Steps>

--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -7,26 +7,321 @@ layout: integrations
 
 In this guide you'll learn how to use Knock to send notifications to Slack. There are two ways to do this:
 
-1. [SlackKit](/integrations/chat/slack-kit/overview): Follow this guide to use the Knock-managed approach to integrating Slack. Using this method, Knock handles authorization and API calls to Slack on your users' behalf and provides pre-built components and hooks for you to quickly build out the UI of your Slack integration.
-2. [DIY Slack OAuth](/integrations/chat/slack-diy/slack-apps-and-scopes): If you want to connect Slack yourself either via incoming webhooks or access tokens, this guide will show you how to implement this for yourself. You'll have to build out the UI yourself when using this method.
+Once you have your Slack app configured and you've figured out which [OAuth scopes](https://api.slack.com/scopes) it will need, you're ready to build the OAuth flow your customers will use to install your Slack app in their Slack workspace.
 
-We'll also cover:
+Here's what we'll cover in this guide.
 
-- [**The Knock-Slack model.**](/integrations/chat/slack/how-knock-slacks) An overview of how you'll build your Knock-Slack integration and the key concepts involved.
-- [**Building a Slack app.**](/integrations/chat/slack/building-a-slack-app) How to build a Slack app you'll use for SlackKit or your own DIY approach.
-- [**Designing Slack templates.**](/integrations/chat/slack/designing-slack-templates) How to design your Slack notification templates in Knock using our markdown or JSON block editors.
-- [**Powering Slack interactivity.**](/integrations/chat/slack/slack-interactivity) How to build interactive Slack messages using Knock.
-- [**Example use cases.**](/integrations/chat/slack/slack-examples) Step-by-step walkthroughs of a number of example Slack use cases, from notifying a user via DM to notifying a channel in your own Slack workspace.
+- How to build a simple Slack OAuth in your product
+- How to use the response received in that OAuth handshake to set Knock channel data
+- How to decide when to set Knock channel data on `users` vs. `objects`
+
+## How to connect Slack to Knock
+
+Regardless of whether you're using Knock's managed approach to integrating Slack with [SlackKit](/integrations/chat/slack-kit/overview) or building the flow entirely yourself, you'll need a Slack app to send notifications from Knock to a Slack workspace. If you haven’t built a Slack app yet, you can get started in [Slack’s app documentation](https://api.slack.com/start/quickstart#creating).
+
+Once you create your Slack app, you’ll be routed to its app management page within the Slack dashboard. It looks like this.
+
+![Slack app management page](/images/slack-app-management-page.png)
+
+If you are new to Slack apps, a few key concepts to understand:
+
+- A [scope](https://api.slack.com/scopes) is a permission granted to your Slack app when it joins a Slack workspace. You configure which scopes your app asks for in the **OAuth & Permissions** sidebar of your [app management page](https://api.slack.com/apps).
+- Your Slack app is installed to a customer's workspace through the [Slack OAuth flow](https://api.slack.com/authentication/oauth-v2). In this flow, your app requests scopes and the user installing the app confirms which scopes to grant. You’ll need to surface this OAuth flow to your users wherever you want them to install your Slack app.
+- A Slack app can have bot token scopes and user token scopes. For almost all use cases, you’ll be using bot token scopes. ([This Slack doc explains why.](https://api.slack.com/authentication/basics)) When you add bot token scopes to an app, you will **also** need to make sure your app has its display information configured. You can do this under the **App Home** sidebar on the [app management page](https://api.slack.com/apps).
+
+In this section we'll complete the steps for setting up your Knock account and Slack app to enable SlackKit.
+
+<Steps titleSize="h3">
+  <Step title="Set up Slack app">
+    See [Build a Slack app](/integrations/chat/slack/building-a-slack-app) to create the bot that you'll use to post notifications.
+
+    <Callout
+      emoji="🤖"
+      text={
+        <>
+          <strong>Prepare existing Slackbot</strong>
+          <br />
+          <br />
+          If you already have a Slackbot you want to use, you'll just need to
+          make sure it has its redirect URL set and that it's publicly distributed, which
+          is described below.
+        </>
+      }
+    />
+
+    The following steps will be completed in the **OAuth & Permissions** sidebar of your Slack app's [management page](https://api.slack.com/apps):
+
+    <AccordionGroup>
+      <Accordion title="Add a scope">
+        Although SlackKit manages your scopes, you have to add one in your Slack application's settings to start with so that it exposes the form for you to add a redirect URL.
+
+        Add `channels:read` to the scopes section. For the rest, you won't be managing SlackKit's scopes directly since the components will request the scopes they need. Here is the list of scopes and the reasons they're required:
+
+        - `chat:write`: This scope allows your bot to send messages to channels that the bot has been explicitly invited to, including private channels. It doesn't grant the ability to send messages to public channels without an invite.
+        - `chat:write.public`: This scope extends the bot's capabilities to send messages to public channels without needing a specific invitation to those channels. It's an addition to the chat:write scope, offering broader access for the bot to interact within the workspace.
+        - `channels:read`: This scope allows your bot to list all channels in a workspace and view details about specific channels (like name, topic, purpose, members), but does not grant access to private channels.
+        - `groups:read`: This scope allows your app to list all private channels that the bot or user is a member of and to view details about those channels.
+
+        You can read more about scopes in general in [building a slack app](/integrations/chat/slack/building-a-slack-app).
+      </Accordion>
+      <Accordion title="Add redirect URL">
+        Under **OAuth & Permissions** in the **Features** sidebar, you need to add a redirect URL so that Knock can receive the Slack OAuth handshake on your behalf.
+
+        Copy and paste this redirect URL:
+
+        <CopyableText
+          label="https://api.knock.app/providers/slack/authenticate"
+          content="https://api.knock.app/providers/slack/authenticate"
+        />
+      </Accordion>
+      <Accordion title="Set up public distribution">
+        Under **Manage Distribution**, click the "Distribute app" button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for "Remove hard coded information."
+
+        Check the box and then click "Activate Public Distribution."
+      </Accordion>
+    </AccordionGroup>
+
+  </Step>
+  <Step title="Add Slack app to Knock Slack channel">
+    Now that your Slack app is set up, you'll want to reference three attributes in the **Basic Information** section:
+
+    1. App ID
+    2. Client ID
+    3. Client secret
+
+    You need to add this data to a new or existing Slack channel in the Knock dashboard to link your app to Knock. From the dashboard, [create a Slack channel](/concepts/channels#managing-channels) or open an existing one, and click **Manage configuration**. You'll see where to paste these three strings under **Provider settings**. Click "Update settings" to save.
+
+  </Step>
+  <Step title="Use Slack channel in a workflow">
+    In order to test this flow, you'll want to set up a workflow with a Slack channel step. Later on we'll discuss how you can [design your notification templates for Slack](/integrations/chat/slack/designing-slack-templates), but for now you can just add the channel step to a workflow.
+  </Step>
+</Steps>
+
+## How to set channel data for a Slack integration in Knock
+
+When you receive an OAuth callback from Slack, you'll need to set the returned identifier (either an `incoming_webhook_url` or an `access_token`) as [channel data](/send-notifications/setting-channel-data) on a [`user`](/send-and-manage-data/users) or an [`object`](/send-and-manage-data/objects) in Knock. We cover how to decide [which to use](/integrations/chat/slack-diy/building-oauth-flow#setting-channel-data-users-vs-objects) in the section below.
+
+Here's an example of setting channel data on an `object` in Knock.
+
+<MultiLangCodeBlock
+  snippet="objects.setChannelData.slack"
+  title="Store Slack connection on object"
+/>
+
+<br />
 
 <Callout
-  emoji="👩‍💻"
+  emoji="🚨"
   text={
     <>
-      <span className="font-bold">See an example.</span> You can check out our{" "}
-      <a href="https://github.com/knocklabs/javascript/tree/main/examples/slack-kit-example">
-        tutorial app
-      </a>{" "}
-      for setting up Knock with SlackKit.
+      <span className="font-bold">Potential confusion alert.</span> In the
+      example above, the <code>KNOCK_SLACK_CHANNEL_ID</code> variable is the id
+      of the Knock channel you've created to represent your Slack app within the
+      Knock dashboard. You can find it by going to{" "}
+      <span className="font-bold">Integrations</span> {">"}{" "}
+      <span className="font-bold">Channels</span> in the Knock dashboard and
+      then copying the ID of your Slack app channel.
     </>
   }
 />
+
+### Channel data requirements
+
+Here's an overview of the data requirements for [setting recipient channel data](/send-notifications/setting-channel-data) for either an incoming webhook or an access token Slack connection. Both will need to live under the `connections` key
+
+<Attributes>
+  <Attribute
+    name="connections"
+    type="SlackConnection[]*"
+    description="One or more connections to Slack"
+  />
+</Attributes>
+
+<br />
+
+#### `SlackConnection` with incoming webhook url
+
+<Attributes>
+  <Attribute
+    name="incoming_webhook.url"
+    type="string*"
+    description="The Slack incoming webhook URL"
+  />
+</Attributes>
+
+#### `SlackConnection` with an access token
+
+<Attributes>
+  <Attribute
+    name="access_token"
+    type="string*"
+    description="A bot access token"
+  />
+  <Attribute
+    name="channel_id"
+    type="string*"
+    description="A Slack channel ID"
+  />
+  <Attribute name="user_id" type="string*" description="A Slack channel ID" />
+</Attributes>
+
+### Setting channel data: users vs. objects
+
+Depending on the Slack integration you build into your product, you’ll store the connection data you receive from Slack as `channel_data` on either a `user` or an `object` in Knock.
+
+<AccordionGroup>
+  <Accordion title="Users" description="For notifying users via direct message">
+    If your integration involves a user opting in to receive DMs from your Slack bot, you’ll be storing the channel data [on that user](/reference#set-user-channel-data) in Knock. When you want to notify this user, you'll include them as a recipient in a Knock workflow trigger.
+
+    For this integration, you'll store a user's Slack `user_id` in the `SlackConnection` object. You can find the correct `user_id` by querying Slack's API:
+    - by [a given user's email address](https://api.slack.com/methods/users.lookupByEmail)
+    - for [a list of all of a workspace's users](https://api.slack.com/methods/users.list)
+
+    You'll need to be sure that you request the appropriate [`scopes`](/integrations/chat/slack-diy/slack-apps-and-scopes) for these methods during the auth process.
+
+  </Accordion>
+  <Accordion title="Objects" description="For notifying Slack channels about non-user resources">
+    If your integration involves a customer connecting a _non-user resource_ in their product (such as a project or a page) to a Slack channel, you’ll want to store that channel data [on an object](/reference#set-object-channel-data) in Knock, as it’s not specific to any single user.
+
+    You can find the correct `channel_id` and display a list of channels for your user to select from by querying the Slack API:
+    - for [a list of all of a workspace's channels](https://api.slack.com/methods/conversations.list)
+
+    Here's a real-life example of how `objects` would be used in a product you may be familiar with: Notion. In Notion you can connect a Notion page to a Slack channel of your choosing. If we were to power this with Knock, when a user completed the Slack OAuth flow for that Notion page we’d store the connection data on the Knock `object` that maps to that Notion page. Then when something happens on that page that the connected Slack channel should be notified about, we include the Notion page `object` as a recipient on the workflow trigger.
+
+    You can learn more about the Knock object model and see an example how to use it to power Slack notifications in our [Objects concept guide](/send-and-manage-data/objects).
+
+  </Accordion>
+</AccordionGroup>
+
+## Designing notification templates for Slack
+
+When you add a new Slack channel step to a workflow in Knock, you'll need to configure a template for that step so Knock knows how to format the message to Slack.
+
+### Markdown templates
+
+Editing a markdown template for Slack is just like editing any other markdown-based template in Knock. You can use [liquid](https://shopify.github.io/liquid/) to inject variables and add control tags (e.g. if-then, for-loop) into your template.
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Knock fun fact.</span> Slack uses a
+      markdown-variant syntax called{" "}
+      <a href="https://api.slack.com/reference/surfaces/formatting#basics">
+        mrkdwn
+      </a>
+      , but Knock handles this for you automatically, so you can write your templates
+      in good old <a href="https://daringfireball.net/projects/markdown/">
+        {" "}
+        markdown{" "}
+      </a>.
+    </>
+  }
+/>
+
+Here's an example Slack template written in Knock using markdown.
+
+```markdown title="A markdown-based Slack template with for-loop iteration"
+Hi **{{ recipient.name | split:" " | first }}**,
+
+There are {{ total_activities }} comments left on {{ page_name }}.
+
+{% for activity in activities %}
+
+- From **{{activity.actor.name}}**: "{{activity.comment.body}}""
+  {% endfor %}
+
+[**View page**]({{vars.base_url}}/{{account_id}}/pages/{{ page_id }})
+```
+
+In the example above we're using [liquid's for-loop tag](https://shopify.github.io/liquid/tags/iteration/) to iterate over the activities array produced by a Knock batch function. You can learn more about Knock batch functions and the state they produce in our [batch function guide](/send-notifications/designing-workflows/batch-function).
+
+### Block-based templates
+
+For more advanced layouts in your Slack messages, including images and buttons, you'll need to use Slack's [block kit UI framework](https://api.slack.com/block-kit) to build your notification templates. The block kit framework is a set of different JSON objects you can use together and arrange to create Slack app and notification layouts.
+
+#### Designing block kit templates
+
+To start you'll want to design your block-based Slack message template. The best way to do this today is to use [Slack's block kit builder](https://app.slack.com/block-kit-builder/). It gives you a drag-and-drop interface for building out your Slack templates, and outputs the JSON you'll need to bring into your Knock template.
+
+<Callout
+  emoji="🛣"
+  text={
+    <>
+      <span className="font-bold">Knock roadmap alert.</span> In the future
+      you'll be able to use a visual, drag-and-drop editor within Knock to build
+      these block-based Slack templates without having to leave the Knock
+      product. <br />
+      <br /> If you're interested in trying this functionality, please shoot us a
+      note at <a href="mailto:support@knock.app">support@knock.app</a> or use the
+      feedback button at the top of this page.
+    </>
+  }
+/>
+
+Once you've designed your Slack template, copy the JSON from the block kit builder and bring it into your Knock notification template. You'll use the "Switch to JSON editor" button at the bottom right of the Knock template editor page to switch to our JSON editor, and then paste in the JSON you copied from the block kit builder.
+
+#### Knock's JSON template editor
+
+You can use liquid in the Knock JSON template editor just as you would in the markdown editor. This is helpful for both injecting variables into the text of your Slack UI blocks, as well as for for using liquid control tags to control when certain blocks should be displayed and for iterating through an array and mapping its items into a list of Slack blocks.
+
+Here's an example of a block kit UI template with liquid syntax added to iterate through a list of items.
+
+```json title="A block kit UI template in Knock with for-loop iteration"
+{
+	"blocks": [
+		{
+			"type": "header",
+			"text": {
+				"type": "plain_text",
+				"text": "Users marked for onboarding",
+				"emoji": true
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Hi John,\n\n The following users have been assigned to you for onboarding today:"
+			}
+		},
+		{% for activity in activities %}
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*{{activity.assigned_user.name}}* \n {{activity.assigned_user.email}} \n _{{activity.assigned_user.title}}_"
+			},
+			"accessory": {
+				"type": "image",
+				"image_url": "{{activity.assigned_user.avatar_url}}",
+				"alt_text": "avatar image"
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{% endfor %}
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "View in dashboard",
+						"emoji": true
+					},
+					"value": "{{dashboard_url}}"
+				}
+			]
+		}
+	]
+}
+```
+
+In the template above, we're using the `activities` array produced by a [batch function](/send-notifications/designing-workflows/batch-function) to iterate over a number of items that we want to display in our Slack message. For each one of those items, we're producing a `section` that includes both `text` and an `image`, both of which are injected with variables from the `activity` from our `activities` array.
+
+Here's an example of a Slack message produced with this template. **Note:** this template was produced by three separate workflow trigger calls to the Knock API, all of which were batched into a single message automatically using our batch function.
+
+![An example Slack message built with block kit UI](/images/slack-json-block-example.png)

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -1,0 +1,17 @@
+---
+title: Sending a direct message to a user in Slack
+description: How to configure basic and interactive Slack notification templates in Knock.
+tags: ["slack", "chat"]
+section: Integrations > Slack
+layout: integrations
+---
+
+## Sending direct messages to a user in your customer’s Slack workspace
+
+If you want to notify a user in Slack via direct message instead of through a channel, you can still accomplish this through a simple Slack app with the `incoming-webhook` scope. (This is possible because during the OAuth flow for an app with the `incoming-webhook` scope, the installing user can select their own Direct Message channel for the integration.)
+
+![An example of selecting a Direct Message in an OAuth flow](/images/slack-oauth-flow-select-channel.png)
+
+Just surface your Slack OAuth flow to users in their personal notification settings and [store the webhook URL](/integrations/chat/slack-diy/building-oauth-flow#setting-channel-data-users-vs-objects) received from the OAuth process on the relevant `user` in Knock.
+
+You can learn more users and channel data in our docs on [how to set channel data](https://docs.knock.app/send-notifications/setting-channel-data).

--- a/content/integrations/chat/slack/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/slack/sending-a-message-to-channels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Designing Slack notification templates
+title: Sending a message to public and private channels
 description: How to configure basic and interactive Slack notification templates in Knock.
 tags: ["slack", "chat"]
 section: Integrations > Slack

--- a/content/integrations/chat/slack/sending-an-internal-message.mdx
+++ b/content/integrations/chat/slack/sending-an-internal-message.mdx
@@ -1,0 +1,143 @@
+---
+title: Sending a message to an internal Slack workspace
+description: How to configure basic and interactive Slack notification templates in Knock.
+tags: ["slack", "chat"]
+section: Integrations > Slack
+layout: integrations
+---
+
+In this guide we'll cover how to design Slack notification templates within Knock.
+
+When you're creating a template for a Slack step within a Knock workflow, you have two options:
+
+- **Knock markdown editor.** For simple messages that just use markdown, you can use regular markdown in Knock to write your template.
+- **Knock JSON block editor.** For advanced messages built using Slack's block kit UI framework, you can switch to our JSON editor to paste in your Slack JSON blocks. Liquid syntax is supported.
+
+## Markdown templates
+
+Editing a markdown template for Slack is just like editing any other markdown-based template in Knock. You can use [liquid](https://shopify.github.io/liquid/) to inject variables and add control tags (e.g. if-then, for-loop) into your template.
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Knock fun fact.</span> Slack uses a
+      markdown-variant syntax called{" "}
+      <a href="https://api.slack.com/reference/surfaces/formatting#basics">
+        mrkdwn
+      </a>
+      , but Knock handles this for you automatically, so you can write your templates
+      in good old <a href="https://daringfireball.net/projects/markdown/">
+        {" "}
+        markdown{" "}
+      </a>.
+    </>
+  }
+/>
+
+Here's an example Slack template written in Knock using markdown.
+
+```markdown title="A markdown-based Slack template with for-loop iteration"
+Hi **{{ recipient.name | split:" " | first }}**,
+
+There are {{ total_activities }} comments left on {{ page_name }}.
+
+{% for activity in activities %}
+
+- From **{{activity.actor.name}}**: "{{activity.comment.body}}""
+  {% endfor %}
+
+[**View page**]({{vars.base_url}}/{{account_id}}/pages/{{ page_id }})
+```
+
+In the example above we're using [liquid's for-loop tag](https://shopify.github.io/liquid/tags/iteration/) to iterate over the activities array produced by a Knock batch function. You can learn more about Knock batch functions and the state they produce in our [batch function guide](/send-notifications/designing-workflows/batch-function).
+
+## Block-based templates
+
+For more advanced layouts in your Slack messages, including images and buttons, you'll need to use Slack's [block kit UI framework](https://api.slack.com/block-kit) to build your notification templates. The block kit framework is a set of different JSON objects you can use together and arrange to create Slack app and notification layouts.
+
+### Designing block kit templates
+
+To start you'll want to design your block-based Slack message template. The best way to do this today is to use [Slack's block kit builder](https://app.slack.com/block-kit-builder/). It gives you a drag-and-drop interface for building out your Slack templates, and outputs the JSON you'll need to bring into your Knock template.
+
+<Callout
+  emoji="🛣"
+  text={
+    <>
+      <span className="font-bold">Knock roadmap alert.</span> In the future
+      you'll be able to use a visual, drag-and-drop editor within Knock to build
+      these block-based Slack templates without having to leave the Knock
+      product. <br />
+      <br /> If you're interested in trying this functionality, please shoot us a
+      note at <a href="mailto:support@knock.app">support@knock.app</a> or use the
+      feedback button at the top of this page.
+    </>
+  }
+/>
+
+Once you've designed your Slack template, copy the JSON from the block kit builder and bring it into your Knock notification template. You'll use the "Switch to JSON editor" button at the bottom right of the Knock template editor page to switch to our JSON editor, and then paste in the JSON you copied from the block kit builder.
+
+### Knock's JSON template editor
+
+You can use liquid in the Knock JSON template editor just as you would in the markdown editor. This is helpful for both injecting variables into the text of your Slack UI blocks, as well as for for using liquid control tags to control when certain blocks should be displayed and for iterating through an array and mapping its items into a list of Slack blocks.
+
+Here's an example of a block kit UI template with liquid syntax added to iterate through a list of items.
+
+```json title="A block kit UI template in Knock with for-loop iteration"
+{
+	"blocks": [
+		{
+			"type": "header",
+			"text": {
+				"type": "plain_text",
+				"text": "Users marked for onboarding",
+				"emoji": true
+			}
+		},
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "Hi John,\n\n The following users have been assigned to you for onboarding today:"
+			}
+		},
+		{% for activity in activities %}
+		{
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": "*{{activity.assigned_user.name}}* \n {{activity.assigned_user.email}} \n _{{activity.assigned_user.title}}_"
+			},
+			"accessory": {
+				"type": "image",
+				"image_url": "{{activity.assigned_user.avatar_url}}",
+				"alt_text": "avatar image"
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{% endfor %}
+		{
+			"type": "actions",
+			"elements": [
+				{
+					"type": "button",
+					"text": {
+						"type": "plain_text",
+						"text": "View in dashboard",
+						"emoji": true
+					},
+					"value": "{{dashboard_url}}"
+				}
+			]
+		}
+	]
+}
+```
+
+In the template above, we're using the `activities` array produced by a [batch function](/send-notifications/designing-workflows/batch-function) to iterate over a number of items that we want to display in our Slack message. For each one of those items, we're producing a `section` that includes both `text` and an `image`, both of which are injected with variables from the `activity` from our `activities` array.
+
+Here's an example of a Slack message produced with this template. **Note:** this template was produced by three separate workflow trigger calls to the Knock API, all of which were batched into a single message automatically using our batch function.
+
+![An example Slack message built with block kit UI](/images/slack-json-block-example.png)

--- a/data/integrationsSidebar.ts
+++ b/data/integrationsSidebar.ts
@@ -53,55 +53,16 @@ const sidebarContent: SidebarSection[] = [
         pages: [
           { slug: "/overview", title: "Overview" },
           {
-            slug: "/how-knock-slacks",
-            title: "The Knock-Slack model",
+            slug: "/sending-an-internal-message",
+            title: "Sending an internal message",
           },
           {
-            slug: "/building-a-slack-app",
-            title: "Build a Slack app",
+            slug: "/sending-a-direct-message",
+            title: "Sending a direct message",
           },
           {
-            slug: "/designing-slack-templates",
-            title: "Designing Slack templates",
-          },
-          {
-            slug: "/slack-interactivity",
-            title: "Slack interactivity",
-          },
-          {
-            slug: "/slack-examples",
-            title: "Example use cases",
-          },
-        ],
-      },
-      {
-        title: "SlackKit",
-        slug: "/slack-kit",
-        pages: [
-          { slug: "/overview", title: "Overview" },
-          { slug: "/setup", title: "Setup" },
-          {
-            slug: "/resource-access-grants",
-            title: "Resource access grants",
-          },
-          { slug: "/ui", title: "UI" },
-          {
-            slug: "/trigger-workflow",
-            title: "Triggering workflows",
-          },
-        ],
-      },
-      {
-        title: "Slack DIY",
-        slug: "/slack-diy",
-        pages: [
-          {
-            slug: "/slack-apps-and-scopes",
-            title: "Slack apps and scopes",
-          },
-          {
-            slug: "/building-oauth-flow",
-            title: "Build your OAuth flow",
+            slug: "/sending-a-message-to-channels",
+            title: "Sending a message to channels",
           },
         ],
       },


### PR DESCRIPTION
### Description

This PR restructures all of the Slack-related docs found in 'Integrations' section to address the following issues in the current docs:

1. We offer the user many alternative paths, Slack, SlackKit, DIY, without making it clear which path they should take based on their use case. We have an opportunity to be more prescriptive here. 
2. This section of the docs combines reference material with implementation instructions. We should start with a clear explanation of what a Slack <-> Knock integration looks like, which is basically some combination of channel data.
