### PR TITLE
fix: typo in Slack direct message docs

### DIFF
--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -111,7 +111,7 @@ Your users will give your Slack app access to their own Slack workspaces via the
   <figcaption>The SlackAuthButton component with SlackAuthContainer</figcaption>
 </figure>
 
-Since we'll also be using this `access_token` to resolve a user's email address to their Slack ID, we'll need to add some additional scopes to this OAuth request. We can do that by adding the `users:read` and `users:read.email` scopes to the `SlackAuthButton` component with the `additionalScopes` paramters.
+Since we'll also be using this `access_token` to resolve a user's email address to their Slack ID, we'll need to add some additional scopes to this OAuth request. We can do that by adding the `users:read` and `users:read.email` scopes to the `SlackAuthButton` component with the `additionalScopes` parameters.
 
 Here's an example of how to use them:
 


### PR DESCRIPTION
🔡
