### PR TITLE
chore: update descriptions of merge behavior

### DIFF
--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -88,7 +88,7 @@ The object `id` should be unique within the collection. It should also be a stab
 
 ### Properties
 
-Objects can contain any number of key-value property pairs that you can then reference in templates and trigger conditions. Properties will always be shallowly merged between set calls, meaning that existing properties will be overwritten.
+Objects can contain any number of key-value property pairs that you can then reference in templates and trigger conditions. Properties will always be deeply merged between set calls, meaning that existing properties (including nested properties) will be updated with the newly provided values. Note that this also means that existing properties cannot be explicitly removed; rather, you can overwrite them with a `null` value.
 
 ### Object subscribers
 

--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -88,7 +88,7 @@ The object `id` should be unique within the collection. It should also be a stab
 
 ### Properties
 
-Objects can contain any number of key-value property pairs that you can then reference in templates and trigger conditions. Properties will always be deeply merged between set calls, meaning that existing properties (including nested properties) will be updated with the newly provided values. Note that this also means that existing properties cannot be explicitly removed; rather, you can overwrite them with a `null` value.
+Objects can contain any number of key-value property pairs that you can then reference in templates and trigger conditions. Properties will always be deeply merged between upserts, meaning that existing properties (including nested properties) will be updated with the newly provided values. Note that this means that existing properties cannot be explicitly removed, but you can overwrite them with a `null` value.
 
 ### Object subscribers
 

--- a/content/concepts/users.mdx
+++ b/content/concepts/users.mdx
@@ -58,7 +58,7 @@ In addition to the system attributes defined on the user schema above, Knock wil
 
 Traits are useful for when you need to perform additional personalization on a user, like denormalizing the current plan they're on so you can use this to determine the portion of a notification they should receive.
 
-You can nest the properties you send as deeply as you like; Knock will perform a deep merge of the properties you send on subsequent upserts. Note that this means that existing properties cannot be explicitly removed; rather, you can overwrite them with a `null` value.
+You can nest the properties you send as deeply as needed, and Knock will perform a deep merge with these properties on each subsequent upsert. Note that this means that existing properties cannot be explicitly removed, but you can overwrite them with a `null` value.
 
 ### The user object
 

--- a/content/concepts/users.mdx
+++ b/content/concepts/users.mdx
@@ -58,7 +58,7 @@ In addition to the system attributes defined on the user schema above, Knock wil
 
 Traits are useful for when you need to perform additional personalization on a user, like denormalizing the current plan they're on so you can use this to determine the portion of a notification they should receive.
 
-You can nest the properties you send as deeply as you like, but please remember that we will not deep merge these keys.
+You can nest the properties you send as deeply as you like; Knock will perform a deep merge of the properties you send on subsequent upserts. Note that this means that existing properties cannot be explicitly removed; rather, you can overwrite them with a `null` value.
 
 ### The user object
 


### PR DESCRIPTION
### Description

As per testing related to [this discussion](https://knocklabs.slack.com/archives/C01RLET7A6B/p1729898958187719), it appears that our documentation regarding the way that we merge recipient properties on subsequent upserts is outdated. We employ a deep merge strategy, which means that you can send updated values for nested properties without overwriting other values.

I'll hold off on merging these updates until we address [KNO-7239](https://linear.app/knock/issue/KNO-7239/[switchboard]-merging-properties-on-recipients-objectsuserstenants)

- Preview of [User update](https://docs-git-mk-merge-prop-update-knocklabs.vercel.app/concepts/users#storing-user-properties)
- Preview of [Objects update](https://docs-git-mk-merge-prop-update-knocklabs.vercel.app/concepts/objects#properties)