### PR TITLE
chore: document push overrides consistently across providers

### DIFF
--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -63,9 +63,9 @@ When silent push is enabled, we'll no longer pass through the content payload an
 
 ## Using overrides to customize notifications
 
-We have full support for overriding the payload sent to APNS for adding things like badge counts, extra data properties, and sound files. You can set the push overrides on the template settings modal, open it by clicking on the "Manage template settings" button. Push overrides support liquid for injecting data properties and referencing attributes on your recipients.
+We have full support for overriding the payload sent to APNS for adding things like badge counts, extra data properties, and sound files. You can set push overrides on the template settings modal, which is accessed by clicking on the "Manage template settings" button when viewing a push notification template within the workflow editor. Push overrides support Liquid for injecting `data` properties and referencing attributes on your recipients.
 
-See the [APNS documentation for details](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification).
+Overrides are merged into the notification payload sent to APNS. See the <a href="https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification" target="_blank">APNS documentation for more details</a>.
 
 | Property | Type       | Description                                                                                                    |
 | -------- | ---------- | -------------------------------------------------------------------------------------------------------------- |

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -48,9 +48,9 @@ When silent push is enabled, we'll no longer pass through the content payload an
 
 ## Using overrides to customize notifications
 
-We have full support for overriding the payload sent to Expo for adding things like badge counts, extra data properties, and sound files. You can set the push overrides on the template settings modal, open it by clicking on the "Manage template settings" button. Push overrides support liquid for injecting data properties and referencing attributes on your recipients.
+We have full support for overriding the payload sent to Expo for adding things like badge counts, extra data properties, and sound files. You can set push overrides on the template settings modal, which is accessed by clicking on the "Manage template settings" button when viewing a push notification template within the workflow editor. Push overrides support Liquid for injecting `data` properties and referencing attributes on your recipients.
 
-The overrides set are merged into the notification payload sent to Expo. See the <a href="https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format" target="_blank">Expo documentation for details</a>.
+Overrides are merged into the notification payload sent to Expo. See the <a href="https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format" target="_blank">Expo documentation for more details</a>.
 
 ## Channel data requirements
 

--- a/content/integrations/push/firebase.mdx
+++ b/content/integrations/push/firebase.mdx
@@ -91,9 +91,9 @@ When silent push is enabled, we'll no longer pass through the message payload. A
 
 ## Using overrides to customize notifications
 
-We have full support for overriding the payload sent to FCM for adding things like badge counts, extra data properties, and sound files. You can set the push overrides on the template settings modal, which is accessed by clicking on the "Manage template settings" button from within the message template editor. Push overrides support liquid for injecting data properties and referencing attributes on your recipients.
+We have full support for overriding the payload sent to FCM for adding things like badge counts, extra data properties, and sound files. You can set push overrides on the template settings modal, which is accessed by clicking on the "Manage template settings" button when viewing a push notification template within the workflow editor. Push overrides support Liquid for injecting `data` properties and referencing attributes on your recipients.
 
-By default, payload overrides will be merged into the base data and will not replace other trigger data being passed to FCM. The override also needs to match the format that is expected by FCM, meaning that any custom key-value pairs should be contained inside of a `data` dictionary:
+By default, payload overrides will be merged into the base `data` and will not replace other trigger `data` being passed to FCM. The override also needs to match the format that is expected by FCM, meaning that any custom key-value pairs should be contained inside of a `data` dictionary:
 
 ```json
 {

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -60,6 +60,12 @@ When sending a push notification to OneSignal, we will automatically pass the fo
 
 When selecting to send as a silent/background notification, Knock will passthrough the content_available=true option to OneSignal. You can enable this per push notification template by clicking "Manage template settings" in the header of the template editor.
 
+## Using overrides to customize notifications
+
+We have full support for overriding the payload sent to OneSignal for adding things like badge counts, extra data properties, and sound files. You can set push overrides on the template settings modal, which is accessed by clicking on the "Manage template settings" button when viewing a push notification template within the workflow editor. Push overrides support Liquid for injecting `data` properties and referencing attributes on your recipients.
+
+Overrides are merged into the notification payload sent to OneSignal. See the <a href="https://documentation.onesignal.com/reference/push-notification" target="_blank">OneSignal documentation for more details</a>. Knock uses the "Aliases" targeting strategy to send push notifications to specific users via External ID.
+
 ## Channel data requirements
 
 When your OneSignal push channel is configured to use `player_ids` you must supply ChannelData per-recipient that contains one or more player_ids for a user.


### PR DESCRIPTION
### Description

The PR
- Adds a section on overriding the payload JSON for OneSignal templates
- Cleans up language about payload overrides on the other push provider pages