### PR TITLE
docs: mention version of React Native used to test SDK

### DIFF
--- a/content/sdks/react-native/overview.mdx
+++ b/content/sdks/react-native/overview.mdx
@@ -19,7 +19,7 @@ Our [`@knocklabs/react-native`](https://www.npmjs.com/package/@knocklabs/react-n
   }
 />
 
-The React Native library is built on top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency.
+The React Native library is built on top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency. Internally, our React Native SDK is tested with React Native v0.73.4, but it should work with all recent versions of React Native. If you encounter issues with React Native compatibility, please [reach out to our support team](mailto:support@knock.app).
 
 **Quick links:**
 


### PR DESCRIPTION
### Description

We previously received feedback that our docs don’t make it clear which versions of React Native our SDK can be used with. While we don’t currently test the SDK with multiple versions of React Native, we can at least mention that we test with React Native v0.73.4 internally.

### Screenshots

<img width="1623" alt="Screenshot 2024-10-29 at 9 57 59 AM" src="https://github.com/user-attachments/assets/ae106850-6572-4fff-bf1b-3cc4445fe72c">
