### PR TITLE
fix: grammar on create schedules description

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -5500,7 +5500,7 @@ A paginated response containing a list of `Schedule` entities.
 <Section title="Create schedules" slug="create-schedules">
 <ContentColumn>
 
-Creates new schedules for the recipients given using. Up to 100 recipients may be specified in a single schedule creation call. Recipients may be inline-identified during this call.
+Creates new schedules for the recipients provided. Up to 100 recipients may be specified in a single schedule creation call. Recipients may be inline-identified during this call.
 
 ### Endpoint
 


### PR DESCRIPTION
### Description

Small update to Create schedules endpoint description for grammar.
