### PR TITLE
feat(kno-7184): add SMTP docs

### DIFF
--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -74,8 +74,8 @@ Knock supports the following channel types and providers:
     [Mandrill](/integrations/email/mandrill),
     [Postmark](/integrations/email/postmark),
     [Resend](/integrations/email/resend),
-    [Sendgrid](/integrations/email/sendgrid), and
-    [Sparkpost](/integrations/email/sparkpost).
+    [Sendgrid](/integrations/email/sendgrid), [SMTP](/integrations/email/smtp),
+    and [Sparkpost](/integrations/email/sparkpost).
   </Accordion>
   <Accordion title="SMS">
     Knock supports sending SMS with [Africa's

--- a/content/integrations/email/overview.mdx
+++ b/content/integrations/email/overview.mdx
@@ -31,6 +31,7 @@ Knock currently supports sending email notifications to the following email prov
 - [Postmark](/integrations/email/postmark)
 - [Resend](/integrations/email/resend)
 - [Sendgrid](/integrations/email/sendgrid)
+- [SMTP](/integrations/email/smtp)
 - [Sparkpost](/integrations/email/sparkpost)
 
 If you want us to add a new provider to this list, please let us know through the feedback button at the top of this page.

--- a/content/integrations/email/smtp.mdx
+++ b/content/integrations/email/smtp.mdx
@@ -5,4 +5,120 @@ section: Integrations > Email
 layout: integrations
 ---
 
-TODO.
+Knock supports sending email notifications to your users via the Simple Mail Transfer Protocol (SMTP). In this configuration, Knock will act as an SMTP client and send email notifications to a specified SMTP server.
+
+In this guide, we'll cover how to get started sending email notifications using SMTP with Knock.
+
+## Features
+
+- Attachments support
+- Link and open tracking
+- Per environment configuration
+- Sandbox mode
+
+## Getting started
+
+You can create a new SMTP Relay channel in the dashboard under the **Integrations** {">"} **Channels** section. From there, you'll need to configure the channel for each environment you have.
+
+The following information is required to configure an SMTP Relay channel:
+
+- SMTP server host
+- SMTP server port
+- Username
+- Password
+
+Please note the following:
+
+- **Knock only supports authenticated SMTP connections.**
+- **The port must support TLS.** Email providers commonly use port 587 for TLS, but check your provider's documentation to confirm.
+- **We cannot currently track deliverability through SMTP Relay channels.** This means that all notifications sent via SMTP will show up as "Sent" in the Knock messages log, but not "Delivered."
+
+## Provider configuration
+
+<Attributes>
+  <Attribute name="Host" type="string*" description="The SMTP server host" />
+  <Attribute
+    name="Username"
+    type="string*"
+    description="The username to use when authenticating with the SMTP server"
+  />
+  <Attribute
+    name="Password"
+    type="string*"
+    description="The password to use when authenticating with the SMTP server"
+  />
+  <Attribute
+    name="Port"
+    type="number"
+    description="The SMTP server port. This port must support TLS."
+  />
+</Attributes>
+
+## Environment default settings
+
+The following fields are optional and, if set, will be applied to all email messages sent via this channel within the environment:
+
+<Attributes>
+  <Attribute
+    name="Reply-to address"
+    type="string | liquid"
+    description="The reply-to email address (can use Liquid tags)"
+  />
+  <Attribute
+    name="CC address"
+    type="string | liquid"
+    description="The cc email address (can use Liquid tags)"
+  />
+  <Attribute
+    name="BCC address"
+    type="string | liquid"
+    description="The bcc email address (can use Liquid tags)"
+  />
+  <Attribute
+    name="JSON overrides"
+    type="string | liquid"
+    description="SMTP header overrides"
+  />
+</Attributes>
+
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">JSON overrides behavior.</span> For SMTP Relay
+      channels, only header overrides are supported. See{" "}
+      <a href="#setting-smtp-headers">Setting SMTP headers</a> for more details.
+    </>
+  }
+/>
+
+## Setting SMTP headers
+
+For SMTP Relay channels, the JSON overrides field can be used to set SMTP headers. Overrides can be set in either the environment settings or per template.
+
+Knock supports overriding existing SMTP headers and adding custom headers.
+
+```json title="Adding a custom SMTP header via JSON overrides"
+{
+  "headers": {
+    "X-SMTPAPI": "{\"category\": \"transactional\"}"
+  }
+}
+```
+
+Headers must be nested under the `headers` key. Other keys will be ignored.
+
+<Callout
+  emoji="🔦"
+  text={
+    <>
+      <b>SMTP headers are sent as strings.</b> If one of your header overrides
+      is not already a string, Knock will automatically convert it to a string
+      before sending.
+    </>
+  }
+/>
+
+## Recipient data requirements
+
+In order to send an email notification you'll need a valid `email` property set on your recipient.

--- a/content/integrations/email/smtp.mdx
+++ b/content/integrations/email/smtp.mdx
@@ -1,0 +1,8 @@
+---
+title: How to send email with SMTP
+description: How to send transactional email notifications using SMTP with Knock.
+section: Integrations > Email
+layout: integrations
+---
+
+TODO.

--- a/content/integrations/overview.md
+++ b/content/integrations/overview.md
@@ -98,6 +98,7 @@ Here are the providers we currently support within Knock. We're adding more each
 - [Postmark](/integrations/email/postmark)
 - [Resend](/integrations/email/resend)
 - [Sendgrid](/integrations/email/sendgrid)
+- [SMTP](/integrations/email/smtp)
 - [Sparkpost](/integrations/email/sparkpost)
 
 ### Push

--- a/data/integrationsSidebar.ts
+++ b/data/integrationsSidebar.ts
@@ -37,6 +37,7 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/postmark", title: "Postmark" },
       { slug: "/resend", title: "Resend" },
       { slug: "/sendgrid", title: "SendGrid" },
+      { slug: "/smtp", title: "SMTP" },
       { slug: "/sparkpost", title: "Sparkpost" },
       { slug: "/attachments", title: "Sending attachments" },
     ],


### PR DESCRIPTION
### Description

This PR updates the docs to describe sending email via SMTP using Knock.

### Tasks

[KNO-7184](https://linear.app/knock/issue/KNO-7184/update-docs-to-include-smtp)

### Screenshots

<img width="1503" alt="Screenshot 2024-10-28 at 4 04 02 PM" src="https://github.com/user-attachments/assets/65939093-f31a-437c-915c-082e8e813c5b">
