### PR TITLE
chore: add callouts for inline identify with source events

### DIFF
--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -113,7 +113,22 @@ Note that Knock will correctly map `name`, `email`, `avatar`, and `phone` proper
 
 ### Inline identify users in a source event
 
-In cases where you send a source event to Knock with recipients that may not yet have been identified into our system, it's good practice to inline identify your users. By inline identifying your users within your source events, you ensure that those users are identified in Knock when your event triggers a workflow.
+<Callout
+  emoji="☝️"
+  text={
+    <>
+      <span className="font-bold">Note:</span> Inline identification is not
+      supported by our{" "}
+      <a href="/send-notifications/testing-workflows#the-workflow-test-runner">
+        workflow test runner
+      </a>
+      , which can only trigger test runs for existing users. To test inline identification
+      with a source event, you should send a test event from your configured source.
+    </>
+  }
+/>
+
+In cases where you send a source event to Knock with recipients that may not yet have been identified into our system, it's good practice to [inline identify](/managing-recipients/identifying-recipients#inline-identifying-recipients) your users. By inline identifying your users within your source events, you ensure that those users are identified in Knock when your event triggers a workflow.
 
 As an example, take the user-signed-up event below. We're currently mapping the `properties.recipients` field to the `recipients` field of our workflow in Knock. If we send this event to Knock before the user with id `sam10` has been identified, the user will not be notified.
 
@@ -154,6 +169,8 @@ To ensure that the user is notified, we'd change the id reference in `recipients
   "timestamp": "2023-05-23T21:49:54Z"
 }
 ```
+
+You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
 
 ## Event idempotency
 

--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -114,7 +114,22 @@ To enable handling of identify events, open the settings for the source in the e
 
 ## Inline identify users in a RudderStack event
 
-In cases where you send a RudderStack event to Knock with recipients that may not yet have been identified into our system, it's good practice to inline identify your users. By inline identifying your users within your RudderStack events, you ensure that those users are identified in Knock when your event triggers a workflow.
+<Callout
+  emoji="☝️"
+  text={
+    <>
+      <span className="font-bold">Note:</span> Inline identification is not
+      supported by our{" "}
+      <a href="/send-notifications/testing-workflows#the-workflow-test-runner">
+        workflow test runner
+      </a>
+      , which can only trigger test runs for existing users. To test inline identification
+      with a source event, you should send a test event from RudderStack.
+    </>
+  }
+/>
+
+In cases where you send a RudderStack event to Knock with recipients that may not yet have been identified into our system, it's good practice to [inline identify](/managing-recipients/identifying-recipients#inline-identifying-recipients) your users. By inline identifying your users within your RudderStack events, you ensure that those users are identified in Knock when your event triggers a workflow.
 
 As an example, take the user-signed-up event below. We're currently mapping the `properties.recipients` field to the `recipients` field of our workflow in Knock. If we send this event to Knock before the user with id `sam10` has been identified, the user will not be notified.
 
@@ -156,7 +171,7 @@ To ensure that the user is notified, we'd change the id reference in `recipients
 }
 ```
 
-You can learn more about inline identification in [our users concept guide](/send-and-manage-data/users).
+You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
 
 ## Video walkthrough
 

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -144,7 +144,22 @@ To enable the handling of identify events, open the settings for the source in t
 
 ## Inline identify users in a Segment event
 
-In cases where you send a Segment event to Knock with recipients who may not yet have been identified in our system, it's good practice to inline identify your users. By inline identifying your users within your Segment events, you ensure that those users are identified in Knock when your event triggers a workflow.
+<Callout
+  emoji="☝️"
+  text={
+    <>
+      <span className="font-bold">Note:</span> Inline identification is not
+      supported by our{" "}
+      <a href="/send-notifications/testing-workflows#the-workflow-test-runner">
+        workflow test runner
+      </a>
+      , which can only trigger test runs for existing users. To test inline identification
+      with a source event, you should send a test event from Segment.
+    </>
+  }
+/>
+
+In cases where you send a Segment event to Knock with recipients who may not yet have been identified in our system, it's good practice to [inline identify](/managing-recipients/identifying-recipients#inline-identifying-recipients) your users. By inline identifying your users within your Segment events, you ensure that those users are identified in Knock when your event triggers a workflow.
 
 As an example, take the user-signed-up event below. We're currently mapping the `properties.recipients` field to the `recipients` field of our workflow in Knock. If we send this event to Knock before the user with id `sam10` has been identified, the user will not be notified.
 
@@ -186,7 +201,7 @@ To ensure the user is notified, we'd change the id reference in `recipients` to 
 }
 ```
 
-You can learn more about inline identification in [our users concept guide](/send-and-manage-data/users).
+You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
 
 ## Video walkthrough
 


### PR DESCRIPTION
### Description

Due to customer confusion, this PR explicitly calls out that the test runner will only work with existing users for source events (meaning inline identification is not supported). It also updates some outdated links and adds an additional link to the documentation of what inline identification is.

When you use the rest runner (which triggers a workflow run for the most-recently-saved version of a workflow rather than hitting our public API), we don't support inline identification. For API-triggered workflows, the test runner modal allows you to select from a list of existing users. However, a source event-triggered workflow allows you to simply paste in a test event (with any recipient(s) that you would like to test with), meaning that it's possible to use inline identification syntax in your event.

If you do this, we'll show an error that the recipient is "missing" in the current environment, and we won't execute a workflow run. These callouts are an attempt to help a customer anticipate these errors before they occur and provide an alternative for testing inline identification via source events.

https://docs-git-mk-inline-test-runner-update-knocklabs.vercel.app/integrations/sources/overview#inline-identify-users-in-a-source-event
