### PR TITLE
chore: add callout about using batching with preference conditions

### DIFF
--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -19,8 +19,8 @@ With preference conditions you can add additional custom expressions to a `Prefe
     <>
       <span className="font-bold">Batch processing limitation.</span> When using
       a <a href="/designing-workflows/batch-function">batch function</a>,
-      preference conditions for subsequent channel steps will only be evaluated against the first activity in the
-      batch.
+      preference conditions for subsequent channel steps will only be evaluated
+      against the first activity in the batch.
     </>
   }
 />

--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -19,7 +19,7 @@ With preference conditions you can add additional custom expressions to a `Prefe
     <>
       <span className="font-bold">Batch processing limitation.</span> When using
       a <a href="/designing-workflows/batch-function">batch function</a>,
-      preference conditions will only be evaluated against the first item in the
+      preference conditions for subsequent channel steps will only be evaluated against the first activity in the
       batch.
     </>
   }

--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -13,6 +13,18 @@ Typically, a `PreferenceSet` evaluates to boolean values representing if your re
 
 With preference conditions you can add additional custom expressions to a `PreferenceSet`, where the notification is only sent if all preferences (including the preference condition statement) evaluate to `true`.
 
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">Batch processing limitation.</span> When using
+      a <a href="/designing-workflows/batch-function">batch function</a>,
+      preference conditions will only be evaluated against the first item in the
+      batch.
+    </>
+  }
+/>
+
 Below is an example of a workflow preference that has conditions applied to determine if the preference is `true` or `false`:
 
 ```json title="An example of preferences with conditions"


### PR DESCRIPTION
### Description

Adds a callout warning about using batching with preference conditions, informing users that preference conditions will only be evaluated against the first item in the batch.

### Tasks

[KNO-7317](https://linear.app/knock/issue/KNO-7317/[docs]-add-callout-about-using-preference-conditions-with-batching)

### Screenshots
https://docs-git-rt-add-preference-conditions-batching-7c0e0e-knocklabs.vercel.app/preferences/preference-conditions
![Screenshot 2024-11-08 at 11 19 35 AM](https://github.com/user-attachments/assets/f094a4fe-127e-45e3-ad8d-cac38646abc1)

