### PR TITLE
feat(kno-7174): add Expo SDK docs

### DIFF
--- a/components/SdkCard.tsx
+++ b/components/SdkCard.tsx
@@ -13,9 +13,8 @@ import {
 } from "react-icons/fa";
 import { DiRuby, DiDotnet } from "react-icons/di";
 import { FaGolang } from "react-icons/fa6";
-import { SiElixir, SiFlutter } from "react-icons/si";
+import { SiElixir, SiFlutter, SiExpo } from "react-icons/si";
 import { TbBrandKotlin, TbBrandReactNative } from "react-icons/tb";
-
 import { Card } from "./Card";
 
 export type SupportedIcon =
@@ -36,9 +35,10 @@ export type SupportedIcon =
   | "reactnative"
   | "angular"
   | "vue"
-  | "youtube";
+  | "youtube"
+  | "expo";
 
-const icons = {
+const icons: Record<SupportedIcon, React.ReactNode> = {
   default: <IoCubeOutline />,
   node: <FaNodeJs />,
   python: <FaPython />,
@@ -57,6 +57,7 @@ const icons = {
   angular: <FaAngular />,
   vue: <FaVuejs />,
   youtube: <FaYoutube />,
+  expo: <SiExpo />,
 };
 
 type Props = {

--- a/content/in-app-ui/react-native/components.mdx
+++ b/content/in-app-ui/react-native/components.mdx
@@ -49,14 +49,12 @@ section: Building in-app UI
 
 ```tsx
 import {
-  KnockExpoPushNotificationProvider,
   KnockFeedProvider,
   KnockProvider,
   NotificationIconButton,
 } from "@knocklabs/react-native";
-import { StatusBar } from "expo-status-bar";
 import React, { useCallback, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, View, StatusBar } from "react-native";
 
 import NotificationFeedContainer from "./NotificationFeedContainer";
 
@@ -68,35 +66,27 @@ const App: React.FC = () => {
 
   return (
     <KnockProvider
-      apiKey={process.env.EXPO_PUBLIC_KNOCK_PUBLIC_API_KEY}
-      host={process.env.EXPO_PUBLIC_KNOCK_HOST}
-      userId={process.env.EXPO_PUBLIC_KNOCK_USER_ID}
+      apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+      host={process.env.KNOCK_HOST}
+      userId={process.env.KNOCK_USER_ID}
       logLevel="debug"
     >
-      <KnockExpoPushNotificationProvider
-        knockExpoChannelId={process.env.EXPO_PUBLIC_KNOCK_PUSH_CHANNEL_ID}
-      >
-        <KnockFeedProvider
-          feedId={process.env.EXPO_PUBLIC_KNOCK_FEED_CHANNEL_ID}
-        >
-          <View style={styles.container}>
-            <StatusBar style="auto" />
-            {!isNotificationFeedOpen && (
-              <NotificationIconButton
-                onClick={onTopActionButtonTap}
-                badgeCountType={"unread"}
-              />
-            )}
-            {isNotificationFeedOpen && (
-              <NotificationFeedContainer
-                handleClose={() =>
-                  setIsNotificationFeedOpen(!isNotificationFeedOpen)
-                }
-              />
-            )}
-          </View>
-        </KnockFeedProvider>
-      </KnockExpoPushNotificationProvider>
+      <View style={styles.container}>
+        <StatusBar />
+        {!isNotificationFeedOpen && (
+          <NotificationIconButton
+            onClick={onTopActionButtonTap}
+            badgeCountType={"unread"}
+          />
+        )}
+        {isNotificationFeedOpen && (
+          <NotificationFeedContainer
+            handleClose={() =>
+              setIsNotificationFeedOpen(!isNotificationFeedOpen)
+            }
+          />
+        )}
+      </View>
     </KnockProvider>
   );
 };

--- a/content/in-app-ui/react-native/components.mdx
+++ b/content/in-app-ui/react-native/components.mdx
@@ -71,22 +71,24 @@ const App: React.FC = () => {
       userId={process.env.KNOCK_USER_ID}
       logLevel="debug"
     >
-      <View style={styles.container}>
-        <StatusBar />
-        {!isNotificationFeedOpen && (
-          <NotificationIconButton
-            onClick={onTopActionButtonTap}
-            badgeCountType={"unread"}
-          />
-        )}
-        {isNotificationFeedOpen && (
-          <NotificationFeedContainer
-            handleClose={() =>
-              setIsNotificationFeedOpen(!isNotificationFeedOpen)
-            }
-          />
-        )}
-      </View>
+      <KnockFeedProvider feedId={process.env.KNOCK_FEED_CHANNEL_ID}>
+        <View style={styles.container}>
+          <StatusBar />
+          {!isNotificationFeedOpen && (
+            <NotificationIconButton
+              onClick={onTopActionButtonTap}
+              badgeCountType={"unread"}
+            />
+          )}
+          {isNotificationFeedOpen && (
+            <NotificationFeedContainer
+              handleClose={() =>
+                setIsNotificationFeedOpen(!isNotificationFeedOpen)
+              }
+            />
+          )}
+        </View>
+      </KnockFeedProvider>
     </KnockProvider>
   );
 };

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -27,6 +27,12 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 npm install @knocklabs/react-native
 ```
 
+When using React Native with Expo, install [our Expo SDK](/sdks/expo/overview) instead:
+
+```bash
+npm install @knocklabs/expo
+```
+
 ## Rendering a notification feed
 
 <Callout emoji="🔐"

--- a/content/in-app-ui/react-native/notification-feeds.mdx
+++ b/content/in-app-ui/react-native/notification-feeds.mdx
@@ -23,13 +23,13 @@ To use this example, you'll need [an account on Knock](https://dashboard.knock.a
 
 ## Installing dependencies
 
-```bash title="Installing dependencies"
+```bash title="Install the Knock React Native SDK"
 npm install @knocklabs/react-native
 ```
 
 When using React Native with Expo, install [our Expo SDK](/sdks/expo/overview) instead:
 
-```bash
+```bash title="Install the Knock Expo SDK"
 npm install @knocklabs/expo
 ```
 

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -16,13 +16,13 @@ The Knock React Native SDK provides pre-built UI components that you can use to 
 
 Please reference our [React Native SDK documentation](/sdks/react-native/quick-start) to set up the library.
 
-```bash
+```bash title="Install the Knock React Native SDK"
 npm install @knocklabs/react-native
 ```
 
 When using React Native with Expo, install [our Expo SDK](/sdks/expo/overview) instead:
 
-```bash
+```bash title="Install the Knock Expo SDK"
 npm install @knocklabs/expo
 ```
 

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -20,7 +20,7 @@ Please reference our [React Native SDK documentation](/sdks/react-native/quick-s
 npm install @knocklabs/react-native
 ```
 
-When using React Native with Expo, install [our Expo SDK](/sdks/expo/quick-start) instead:
+When using React Native with Expo, install [our Expo SDK](/sdks/expo/overview) instead:
 
 ```bash
 npm install @knocklabs/expo

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -41,3 +41,4 @@ npm install @knocklabs/expo
 - [Expo SDK reference](/sdks/expo/reference)
 - [Javascript SDK reference](/sdks/javascript/reference)
 - [`@knocklabs/react-native` on npm](https://www.npmjs.com/package/@knocklabs/react-native)
+- [`@knocklabs/expo` on npm](https://www.npmjs.com/package/@knocklabs/expo)

--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -14,10 +14,16 @@ The Knock React Native SDK provides pre-built UI components that you can use to 
 
 ## Getting started
 
-Please reference our iOS SDK [documentation](https://docs.knock.app/sdks/react-native/quick-start) to setup the library.
+Please reference our [React Native SDK documentation](/sdks/react-native/quick-start) to set up the library.
 
 ```bash
 npm install @knocklabs/react-native
+```
+
+When using React Native with Expo, install [our Expo SDK](/sdks/expo/quick-start) instead:
+
+```bash
+npm install @knocklabs/expo
 ```
 
 ### In-app notifications
@@ -32,5 +38,6 @@ npm install @knocklabs/react-native
 ## Links
 
 - [React Native SDK reference](/sdks/react-native/reference)
+- [Expo SDK reference](/sdks/expo/reference)
 - [Javascript SDK reference](/sdks/javascript/reference)
 - [`@knocklabs/react-native` on npm](https://www.npmjs.com/package/@knocklabs/react-native)

--- a/content/sdks/expo/overview.mdx
+++ b/content/sdks/expo/overview.mdx
@@ -1,0 +1,57 @@
+---
+title: "Knock Expo SDK"
+description: Learn more about integrating Knock into your Expo applications through our Expo SDK.
+section: SDKs
+tags: ["expo", "rn", "react native"]
+---
+
+Our [`@knocklabs/expo`](https://www.npmjs.com/package/@knocklabs/expo) library lets you create in-app notification experiences using Knock's client APIs in applications built with React Native and Expo.
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Not using Expo?</strong> See our{" "}
+      <a href="/sdks/react-native/overview">React Native SDK</a>. Our Expo SDK
+      is only meant for use with React Native apps that are built with Expo.
+    </>
+  }
+/>
+
+The Expo library is built on top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency.
+
+**Quick links:**
+
+- [`@knocklabs/expo` on npm](https://www.npmjs.com/package/@knocklabs/expo)
+- [`@knocklabs/client` on npm](https://www.npmjs.com/package/@knocklabs/client)
+- [Expo SDK reference](/sdks/expo/reference)
+- [Javascript SDK reference](/sdks/javascript/reference)
+
+Using the Expo SDK it's possible to build:
+
+- [Notification feeds](/in-app-ui/react-native/notification-feeds) that update in real time
+- Notification preference control centers
+- Push notification management
+
+## Example app
+
+Our [Expo SDK example app](https://github.com/knocklabs/javascript/tree/main/examples/expo-example) shows patterns for handling push token registration, building an in-app feed, and managing user notification preferences.
+
+## Need help?
+
+Our Expo SDK is worked on full-time by the Knock JavaScript team.
+
+### Join the community
+
+Ask questions and find answers on the following platforms:
+
+- [Knock community Slack](https://knock.app/join-slack)
+
+### Provide feedback
+
+- [Open an issue](https://github.com/knocklabs/javascript/issues/new)
+- Use the "Help" dropdown at the top of this page to contact support.
+
+### Contributing
+
+All contributors are welcome, from casual to regular. Feel free to open a [pull request](https://github.com/knocklabs/javascript/pulls/new).

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -8,7 +8,7 @@ section: SDKs
 
 ## Prerequisites
 
-Before diving into the integration process, ensure your Knock account is set up for push notifications. For initial setup instructions, please visit our [Push Notification Configuration Guide](https://docs.knock.app/integrations/push/overview).
+Before diving into the integration process, ensure your Knock account is set up for push notifications. For initial setup instructions, please visit our [Push Notification Configuration Guide](/integrations/push/overview).
 
 ## Step 1: Setting Up Push Notifications with Expo
 

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -14,7 +14,7 @@ Before diving into the integration process, ensure your Knock account is set up 
 
 1. **Create a Push Notification Channel in Knock:**
 
-   - Log in to your Knock dashboard and navigate to the Channels section.
+   - Log in to your Knock account and navigate to the **Integrations** > **Channels** section of the dashboard.
    - Create a new channel with type `Expo Push Notifications` and note the channel ID.
 
 2. **Install Expo Dependencies:**

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -96,4 +96,4 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
 - **Not Receiving Notifications:** Ensure your Expo push token is correctly registered with Knock and that your device's notification settings allow push notifications from your app.
 - **Handling Silent Notifications:** If implementing silent notifications, ensure that your notification payload is correctly configured to not display an alert or sound.
 
-For further assistance, visit our [support documentation](https://docs.knock.app) or reach out to our support team.
+For further assistance, contact [our support team](mailto:support@knock.app).

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -34,7 +34,7 @@ import { View } from "react-native";
 import {
   KnockProvider,
   KnockExpoPushNotificationProvider,
-} from "@knocklabs/react-native";
+} from "@knocklabs/expo";
 
 export default function App() {
   return (
@@ -49,12 +49,12 @@ export default function App() {
 
 2. **Initiate Registration in Your Component:**
    - The KnockExpoPushNotificationProvider automatically registers for push notifications.
-   - If you want to manually register, Utilize the `useExpoPushNotifications` hook:
+   - If you want to manually register, utilize the `useExpoPushNotifications` hook:
 
 ```jsx
 import React, { useEffect } from "react";
 import { Text } from "react-native";
-import { useExpoPushNotifications } from "@knocklabs/react-native";
+import { useExpoPushNotifications } from "@knocklabs/expo";
 
 const MyComponent = () => {
   const { expoPushToken, registerForPushNotifications } =

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -26,7 +26,7 @@ Before diving into the integration process, ensure your Knock account is set up 
 ## Step 2: Registering for Push Notifications
 
 1. **Wrap Your App with `KnockExpoPushNotificationProvider`:**
-   Ensure your app is wrapped with `KnockProvider` and then `KnockExpoPushNotificationProvider`, passing the Expo channel ID from Knock.
+   - Ensure your app is wrapped with `KnockProvider` and then `KnockExpoPushNotificationProvider`, passing the Expo channel ID from Knock.
 
 ```jsx
 import React from "react";

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -96,4 +96,4 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
 - **Not Receiving Notifications:** Ensure your Expo push token is correctly registered with Knock and that your device's notification settings allow push notifications from your app.
 - **Handling Silent Notifications:** If implementing silent notifications, ensure that your notification payload is correctly configured to not display an alert or sound.
 
-For further assistance, contact [our support team](mailto:support@knock.app).
+For further assistance, [reach out to our support team](mailto:support@knock.app).

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -10,7 +10,9 @@ section: SDKs
 
 Before diving into the integration process, ensure your Knock account is set up for push notifications. For initial setup instructions, please visit our [Push Notification Configuration Guide](/integrations/push/overview).
 
-## Step 1: Setting Up Push Notifications with Expo
+<Steps titleSize="h2">
+
+<Step title="Setting Up Push Notifications with Expo">
 
 1. **Create a Push Notification Channel in Knock:**
 
@@ -23,7 +25,9 @@ Before diving into the integration process, ensure your Knock account is set up 
    - `expo-device": "^5.9.3`
    - `expo-notifications": "^0.27.6`
 
-## Step 2: Registering for Push Notifications
+</Step>
+
+<Step title="Registering for Push Notifications">
 
 1. **Wrap Your App with `KnockExpoPushNotificationProvider`:**
    - Ensure your app is wrapped with `KnockProvider` and then `KnockExpoPushNotificationProvider`, passing the Expo channel ID from Knock.
@@ -68,7 +72,9 @@ const MyComponent = () => {
 };
 ```
 
-## Step 3: Handling Incoming Push Notifications
+</Step>
+
+<Step title="Handling Incoming Push Notifications">
 
 The `KnockExpoPushNotificationProvider` automatically handles receiving and tapping on notifications. To customize this behavior:
 
@@ -87,9 +93,15 @@ useEffect(() => {
 }, []);
 ```
 
-## Step 4: Sending Test Notifications
+</Step>
+
+<Step title="Sending Test Notifications">
 
 Use the Knock dashboard or API to send a test notification to ensure your setup is correct. Verify that the notification appears on your device and that tapping on it triggers the expected behavior.
+
+</Step>
+
+</Steps>
 
 ## Troubleshooting
 

--- a/content/sdks/expo/push-notifications.mdx
+++ b/content/sdks/expo/push-notifications.mdx
@@ -48,7 +48,7 @@ export default function App() {
 ```
 
 2. **Initiate Registration in Your Component:**
-   - The KnockExpoPushNotificationProvider automatically registers for push notifications.
+   - The `KnockExpoPushNotificationProvider` automatically registers for push notifications.
    - If you want to manually register, utilize the `useExpoPushNotifications` hook:
 
 ```jsx

--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -1,0 +1,423 @@
+---
+title: "Expo API reference"
+description: Complete API reference for the Knock Expo SDK.
+tags: ["sdk"]
+section: SDKs
+---
+
+In this section, you'll find the complete documentation for the components exposed in `@knocklabs/expo`, including the props available.
+
+**Note**: You can see a reference for the methods available for the `Knock` class, as well as a `Feed` instance under the [client JS docs](/in-app-ui/javascript/reference).
+
+## Components
+
+### `KnockProvider`
+
+The top-level provider that connects to Knock with the given API key and authenticates a user.
+
+#### Props
+
+Accepts `KnockProviderProps`
+
+<Attributes>
+  <Attribute
+    name="apiKey*"
+    type="string"
+    description="The public API key for the environment"
+  />
+  <Attribute
+    name="userId*"
+    type="string"
+    description="The ID of the user for which to retrieve a feed"
+  />
+  <Attribute
+    name="userToken"
+    type="string"
+    description={
+      <span>
+        A JWT that identifies the authenticated user, signed with the private
+        key provided in the Knock dashboard. Required to secure your production
+        environment.{" "}
+        <a
+          href="https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security"
+          target="_blank"
+        >
+          Learn more.
+        </a>
+      </span>
+    }
+  />
+  <Attribute
+    name="host"
+    type="string"
+    description="A custom API host for Knock"
+  />
+  <Attribute
+    name="i18n"
+    type="I18nContent"
+    description="An optional set of translations to override the default `en` translations used in the feed components"
+  />
+</Attributes>
+
+### `KnockFeedProvider`
+
+The feed-specific provider that connects to a feed for that user. Must be a child of the `KnockProvider`.
+
+#### Props
+
+Accepts `KnockFeedProviderProps`:
+
+<Attributes>
+  <Attribute
+    name="feedId*"
+    type="string"
+    description="The channel ID of the in-app feed to be displayed"
+  />
+  <Attribute
+    name="defaultFeedOptions"
+    type="FeedClientOptions"
+    description="Set defaults for `tenant`, `has_tenant`, `source`, `archived` to scope all subsequent feed queries"
+  />
+  <Attribute
+    name="colorMode"
+    type="ColorMode"
+    description="Sets the theme as either light or dark mode (defaults to light)"
+  />
+</Attributes>
+
+### `KnockExpoPushNotificationProvider`
+
+A React component designed to streamline the integration of Expo push notifications within your React Native application.
+It facilitates the registration of device push tokens with the Knock backend, enabling the delivery of notifications.
+Moreover, this provider empowers developers to define custom behavior for handling notifications when they are received or interacted with, either by tapping or performing another action.
+By default, it provides a basic notification handling strategy, but it also allows for custom logic to be easily implemented according to specific application needs.
+
+**Note:** Must be a child of the `KnockProvider`.
+
+#### Props
+
+Accepts `KnockExpoPushNotificationProviderProps`:
+
+<Attributes>
+  <Attribute
+    name="knockExpoChannelId*"
+    type="string"
+    description="The channel ID of your Expo channel from Knock."
+  />
+  <Attribute
+    name="customNotificationHandler"
+    type="Promise<Notifications.NotificationBehavior>"
+    description="Allows developers to define custom behavior for handling notifications, including whether to show alerts, play sounds, or set badge counts"
+  />
+</Attributes>
+
+## Hooks
+
+### `useKnock`
+
+The `KnockProvider` exposes a `useKnock` hook for all child components.
+
+**Returns**: `Knock`, an instance of the Knock JS client.
+
+**Example**:
+
+```jsx
+import { KnockProvider, useKnock } from "@knocklabs/react";
+
+const App = ({ authenticatedUser }) => (
+  <KnockProvider
+    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+    userId={authenticatedUser.id}
+  >
+    <MyComponent />
+  </KnockProvider>
+);
+
+const MyComponent = () => {
+  const knock = useKnock();
+
+  return null;
+};
+```
+
+### `useKnockFeed`
+
+The `KnockFeedProvider` exposes a `useKnockFeed` hook for all child components.
+
+**Returns**: `KnockFeedProviderState`
+
+<Attributes>
+  <Attribute
+    name="knock"
+    type="Knock"
+    description="The instance of the Knock client"
+  />
+  <Attribute
+    name="feedClient"
+    type="Feed"
+    description="The instance of the authenticated Feed"
+  />
+  <Attribute
+    name="useFeedStore"
+    type="UseStore<FeedStoreState>"
+    description="A zustand store containing the FeedStoreState"
+  />
+  <Attribute
+    name="status"
+    type="FilterStatus"
+    description="Current value of the filter status for the Feed"
+  />
+  <Attribute
+    name="setStatus"
+    type="function"
+    description="A function to set the current FilterStatus"
+  />
+  <Attribute
+    name="colorMode"
+    type="ColorMode"
+    description="The current theme color"
+  />
+</Attributes>
+
+**Example**:
+
+```jsx
+import {
+  KnockProvider,
+  KnockFeedProvider,
+  useKnockFeed,
+} from "@knocklabs/expo";
+
+const App = ({ authenticatedUser }) => (
+  <KnockProvider
+    apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+    userId={authenticatedUser.id}
+  >
+    <KnockFeedProvider feedId={process.env.KNOCK_FEED_CHANNEL_ID}>
+      <MyFeedComponent />
+    </KnockFeedProvider>
+  </KnockProvider>
+);
+
+const MyFeedComponent = () => {
+  const { useFeedStore } = useKnockFeed();
+  const items = useFeedStore((state) => state.items);
+
+  return (
+    <View>
+      {items.map((item) => (
+        <NotificationCell key={item.id} item={item} />
+      ))}
+    </View>
+  );
+};
+```
+
+### `useAuthenticatedKnockClient`
+
+Creates an authenticated Knock client.
+
+**Returns**: `Knock` instance, authenticated against the user
+
+**Example**:
+
+```jsx
+import { useAuthenticatedKnockClient } from "@knocklabs/expo";
+
+const MyComponent = () => {
+  const knock = useAuthenticatedKnockClient(
+    process.env.KNOCK_PUBLIC_API_KEY,
+    user.id,
+    user.knockToken,
+  );
+
+  return null;
+};
+```
+
+### `useNotifications`
+
+Creates a `Feed` instance for the provided `Knock` client which creates a stateful, real-time connection to Knock to build in-app experiences.
+
+**Returns**: `Feed` instance
+
+**Example**:
+
+```js
+import {
+  useAuthenticatedKnockClient,
+  useNotifications,
+  useNotificationStore,
+} from "@knocklabs/expo";
+
+const MyComponent = () => {
+  const knock = useAuthenticatedKnockClient(
+    process.env.KNOCK_PUBLIC_API_KEY,
+    user.id,
+    user.knockToken,
+  );
+
+  const notificationFeed = useNotifications(
+    knock,
+    process.env.KNOCK_FEED_CHANNEL_ID,
+  );
+
+  const { metadata } = useNotificationStore(notificationFeed);
+
+  useEffect(() => {
+    notificationFeed.fetch();
+  }, [notificationFeed]);
+
+  return (
+    <View>
+      <Text>Total unread: {metadata.unread_count}</Text>
+    </View>
+  );
+};
+```
+
+### `useTranslations`
+
+Exposed under `KnockI18nProvider` child components.
+
+**Returns**:
+
+<Attributes>
+  <Attribute
+    name="locale"
+    type="string"
+    description="The current locale code (defaults to `en`)"
+  />
+  <Attribute
+    name="t"
+    type="(key: string) => string"
+    description="A helper function to get the value of a translation from the current `Translations`."
+  />
+</Attributes>
+
+### `useExpoPushNotifications`
+
+The `KnockExpoPushNotificationProvider` exposes a `useExpoPushNotifications` hook for all child components, enabling them to interact with push notification functionalities and state.
+
+**Returns**: `ExpoPushNotificationContextType`
+
+<Attributes>
+  <Attribute
+    name="expoPushToken"
+    type="string | null"
+    description="The Expo push token for the current device."
+  />
+  <Attribute
+    name="registerForPushNotifications"
+    type="() => Promise<void>"
+    description="A function to initiate the push notification registration process."
+  />
+  <Attribute
+    name="registerPushTokenToChannel"
+    type="(token: string, channelId: string) => Promise<void>"
+    description="Registers the device's push token with a specific channel in the Knock backend."
+  />
+  <Attribute
+    name="unregisterPushTokenFromChannel"
+    type="(token: string, channelId: string) => Promise<void>"
+    description="Removes the device's push token from a specific channel in the Knock backend."
+  />
+  <Attribute
+    name="onNotificationReceived"
+    type="(handler: (notification: Notifications.Notification) => void) => void"
+    description="Sets a custom handler for notifications received while the app is in the foreground."
+  />
+  <Attribute
+    name="onNotificationTapped"
+    type="(handler: (response: Notifications.NotificationResponse) => void) => void"
+    description="Sets a custom handler for user interactions with notifications."
+  />
+</Attributes>
+
+**Example**:
+
+```jsx
+import React, { useEffect } from "react";
+import { View, Text } from "react-native";
+import {
+  KnockExpoPushNotificationProvider,
+  usePushNotifications,
+} from "@knocklabs/expo";
+
+const App = () => (
+  <KnockExpoPushNotificationProvider knockExpoChannelId="{YOUR_CHANNEL_ID}">
+    <MyComponent />
+  </KnockExpoPushNotificationProvider>
+);
+
+const MyComponent = () => {
+  const { expoPushToken, onNotificationReceived, onNotificationTapped } =
+    usePushNotifications();
+
+  useEffect(() => {
+    onNotificationReceived((notification) => {
+      console.log("Notification Received: ", notification);
+    });
+
+    onNotificationTapped((response) => {
+      console.log("Notification Tapped: ", response);
+    });
+  }, []);
+
+  return (
+    <View>
+      <Text>Expo Push Token: {expoPushToken}</Text>
+    </View>
+  );
+};
+```
+
+## Types
+
+### `I18nContent`
+
+Used to set translations available in the child components exposed under `KnockFeedProvider` and `KnockSlackProvider`. Used in the `useTranslations` hook.
+
+**Note:** `locale` must be a valid locale code.
+
+```typescript
+interface Translations {
+  readonly emptyFeedTitle: string;
+  readonly emptyFeedBody: string;
+  readonly notifications: string;
+  readonly poweredBy: string;
+  readonly markAllAsRead: string;
+  readonly archiveNotification: string;
+  readonly all: string;
+  readonly unread: string;
+  readonly read: string;
+  readonly unseen: string;
+
+  readonly slackConnectChannel: string;
+  readonly slackChannelId: string;
+  readonly slackConnecting: string;
+  readonly slackDisconnecting: string;
+  readonly slackConnect: string;
+  readonly slackConnected: string;
+  readonly slackConnectContainerDescription: string;
+  readonly slackSearchbarDisconnected: string;
+  readonly slackSearchbarMultipleChannels: string;
+  readonly slackSearchbarNoChannelsConnected: string;
+  readonly slackSearchbarNoChannelsFound: string;
+  readonly slackSearchbarChannelsError: string;
+  readonly slackSearchChannels: string;
+  readonly slackConnectionErrorOccurred: string;
+  readonly slackConnectionErrorExists: string;
+  readonly slackChannelAlreadyConnected: string;
+  readonly slackError: string;
+  readonly slackDisconnect: string;
+  readonly slackChannelSetError: string;
+  readonly slackAccessTokenNotSet: string;
+  readonly slackReconnect: string;
+}
+
+interface I18nContent {
+  readonly translations: Partial<Translations>;
+  readonly locale: string;
+}
+```

--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -341,7 +341,7 @@ import React, { useEffect } from "react";
 import { View, Text } from "react-native";
 import {
   KnockExpoPushNotificationProvider,
-  usePushNotifications,
+  useExpoPushNotifications,
 } from "@knocklabs/expo";
 
 const App = () => (
@@ -352,7 +352,7 @@ const App = () => (
 
 const MyComponent = () => {
   const { expoPushToken, onNotificationReceived, onNotificationTapped } =
-    usePushNotifications();
+    useExpoPushNotifications();
 
   useEffect(() => {
     onNotificationReceived((notification) => {

--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Expo API reference"
+title: "Expo SDK API reference"
 description: Complete API reference for the Knock Expo SDK.
 tags: ["sdk"]
 section: SDKs

--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -299,7 +299,7 @@ Exposed under `KnockI18nProvider` child components.
 
 The `KnockExpoPushNotificationProvider` exposes a `useExpoPushNotifications` hook for all child components, enabling them to interact with push notification functionalities and state.
 
-**Returns**: `ExpoPushNotificationContextType`
+**Returns**: `KnockExpoPushNotificationContextType`
 
 <Attributes>
   <Attribute

--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -87,7 +87,7 @@ Accepts `KnockFeedProviderProps`:
 
 ### `KnockExpoPushNotificationProvider`
 
-A React component designed to streamline the integration of Expo push notifications within your React Native application.
+A context provider designed to streamline the integration of Expo push notifications within your React Native application.
 It facilitates the registration of device push tokens with the Knock backend, enabling the delivery of notifications.
 Moreover, this provider empowers developers to define custom behavior for handling notifications when they are received or interacted with, either by tapping or performing another action.
 By default, it provides a basic notification handling strategy, but it also allows for custom logic to be easily implemented according to specific application needs.

--- a/content/sdks/overview.mdx
+++ b/content/sdks/overview.mdx
@@ -122,4 +122,11 @@ Knock's client-side libraries (also known as client-side SDKs) reduce the amount
     languages={["JavaScript", "TypeScript"]}
     isExternal={true}
   />
+  <SdkCard
+    title="Expo SDK"
+    linkUrl="https://github.com/knocklabs/javascript/tree/main/packages/expo"
+    icon="expo"
+    languages={["JavaScript", "TypeScript"]}
+    isExternal={true}
+  />
 </SdkCardGroup>

--- a/content/sdks/react-native/overview.mdx
+++ b/content/sdks/react-native/overview.mdx
@@ -7,6 +7,18 @@ tags: ["expo", "rn", "react native"]
 
 Our [`@knocklabs/react-native`](https://www.npmjs.com/package/@knocklabs/react-native) library lets you create in-app notification experiences in React Native powered applications using Knock's client APIs.
 
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Using Expo?</strong> See our{" "}
+      <a href="/sdks/expo/overview">Expo SDK</a>. Our React Native SDK is meant
+      for use with React Native apps that are not built with a framework such as
+      Expo.
+    </>
+  }
+/>
+
 The React Native library is built on top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency.
 
 **Quick links:**
@@ -28,7 +40,7 @@ You can find a basic example application that uses the React Native SDK [here](h
 
 ## Need help?
 
-Our React library is worked on full-time by the Knock JavaScript team.
+Our React Native SDK is worked on full-time by the Knock JavaScript team.
 
 ### Join the community
 

--- a/content/sdks/react-native/overview.mdx
+++ b/content/sdks/react-native/overview.mdx
@@ -25,8 +25,8 @@ The React Native library is built on top of the `@knocklabs/client` JS SDK and i
 
 - [`@knocklabs/react-native` on npm](https://www.npmjs.com/package/@knocklabs/react-native)
 - [`@knocklabs/client` on npm](https://www.npmjs.com/package/@knocklabs/client)
-- [React Native SDK reference](/in-app-ui/react-native/reference)
-- [Javascript SDK reference](/in-app-ui/javascript/reference)
+- [React Native SDK reference](/sdks/react-native/reference)
+- [Javascript SDK reference](/sdks/javascript/reference)
 
 Using the React Native SDK it's possible to build:
 

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -132,4 +132,4 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
 - **Not Receiving Notifications:** Ensure your FCM device token is correctly registered with Knock and that your device's notification settings allow push notifications from your app.
 - **Handling Silent Notifications:** If implementing silent notifications, ensure that your notification payload is correctly configured to not display an alert or sound.
 
-For further assistance, visit our [support documentation](https://docs.knock.app) or reach out to our support team.
+For further assistance, contact [our support team](mailto:support@knock.app).

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -19,7 +19,7 @@ section: SDKs
 
 ## Step 1: Set up a Firebase Cloud Messaging channel in Knock
 
-If you haven't already, create a new Firebase Cloud Messaging channel in the _Integrations_ page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification guide](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
+If you haven't already, create a new Firebase Cloud Messaging channel in the **Integrations** page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification guide](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
 
 ## Step 2: Set up React Native Firebase
 

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -23,7 +23,7 @@ If you haven't already, create a new Firebase Cloud Messaging channel in the **I
 
 ## Step 2: Set up React Native Firebase
 
-The simplest way to get started with FCM in your React Native app is to use [React Native Firebase](https://rnfirebase.io/), which simplifies the process of handling push notifications and device tokens. Follow their Getting Started guide to set up React Native Firebase in your project.
+The simplest way to get started with FCM in your React Native app is to use <a href="https://rnfirebase.io/" target="_blank">React Native Firebase</a>, which simplifies the process of handling push notifications and device tokens. Follow their Getting Started guide to set up React Native Firebase in your project.
 
 ## Step 3: Add `KnockPushNotificationProvider` to your app
 
@@ -50,13 +50,13 @@ export default function App() {
 
 ## Step 4: Request permissions
 
-Depending upon the platforms supported by your app, you may need to request permissions to receive push notifications on the user's device. See React Native Firebase's documentation on [how to request permissions on Android](https://rnfirebase.io/messaging/usage#android---requesting-permissions) and [how to request permissions on iOS](https://rnfirebase.io/messaging/usage#ios---requesting-permissions). Alternatively, consider using a third-party library such as [react-native-permissions](https://github.com/zoontek/react-native-permissions).
+Depending upon the platforms supported by your app, you may need to request permissions to receive push notifications on the user's device. See React Native Firebase's documentation on <a href="https://rnfirebase.io/messaging/usage#android---requesting-permissions" target="_blank">how to request permissions on Android</a> and <a href="https://rnfirebase.io/messaging/usage#ios---requesting-permissions" target="_blank">how to request permissions on iOS</a>. Alternatively, consider using a third-party library such as <a href="https://github.com/zoontek/react-native-permissions" target="_blank">react-native-permissions</a>.
 
 ## Step 5: Register for push notifications
 
-When your app launches, retrieve the device token using [React Native Firebase's `getToken` function](https://rnfirebase.io/reference/messaging#getToken). Pass this token to the `registerPushTokenToChannel` function provided by Knock's [`usePushNotifications` hook](/sdks/react-native/reference#usepushnotifications) and include the channel ID of your FCM channel.
+When your app launches, retrieve the device token using <a href="https://rnfirebase.io/reference/messaging#getToken" target="_blank">React Native Firebase's `getToken` function</a>. Pass this token to the `registerPushTokenToChannel` function provided by Knock's [`usePushNotifications` hook](/sdks/react-native/reference#usepushnotifications) and include the channel ID of your FCM channel.
 
-Additionally, when your app is in the foreground, register a listener using [`onTokenRefresh`](https://rnfirebase.io/reference/messaging#onTokenRefresh) and invoke `registerPushTokenToChannel` whenever the token is refreshed.
+Additionally, when your app is in the foreground, register a listener using <a href="https://rnfirebase.io/reference/messaging#onTokenRefresh" target="_blank">`onTokenRefresh`</a> and invoke `registerPushTokenToChannel` whenever the token is refreshed.
 
 ```tsx
 import { Text } from "react-native";
@@ -88,7 +88,7 @@ const MyComponent = () => {
 
 ## Step 6: Handle incoming push notifications
 
-Listen for push notifications using React Native Firebase's [`getInitialNotification`](https://rnfirebase.io/reference/messaging#getInitialNotification) and [`onNotificationOpenedApp`](https://rnfirebase.io/reference/messaging#onNotificationOpenedApp) functions. See [React Native Firebase's Notifications guide](https://rnfirebase.io/messaging/notifications#handling-interaction) for more details on these two functions.
+Listen for push notifications using React Native Firebase's <a href="https://rnfirebase.io/reference/messaging#getInitialNotification" target="_blank">`getInitialNotification`</a> and <a href="https://rnfirebase.io/reference/messaging#onNotificationOpenedApp" target="_blank">`onNotificationOpenedApp`</a> functions. See <a href="https://rnfirebase.io/messaging/notifications#handling-interaction" target="_blank">React Native Firebase's Notifications guide</a> for more details on these two functions.
 
 ```tsx
 useEffect(() => {
@@ -120,7 +120,10 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
   text={
     <>
       Check out our{" "}
-      <a href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example">
+      <a
+        href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example"
+        target="_blank"
+      >
         React Native example app
       </a>{" "}
       to see a fully working example of how to integrate push notifications with

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -17,15 +17,21 @@ section: SDKs
   }
 />
 
-## Step 1: Set up a Firebase Cloud Messaging channel in Knock
+<Steps titleSize="h2">
+
+<Step title="Set up a Firebase Cloud Messaging channel in Knock">
 
 If you haven't already, create a new Firebase Cloud Messaging channel in the **Integrations** page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification guide](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
 
-## Step 2: Set up React Native Firebase
+</Step>
+
+<Step title="Set up React Native Firebase">
 
 The simplest way to get started with FCM in your React Native app is to use <a href="https://rnfirebase.io/" target="_blank">React Native Firebase</a>, which simplifies the process of handling push notifications and device tokens. Follow their Getting Started guide to set up React Native Firebase in your project.
 
-## Step 3: Add `KnockPushNotificationProvider` to your app
+</Step>
+
+<Step title="Add KnockPushNotificationProvider to your app">
 
 Ensure your app is wrapped with both `KnockProvider` and `KnockPushNotificationProvider`.
 
@@ -48,11 +54,15 @@ export default function App() {
 }
 ```
 
-## Step 4: Request permissions
+</Step>
+
+<Step title="Request permissions">
 
 Depending upon the platforms supported by your app, you may need to request permissions to receive push notifications on the user's device. See React Native Firebase's documentation on <a href="https://rnfirebase.io/messaging/usage#android---requesting-permissions" target="_blank">how to request permissions on Android</a> and <a href="https://rnfirebase.io/messaging/usage#ios---requesting-permissions" target="_blank">how to request permissions on iOS</a>. Alternatively, consider using a third-party library such as <a href="https://github.com/zoontek/react-native-permissions" target="_blank">react-native-permissions</a>.
 
-## Step 5: Register for push notifications
+</Step>
+
+<Step title="Register for push notifications">
 
 When your app launches, retrieve the device token using <a href="https://rnfirebase.io/reference/messaging#getToken" target="_blank">React Native Firebase's `getToken` function</a>. Pass this token to the `registerPushTokenToChannel` function provided by Knock's [`usePushNotifications` hook](/sdks/react-native/reference#usepushnotifications) and include the channel ID of your FCM channel.
 
@@ -86,7 +96,9 @@ const MyComponent = () => {
 };
 ```
 
-## Step 6: Handle incoming push notifications
+</Step>
+
+<Step title="Handle incoming push notifications">
 
 Listen for push notifications using React Native Firebase's <a href="https://rnfirebase.io/reference/messaging#getInitialNotification" target="_blank">`getInitialNotification`</a> and <a href="https://rnfirebase.io/reference/messaging#onNotificationOpenedApp" target="_blank">`onNotificationOpenedApp`</a> functions. See <a href="https://rnfirebase.io/messaging/notifications#handling-interaction" target="_blank">React Native Firebase's Notifications guide</a> for more details on these two functions.
 
@@ -109,9 +121,15 @@ useEffect(() => {
 }, []);
 ```
 
-## Step 7: Send a test notification
+</Step>
+
+<Step title="Send a test notification">
 
 Use the Knock dashboard or API to send a test notification to ensure your setup is correct. Verify that the notification appears on your device and that tapping on it triggers the expected behavior.
+
+</Step>
+
+</Steps>
 
 ## Troubleshooting
 

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -1,0 +1,135 @@
+---
+title: "Handling Push Notifications with React Native and Firebase Cloud Messaging"
+description: A guide on integrating FCM push notifications with the Knock SDK in your React Native application.
+section: SDKs
+---
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Using Expo?</strong> See our{" "}
+      <a href="/sdks/expo/push-notifications">
+        guide to handling push notifications using our Expo SDK
+      </a>
+      .
+    </>
+  }
+/>
+
+## Step 1: Set up a Firebase Cloud Messaging channel in Knock
+
+If you haven't already, create a new Firebase Cloud Messaging channel in the _Integrations_ page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification guide](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
+
+## Step 2: Set up React Native Firebase
+
+The simplest way to get started with FCM in your React Native app is to use [React Native Firebase](https://rnfirebase.io/), which simplifies the process of handling push notifications and device tokens. Follow their Getting Started guide to set up React Native Firebase in your project.
+
+## Step 3: Add `KnockPushNotificationProvider` to your app
+
+Ensure your app is wrapped with both `KnockProvider` and `KnockPushNotificationProvider`.
+
+```tsx
+import React from "react";
+import { View } from "react-native";
+import {
+  KnockProvider,
+  KnockPushNotificationProvider,
+} from "@knocklabs/react-native";
+
+export default function App() {
+  return (
+    <KnockProvider apiKey="{YOUR_KNOCK_PUBLIC_API_KEY}" userId="{YOUR_USER_ID}">
+      <KnockPushNotificationProvider>
+        <View> {/* Your app content here */} </View>
+      </KnockPushNotificationProvider>
+    </KnockProvider>
+  );
+}
+```
+
+## Step 4: Request permissions
+
+Depending upon the platforms supported by your app, you may need to request permissions to receive push notifications on the user's device. See React Native Firebase's documentation on [how to request permissions on Android](https://rnfirebase.io/messaging/usage#android---requesting-permissions) and [how to request permissions on iOS](https://rnfirebase.io/messaging/usage#ios---requesting-permissions). Alternatively, consider using a third-party library such as [react-native-permissions](https://github.com/zoontek/react-native-permissions).
+
+## Step 5: Register for push notifications
+
+When your app launches, retrieve the device token using [React Native Firebase's `getToken` function](https://rnfirebase.io/reference/messaging#getToken). Pass this token to the `registerPushTokenToChannel` function provided by Knock's [`usePushNotifications` hook](/sdks/react-native/reference#usepushnotifications) and include the channel ID of your FCM channel.
+
+Additionally, when your app is in the foreground, register a listener using [`onTokenRefresh`](https://rnfirebase.io/reference/messaging#onTokenRefresh) and invoke `registerPushTokenToChannel` whenever the token is refreshed.
+
+```tsx
+import { Text } from "react-native";
+import { usePushNotifications } from "@knocklabs/react-native";
+import messaging from "@react-native-firebase/messaging";
+
+const MyComponent = () => {
+  const { registerPushTokenToChannel } = usePushNotifications();
+
+  useEffect(() => {
+    messaging()
+      .getToken()
+      .then((token) =>
+        registerPushTokenToChannel(token, "{YOUR_KNOCK_FCM_CHANNEL_ID}"),
+      )
+      .catch(console.error);
+
+    const unsubscribe = messaging().onTokenRefresh((token) =>
+      registerPushTokenToChannel(token, "{YOUR_KNOCK_FCM_CHANNEL_ID}").catch(
+        console.error,
+      ),
+    );
+    return unsubscribe;
+  }, [registerPushTokenToChannel]);
+
+  return <Text>Hello, world!</Text>;
+};
+```
+
+## Step 6: Handle incoming push notifications
+
+Listen for push notifications using React Native Firebase's [`getInitialNotification`](https://rnfirebase.io/reference/messaging#getInitialNotification) and [`onNotificationOpenedApp`](https://rnfirebase.io/reference/messaging#onNotificationOpenedApp) functions. See [React Native Firebase's Notifications guide](https://rnfirebase.io/messaging/notifications#handling-interaction) for more details on these two functions.
+
+```tsx
+useEffect(() => {
+  messaging()
+    .getInitialNotification()
+    .then((remoteMessage) => {
+      if (remoteMessage) {
+        console.log("App opened via notification from quit state");
+      }
+    })
+    .catch(console.error);
+
+  const unsubscribe = messaging().onNotificationOpenedApp(() => {
+    console.log("App opened via notification while in the background");
+  });
+
+  return unsubscribe;
+}, []);
+```
+
+## Step 7: Send a test notification
+
+Use the Knock dashboard or API to send a test notification to ensure your setup is correct. Verify that the notification appears on your device and that tapping on it triggers the expected behavior.
+
+## Troubleshooting
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      Check out our{" "}
+      <a href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example">
+        React Native example app
+      </a>{" "}
+      to see a fully working example of how to integrate push notifications with
+      Knock, Firebase Cloud Messaging, and React Native Firebase.
+    </>
+  }
+/>
+
+- **Not Receiving Notifications:** Ensure your FCM device token is correctly registered with Knock and that your device's notification settings allow push notifications from your app.
+- **Handling Silent Notifications:** If implementing silent notifications, ensure that your notification payload is correctly configured to not display an alert or sound.
+
+For further assistance, visit our [support documentation](https://docs.knock.app) or reach out to our support team.

--- a/content/sdks/react-native/push-notifications.mdx
+++ b/content/sdks/react-native/push-notifications.mdx
@@ -132,4 +132,4 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
 - **Not Receiving Notifications:** Ensure your FCM device token is correctly registered with Knock and that your device's notification settings allow push notifications from your app.
 - **Handling Silent Notifications:** If implementing silent notifications, ensure that your notification payload is correctly configured to not display an alert or sound.
 
-For further assistance, contact [our support team](mailto:support@knock.app).
+For further assistance, [reach out to our support team](mailto:support@knock.app).

--- a/content/sdks/react-native/quick-start.mdx
+++ b/content/sdks/react-native/quick-start.mdx
@@ -6,7 +6,7 @@ section: SDKs
 
 To get started, you will need the following:
 
-- [A Knock Account](https://dashboard.knock.app/signup)
+- [A Knock account](https://dashboard.knock.app/signup)
 - A public API key for the Knock environment (which you'll use in the `publishableKey`)
 - An in-app feed channel with a workflow that produces in-app feed messages (optional)
 

--- a/content/sdks/react-native/quick-start.mdx
+++ b/content/sdks/react-native/quick-start.mdx
@@ -9,12 +9,21 @@ To get started, you will need the following:
 - [A Knock Account](https://dashboard.knock.app/signup)
 - A public API key for the Knock environment (which you'll use in the `publishableKey`)
 - An in-app feed channel with a workflow that produces in-app feed messages (optional)
-- An Expo channel with a workflow that produces push notifications (optional)
 
 ## Installation
 
 - Via NPM: `npm install @knocklabs/react-native`
 - Via Yarn: `yarn add @knocklabs/react-native`
+
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <strong>Using Expo?</strong> Install <code>@knocklabs/expo</code> instead
+      to use our <a href="/sdks/expo/overview">Expo SDK</a>.
+    </>
+  }
+/>
 
 ### Configuration
 
@@ -39,7 +48,6 @@ To configure the feed you will need:
    />
 
 3. If integrating an in-app feed, a feed channel ID (found in the Knock dashboard)
-4. If integrating push notifications, an Expo channel ID (found in the Knock dashboard)
 
 ### Usage
 

--- a/content/sdks/react-native/reference.mdx
+++ b/content/sdks/react-native/reference.mdx
@@ -307,33 +307,30 @@ The `KnockPushNotificationProvider` exposes a `usePushNotifications` hook for al
 import React, { useEffect } from "react";
 import { View, Text } from "react-native";
 import {
-  KnockExpoPushNotificationProvider,
-  useExpoPushNotifications,
-} from "@knocklabs/expo";
+  KnockPushNotificationProvider,
+  usePushNotifications,
+} from "@knocklabs/react-native";
 
 const App = () => (
-  <KnockExpoPushNotificationProvider knockExpoChannelId="{YOUR_CHANNEL_ID}">
+  <KnockPushNotificationProvider>
     <MyComponent />
-  </KnockExpoPushNotificationProvider>
+  </KnockPushNotificationProvider>
 );
 
 const MyComponent = () => {
-  const { expoPushToken, onNotificationReceived, onNotificationTapped } =
-    useExpoPushNotifications();
+  // How the push token is retrieved depends upon the push notification service you are using
+  const pushToken = getPushTokenForCurrentDevice();
+  const { registerPushTokenToChannel } = usePushNotifications();
 
   useEffect(() => {
-    onNotificationReceived((notification) => {
-      console.log("Notification Received: ", notification);
-    });
-
-    onNotificationTapped((response) => {
-      console.log("Notification Tapped: ", response);
-    });
-  }, []);
+    registerPushTokenToChannel(pushToken, process.env.KNOCK_PUSH_CHANNEL_ID)
+      .then(() => console.log("Push token registered"))
+      .catch(console.error);
+  }, [registerPushTokenToChannel, pushToken]);
 
   return (
     <View>
-      <Text>Expo Push Token: {expoPushToken}</Text>
+      <Text>Push Token: {pushToken}</Text>
     </View>
   );
 };

--- a/content/sdks/react-native/reference.mdx
+++ b/content/sdks/react-native/reference.mdx
@@ -85,32 +85,6 @@ Accepts `KnockFeedProviderProps`:
   />
 </Attributes>
 
-### `KnockExpoPushNotificationProvider`
-
-A React component designed to streamline the integration of Expo push notifications within your React Native application.
-It facilitates the registration of device push tokens with the Knock backend, enabling the delivery of notifications.
-Moreover, this provider empowers developers to define custom behavior for handling notifications when they are received or interacted with, either by tapping or performing another action.
-By default, it provides a basic notification handling strategy, but it also allows for custom logic to be easily implemented according to specific application needs.
-
-**Note:** Must be a child of the `KnockProvider`.
-
-#### Props
-
-Accepts `KnockExpoPushNotificationProviderProps`:
-
-<Attributes>
-  <Attribute
-    name="knockExpoChannelId*"
-    type="string"
-    description="The channel ID of your Expo channel from Knock."
-  />
-  <Attribute
-    name="customNotificationHandler"
-    type="Promise<Notifications.NotificationBehavior>"
-    description="Allows developers to define custom behavior for handling notifications, including whether to show alerts, play sounds, or set badge counts"
-  />
-</Attributes>
-
 ## Hooks
 
 ### `useKnock`
@@ -294,83 +268,6 @@ Exposed under `KnockI18nProvider` child components.
     description="A helper function to get the value of a translation from the current `Translations`."
   />
 </Attributes>
-
-### `useExpoPushNotifications`
-
-The `KnockExpoPushNotificationProvider` exposes a `useExpoPushNotifications` hook for all child components, enabling them to interact with push notification functionalities and state.
-
-**Returns**: `ExpoPushNotificationContextType`
-
-<Attributes>
-  <Attribute
-    name="expoPushToken"
-    type="string | null"
-    description="The Expo push token for the current device."
-  />
-  <Attribute
-    name="registerForPushNotifications"
-    type="() => Promise<void>"
-    description="A function to initiate the push notification registration process."
-  />
-  <Attribute
-    name="registerPushTokenToChannel"
-    type="(token: string, channelId: string) => Promise<void>"
-    description="Registers the device's push token with a specific channel in the Knock backend."
-  />
-  <Attribute
-    name="unregisterPushTokenFromChannel"
-    type="(token: string, channelId: string) => Promise<void>"
-    description="Removes the device's push token from a specific channel in the Knock backend."
-  />
-  <Attribute
-    name="onNotificationReceived"
-    type="(handler: (notification: Notifications.Notification) => void) => void"
-    description="Sets a custom handler for notifications received while the app is in the foreground."
-  />
-  <Attribute
-    name="onNotificationTapped"
-    type="(handler: (response: Notifications.NotificationResponse) => void) => void"
-    description="Sets a custom handler for user interactions with notifications."
-  />
-</Attributes>
-
-**Example**:
-
-```jsx
-import React, { useEffect } from "react";
-import { View, Text } from "react-native";
-import {
-  KnockExpoPushNotificationProvider,
-  usePushNotifications,
-} from "@knocklabs/react-native";
-
-const App = () => (
-  <KnockExpoPushNotificationProvider knockExpoChannelId="{YOUR_CHANNEL_ID}">
-    <MyComponent />
-  </KnockExpoPushNotificationProvider>
-);
-
-const MyComponent = () => {
-  const { expoPushToken, onNotificationReceived, onNotificationTapped } =
-    usePushNotifications();
-
-  useEffect(() => {
-    onNotificationReceived((notification) => {
-      console.log("Notification Received: ", notification);
-    });
-
-    onNotificationTapped((response) => {
-      console.log("Notification Tapped: ", response);
-    });
-  }, []);
-
-  return (
-    <View>
-      <Text>Expo Push Token: {expoPushToken}</Text>
-    </View>
-  );
-};
-```
 
 ## Types
 

--- a/content/sdks/react-native/reference.mdx
+++ b/content/sdks/react-native/reference.mdx
@@ -85,6 +85,19 @@ Accepts `KnockFeedProviderProps`:
   />
 </Attributes>
 
+### `KnockPushNotificationProvider`
+
+A context provider designed to streamline the integration of push notifications within your React Native application.
+It facilitates the registration of device push tokens with the Knock backend, enabling the delivery of notifications.
+
+It is recommended to use the [`usePushNotifications`](#usepushnotifications) hook to interact with this context provider.
+
+**Note:** Must be a child of the `KnockProvider`.
+
+#### Props
+
+None other than `children`.
+
 ## Hooks
 
 ### `useKnock`
@@ -268,6 +281,63 @@ Exposed under `KnockI18nProvider` child components.
     description="A helper function to get the value of a translation from the current `Translations`."
   />
 </Attributes>
+
+### `usePushNotifications`
+
+The `KnockPushNotificationProvider` exposes a `usePushNotifications` hook for all child components, enabling them to register and unregister a device's push token from a channel.
+
+**Returns**: `KnockPushNotificationContextType`
+
+<Attributes>
+  <Attribute
+    name="registerPushTokenToChannel"
+    type="(token: string, channelId: string) => Promise<void>"
+    description="Registers the device's push token with a specific channel in the Knock backend."
+  />
+  <Attribute
+    name="unregisterPushTokenFromChannel"
+    type="(token: string, channelId: string) => Promise<void>"
+    description="Removes the device's push token from a specific channel in the Knock backend."
+  />
+</Attributes>
+
+**Example**:
+
+```jsx
+import React, { useEffect } from "react";
+import { View, Text } from "react-native";
+import {
+  KnockExpoPushNotificationProvider,
+  useExpoPushNotifications,
+} from "@knocklabs/expo";
+
+const App = () => (
+  <KnockExpoPushNotificationProvider knockExpoChannelId="{YOUR_CHANNEL_ID}">
+    <MyComponent />
+  </KnockExpoPushNotificationProvider>
+);
+
+const MyComponent = () => {
+  const { expoPushToken, onNotificationReceived, onNotificationTapped } =
+    useExpoPushNotifications();
+
+  useEffect(() => {
+    onNotificationReceived((notification) => {
+      console.log("Notification Received: ", notification);
+    });
+
+    onNotificationTapped((response) => {
+      console.log("Notification Tapped: ", response);
+    });
+  }, []);
+
+  return (
+    <View>
+      <Text>Expo Push Token: {expoPushToken}</Text>
+    </View>
+  );
+};
+```
 
 ## Types
 

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -289,7 +289,7 @@ const sidebarContent: SidebarSection[] = [
         pages: [
           { slug: "/overview", title: "Overview" },
           { slug: "/quick-start", title: "Quick start" },
-          { slug: "/push-notifications", title: "Push notifications" },
+          // TODO { slug: "/push-notifications", title: "Push notifications" }
           { slug: "/reference", title: "API reference" },
         ],
       },
@@ -299,7 +299,7 @@ const sidebarContent: SidebarSection[] = [
         pages: [
           // { slug: "/overview", title: "Overview" },
           // { slug: "/quick-start", title: "Quick start" },
-          // { slug: "/push-notifications", title: "Push notifications" },
+          { slug: "/push-notifications", title: "Push notifications" },
           { slug: "/reference", title: "API reference" },
         ],
       },

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -289,6 +289,7 @@ const sidebarContent: SidebarSection[] = [
         pages: [
           { slug: "/overview", title: "Overview" },
           { slug: "/quick-start", title: "Quick start" },
+          { slug: "/push-notifications", title: "Push notifications" },
           { slug: "/reference", title: "API reference" },
         ],
       },

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -297,7 +297,7 @@ const sidebarContent: SidebarSection[] = [
         title: "Expo",
         slug: "/expo",
         pages: [
-          // { slug: "/overview", title: "Overview" },
+          { slug: "/overview", title: "Overview" },
           // { slug: "/quick-start", title: "Quick start" },
           { slug: "/push-notifications", title: "Push notifications" },
           { slug: "/reference", title: "API reference" },

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -293,6 +293,16 @@ const sidebarContent: SidebarSection[] = [
           { slug: "/reference", title: "API reference" },
         ],
       },
+      {
+        title: "Expo",
+        slug: "/expo",
+        pages: [
+          // { slug: "/overview", title: "Overview" },
+          // { slug: "/quick-start", title: "Quick start" },
+          // { slug: "/push-notifications", title: "Push notifications" },
+          { slug: "/reference", title: "API reference" },
+        ],
+      },
     ],
   },
 

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -289,7 +289,6 @@ const sidebarContent: SidebarSection[] = [
         pages: [
           { slug: "/overview", title: "Overview" },
           { slug: "/quick-start", title: "Quick start" },
-          // TODO { slug: "/push-notifications", title: "Push notifications" }
           { slug: "/reference", title: "API reference" },
         ],
       },
@@ -298,7 +297,6 @@ const sidebarContent: SidebarSection[] = [
         slug: "/expo",
         pages: [
           { slug: "/overview", title: "Overview" },
-          // { slug: "/quick-start", title: "Quick start" },
           { slug: "/push-notifications", title: "Push notifications" },
           { slug: "/reference", title: "API reference" },
         ],


### PR DESCRIPTION
### Description

This PR updates the docs to include the Expo SDK added by knocklabs/javascript#243. I also updated the React Native push notifications guide to describe integrating push notifications using Firebase Cloud Messaging and React Native Firebase.

### Tasks

[KNO-7174](https://linear.app/knock/issue/KNO-7174/[expo-sdk]-update-docs-to-include-new-expo-sdk)

### Screenshots

<img width="1487" alt="Screenshot 2024-10-17 at 11 09 43 AM" src="https://github.com/user-attachments/assets/812fa12f-6220-41d3-849a-84394fa4a883">
