### PR TITLE
chore: add the beta tag to message types

### DIFF
--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -124,6 +124,7 @@ const sidebarContent: SidebarSection[] = [
       {
         slug: "/message-types",
         title: "Message types",
+        isBeta: true,
       },
       {
         title: "React",


### PR DESCRIPTION
### Description
Adds the beta tag to message types.

### Tasks
[KNO-7395](https://linear.app/knock/issue/KNO-7395/[doc]-add-a-beta-tag-to-message-type)

### Screenshots

![CleanShot 2024-11-15 at 15 46 35@2x](https://github.com/user-attachments/assets/b0e7395b-3ffb-40c2-8a4e-8faf5083d107)


