### PR TITLE
chore: update set tenant endpoint `settings` attribute to match description above

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -5000,7 +5000,7 @@ Sets a tenant within an environment, performing an upsert operation. Any existin
   <Attribute
     name="settings"
     type="object"
-    description="An object of key-value pairs for configurable settings on a tenant. See example for possible key-value pairs."
+    description="An object of key-value pairs for configurable settings on a tenant. Currently contains a preference_set key for tenant-specific default preferences, as well as a branding key which points to the following configurable values: primary_color, primary_color_contrast, icon_url, and logo_url. The icon_url and logo_url settings must be a valid image URL with an image MIME type."
 />
 
 </Attributes>


### PR DESCRIPTION
### Description

This PR updates the `settings` attribute description on the Set tenant endpoint so that it matches the description of that field from the Tenant overview just above. I think this is helpful for surfacing the `logo_url` and
`icon_url` validation information if you're just looking at this endpoint.