### PR TITLE
chore: add auto-join clarification 

### DIFF
--- a/content/manage-your-account/managing-members.mdx
+++ b/content/manage-your-account/managing-members.mdx
@@ -74,9 +74,9 @@ You can enable auto-join under **Settings** > **Security** in your dashboard.
 />
 
 When you enable auto-join for your account, you'll need to select which domains
-can auto-join your account. For security reasons, we only let you select non-public domains that belong to the existing members of your account.
-This means that you cannot enable auto-join for public domains (such as gmail.com) and that if you have a new domain you'd like to add to auto-join, you'll need to invite
-one member from that domain before doing so.
+can auto-join your account. For security reasons, we only let you select non-public domains that belong to the owners of your account.
+This means that you cannot enable auto-join for public domains (such as gmail.com) and that if you have a new domain you'd like to add to auto-join, you'll need to have
+an account owner with that domain before doing so.
 
 <Callout
   emoji="🚨"

--- a/content/manage-your-account/managing-members.mdx
+++ b/content/manage-your-account/managing-members.mdx
@@ -75,8 +75,7 @@ You can enable auto-join under **Settings** > **Security** in your dashboard.
 
 When you enable auto-join for your account, you'll need to select which domains
 can auto-join your account. For security reasons, we only let you select non-public domains that belong to the owners of your account.
-This means that you cannot enable auto-join for public domains (such as gmail.com) and that if you have a new domain you'd like to add to auto-join, you'll need to have
-an account owner with that domain before doing so.
+This means that you cannot enable auto-join for public domains (such as gmail.com). Additionally, before you can add a new domain to auto-join, someone with an email address from that domain must have an [owner role](/manage-your-account/roles-and-permissions) on your account.
 
 <Callout
   emoji="🚨"


### PR DESCRIPTION
### Description
Add a clarification that it is for non-public domains for **_owners_** of the account (current text reads as if the domain options available are for any members of the account).