### PR TITLE
fix: re-render `documentHeaders` on `sourcePath` change (KNO-7200)

### DIFF
--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -95,7 +95,7 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
     ) as HTMLHeadingElement[];
 
     setHeaders(buildHeaderTree(documentHeaders));
-  }, [title]);
+  }, [title, sourcePath]);
 
   if (headers.length === 0) {
     return null;


### PR DESCRIPTION
### Description

Right now, we only re-render the document headers if the page's `title` changes. This works in most situations, but we do have a few cases (i.e. https://docs.knock.app/concepts/preferences and https://docs.knock.app/preferences/overview, or https://docs.knock.app/designing-workflows/template-editor/variables and https://docs.knock.app/concepts/variables) where pages share a title, which means that we don't re-render the "On this page" sidebar.

This PR adds `sourcePath` to the `useEffect` so that we will re-render based on the path for the page changing as well.

To test, you can navigate between https://docs-6kbzcboux-knocklabs.vercel.app/concepts/preferences and https://docs-6kbzcboux-knocklabs.vercel.app/preferences/overview, or https://docs-6kbzcboux-knocklabs.vercel.app/designing-workflows/template-editor/variables and https://docs-6kbzcboux-knocklabs.vercel.app/concepts/variables.
