### PR TITLE
chore: add beta tag to messaging components nav

### DIFF
--- a/components/Sidebar/SidebarSubsection.tsx
+++ b/components/Sidebar/SidebarSubsection.tsx
@@ -75,6 +75,7 @@ const SidebarSubsectionList: React.FC<Props> = ({
                 title={page.title}
                 path={fullPath}
                 isSelected={isSelected}
+                isBeta={page.isBeta}
               />
             );
           })}

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -135,6 +135,7 @@ const sidebarContent: SidebarSection[] = [
           {
             slug: "/messaging-components",
             title: "Messaging components",
+            isBeta: true,
           },
           { slug: "/toasts", title: "Toasts" },
           { slug: "/inbox", title: "Notification inbox" },


### PR DESCRIPTION
### Description
As flagged here: https://knocklabs.slack.com/archives/C01Q4R82QAU/p1732034131540039

### Tasks
[KNO-7395](https://linear.app/knock/issue/KNO-7395/[doc]-add-a-beta-tag-to-message-type)

### Screenshots

![CleanShot 2024-11-20 at 13 01 45@2x](https://github.com/user-attachments/assets/f9eba207-e379-4b41-a2b4-f79f363a7728)
