### PR TITLE
chore: add requirement indicators for workflow trigger endpoints

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -571,7 +571,7 @@ The workflow trigger endpoint enforces the following payload size limits:
 <Attributes>
   <Attribute
     name="recipients"
-    type="RecipientIdentifier[]"
+    type="RecipientIdentifier[] (required)"
     description="A list of user idenitifers, object references, or inline recipient definitions to run this workflow for"
     typeSlug="/concepts/recipients#recipientidentifier-definiton"
   />
@@ -593,7 +593,7 @@ The workflow trigger endpoint enforces the following payload size limits:
   />
   <Attribute
     name="data"
-    type="object"
+    type="object (optional)"
     description="A set of key-value pairs to pass to the workflow trigger"
   />
 </Attributes>
@@ -661,7 +661,7 @@ The workflow trigger endpoint enforces the following payload size limits:
 <Attributes>
   <Attribute
     name="recipients"
-    type="Recipient[]"
+    type="Recipient[] (required)"
     description="A list of maps of properties describing a user or an object to identify in Knock and trigger this workflow for"
   />
   <Attribute
@@ -681,7 +681,7 @@ The workflow trigger endpoint enforces the following payload size limits:
   />
   <Attribute
     name="data"
-    type="object"
+    type="object (optional)"
     description="A set of key-value pairs to pass to the trigger call"
   />
 </Attributes>


### PR DESCRIPTION
### Description

Currently, this PR adds missing requirement indicators to clarify whether API attributes/parameters are required or optional for the workflow trigger endpoints _only_. Looking throughout the entire API reference, we inconsistently document this, and I have filed [this Linear ticket](https://linear.app/knock/issue/KNO-7408/[docs]-add-missing-requirements-indicators-to-api-attributesparameters) to capture the larger update that is needed. 