### PR TITLE
fix: MS Teams bots cannot message private channels

### DIFF
--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -19,7 +19,8 @@ Here's what we'll cover in this guide:
   emoji="⚠️"
   text={
     <>
-      <strong>Note:</strong> Microsoft Teams bots do not support sending messages to private channels.
+      <strong>Note:</strong> Microsoft Teams bots do not support sending
+      messages to private channels.
     </>
   }
 />

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sending a message to public and private channels
-description: How to send a message to public and private channels in Microsoft Teams using Knock.
+title: Sending a message to public channels
+description: How to send a message to public channels in Microsoft Teams using Knock.
 tags: ["msteams", "teams", "chat"]
 section: Integrations > Microsoft Teams
 layout: integrations
@@ -14,6 +14,15 @@ Here's what we'll cover in this guide:
 - Adding required scopes to your Microsoft Teams app's manifest
 - Setting required Tenant and Object channel data when a Microsoft Teams bot is installed in a channel
 - Triggering a workflow with an object recipient to send a message to a Microsoft Teams channel
+
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <strong>Note:</strong> Microsoft Teams bots do not support sending messages to private channels.
+    </>
+  }
+/>
 
 ## Prerequisites
 


### PR DESCRIPTION
### Description

As per [Microsoft’s docs](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/channel-and-group-conversations?tabs=dotnet#:~:text=Posting%20a%20message%20or%20Adaptive%20Card%20to%20a%20private%20channel%20isn%27t%20supported.):

> Posting a message or Adaptive Card to a private channel [as a bot] isn't supported.

[Stack Overflow says the same](https://stackoverflow.com/a/68339371). 🫠 