### PR TITLE
fix: KnockActivity code snippet in Android push docs

### DIFF
--- a/content/sdks/android/push-notifications.mdx
+++ b/content/sdks/android/push-notifications.mdx
@@ -142,8 +142,8 @@ To detect when a push notification is received in the foreground:
 
   ```kotlin
   class MainActivity: KnockActivity() {
-    override fun onKnockPushNotificationTappedInBackGround(intent: Intent) {
-        super.onKnockPushNotificationTappedInBackGround(intent)
+    override fun onKnockPushNotificationTappedInBackground(intent: Intent) {
+        super.onKnockPushNotificationTappedInBackground(intent)
 
         // Perform any action here
     }


### PR DESCRIPTION
The function should be named `onKnockPushNotificationTappedInBackground`, with a lowercase g, as per [the `KnockActivityInterface` interface](https://github.com/knocklabs/knock-android/blob/96707ada2ee0bec439364ef320d5a293e607915e/sdk/src/main/java/app/knock/client/KnockActivity.kt#L28).