### PR TITLE
fix: "setup" should be "set up"

### DIFF
--- a/content/in-app-ui/ios/overview.mdx
+++ b/content/in-app-ui/ios/overview.mdx
@@ -8,7 +8,7 @@ Our Swift SDK library lets you create notification experiences using Knock's API
 
 ## Getting started
 
-Please reference our iOS SDK [documentation](https://docs.knock.app/sdks/ios/quick-start) to setup the library.
+Please reference our iOS SDK [documentation](https://docs.knock.app/sdks/ios/quick-start) to set up the library.
 
 ## Pre-built components
 

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -14,7 +14,7 @@ The Knock React Native SDK provides pre-built UI components that you can use to 
 
 ## Getting started
 
-Please reference our iOS SDK [documentation](https://docs.knock.app/sdks/react-native/quick-start) to setup the library.
+Please reference our iOS SDK [documentation](https://docs.knock.app/sdks/react-native/quick-start) to set up the library.
 
 ```bash
 npm install @knocklabs/react-native

--- a/content/in-app-ui/react/customizing-feed-components.mdx
+++ b/content/in-app-ui/react/customizing-feed-components.mdx
@@ -174,7 +174,7 @@ If you need even more control over the components rendered in the feed, it's als
 
 ### Using hooks to render custom UI
 
-The React component library ships with hooks that you can use to setup and manage your Knock client and feed connection. You can then use these hooks to provide the data for your own custom feed components. Let's take a look at what that looks like.
+The React component library ships with hooks that you can use to set up and manage your Knock client and feed connection. You can then use these hooks to provide the data for your own custom feed components. Let's take a look at what that looks like.
 
 First of all, we need to use the `useAuthenticatedKnockClient` hook to create a Knock client instance, authenticated for the user that's provided.
 

--- a/content/in-app-ui/react/toasts.mdx
+++ b/content/in-app-ui/react/toasts.mdx
@@ -37,7 +37,7 @@ npm install @knocklabs/react react-hot-toast
 
 ## Adding the Knock providers
 
-We'll need to wrap our toast producing component in a `KnockProvider` and `KnockFeedProvider` to setup a connection to Knock and connect to the authenticated user's feed. You can read more about the available props for the providers in [the reference](/in-app-ui/react/reference#knockprovider).
+We'll need to wrap our toast producing component in a `KnockProvider` and `KnockFeedProvider` to set up a connection to Knock and connect to the authenticated user's feed. You can read more about the available props for the providers in [the reference](/in-app-ui/react/reference#knockprovider).
 
 ```jsx
 import { KnockProvider, KnockFeedProvider } from "@knocklabs/react";

--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -16,7 +16,7 @@ There are two ways to configure APNS with Knock. You can use a token-based authe
 
 **Note**: Knock recommends token-based authentication for all APNS channel connections.
 
-You can read about how to setup a token connection to APNS [in the documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns). For your Knock channel configuration, you will need:
+You can read about how to set up a token connection to APNS [in the documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns). For your Knock channel configuration, you will need:
 
 1. A provider token signing key (a private key)
 2. The key identifier (a 10 digit identifier from your Apple developer account)
@@ -24,7 +24,7 @@ You can read about how to setup a token connection to APNS [in the documentation
 
 ### Certificate-based authentication configuration
 
-You can read aout how to setup a certificate connection to APNS [in the documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns). For your Knock channel configuration, you will need:
+You can read aout how to set up a certificate connection to APNS [in the documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_certificate-based_connection_to_apns). For your Knock channel configuration, you will need:
 
 1. A provider certificate (from your Apple developer account)
 2. A private key (generated in the process above)

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -24,7 +24,7 @@ Your OneSignal channel expects that you are using Knock to author Push notificat
   }
 />
 
-To setup OneSignal Push with Knock you will need:
+To set up OneSignal Push with Knock you will need:
 
 - Your OneSignal App ID
 - Your OneSignal API Key for sending notifications


### PR DESCRIPTION
As per [Merriam-Webster](https://www.merriam-webster.com/dictionary/setup), “setup” is a noun and “set up” is a verb.

Forgive me for being a stickler. 🫠 