### PR TITLE
chore: add missing object prefs endpoint to implementation guide

### DIFF
--- a/content/guides/implementation-guide.mdx
+++ b/content/guides/implementation-guide.mdx
@@ -178,6 +178,9 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
         <a href="https://docs.knock.app/reference#bulk-set-preferences" target="_blank" style={{textDecoration: 'none'}}>
           <Endpoint method="POST" path="https://api.knock.app/v1/users/bulk/preferences" />
         </a>
+        <a href="https://docs.knock.app/reference#set-preferences-object" target="_blank" style={{textDecoration: 'none'}}>
+          <Endpoint method="PUT" path="https://api.knock.app/v1/objects/:collection/:object_id/preferences/:id" />
+        </a>
       </Accordion>
     </AccordionGroup>
 


### PR DESCRIPTION
### Description

Adds an additional "relevant endpoint" for setting Object preferences to the "Preferences" section of the implementation guide.

### Screenshots

<img width="500" alt="image" src="https://github.com/user-attachments/assets/e4df0c99-3fce-4a4e-be59-fd9de6f98b66">
