### PR TITLE
chore: add enterprise feature callout to Datadog, New Relic, and data sync pages

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -5,7 +5,18 @@ layout: integrations
 section: Integrations > Extensions
 ---
 
-You can bring your notification analytics from Knock into your own data warehouse so that you can analyze it alongside the rest of your data. This is an enterprise-only feature. To set up this sync, please contact our [support team](mailto:support@knock.app).
+You can bring your notification analytics from Knock into your own data warehouse so that you can analyze it alongside the rest of your data. To set up this sync, please contact our [support team](mailto:support@knock.app).
+
+<Callout
+  emoji="✨"
+  text={
+    <>
+      <span className="font-bold">Enterprise plan feature.</span> Data warehouse
+      sync is available exclusively with our{" "}
+      <a href="https://knock.app/pricing">Enterprise plan</a>.
+    </>
+  }
+/>
 
 ## How it works
 

--- a/content/integrations/extensions/datadog.mdx
+++ b/content/integrations/extensions/datadog.mdx
@@ -12,6 +12,17 @@ You can use the Knock + Datadog integration to stream workflow, channel, and mes
 - Get up-to-the-minute data on workflows triggered and messages delivered
 - Monitor events ingested and actions triggered from event platforms like [Segment](/integrations/sources/segment) and [Rudderstack](/integrations/sources/rudderstack)
 
+<Callout
+  emoji="✨"
+  text={
+    <>
+      <span className="font-bold">Enterprise plan feature.</span> The Knock
+      Datadog extension is only available on our{" "}
+      <a href="https://knock.app/pricing">Enterprise plan</a>.
+    </>
+  }
+/>
+
 ## What this integration does
 
 This integration will send a stream of metrics as they happen from your Knock account to your Datadog account. Metrics are prefixed `knock.*` and include success and failure codes. Metrics are tagged (where applicable) by:

--- a/content/integrations/extensions/new-relic.mdx
+++ b/content/integrations/extensions/new-relic.mdx
@@ -12,6 +12,17 @@ You can use the Knock + New Relic integration to stream workflow, channel, and m
 - Get up-to-the-minute data on workflows triggered and messages delivered
 - Monitor events ingested and actions triggered from event platforms like [Segment](/integrations/sources/segment) and [Rudderstack](/integrations/sources/rudderstack)
 
+<Callout
+  emoji="✨"
+  text={
+    <>
+      <span className="font-bold">Enterprise plan feature.</span> The Knock New
+      Relic extension is only available on our{" "}
+      <a href="https://knock.app/pricing">Enterprise plan</a>.
+    </>
+  }
+/>
+
 ## What this integration does
 
 This integration will stream metrics from your Knock account to your New Relic account. Metrics are prefixed `knock.*` and include success and failure codes. Metrics are tagged (where applicable) by:


### PR DESCRIPTION
### Description

Adds an enterprise plan feature callout to the Datadog, New Relic, and data sync extension pages (this already existed for Heap & Segment).

https://docs-git-rt-add-enterprise-only-callouts-extensions-knocklabs.vercel.app/integrations/extensions/datadog
https://docs-git-rt-add-enterprise-only-callouts-extensions-knocklabs.vercel.app/integrations/extensions/new-relic
https://docs-git-rt-add-enterprise-only-callouts-extensions-knocklabs.vercel.app/integrations/extensions/data-sync