### PR TITLE
fix: OneSignal is one word

### DIFF
--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -138,7 +138,7 @@ Channel data requirements for each provider are listed below. Typically `channel
     | tokens\* | `string[]` | One or more device tokens |
 
   </Accordion>
-  <Accordion title ="One Signal">
+  <Accordion title ="OneSignal">
     | Property     | Type       | Description            |
     | ------------ | ---------- | ---------------------- |
     | player_ids\* | `string[]` | One or more player_ids |


### PR DESCRIPTION
### Description

Small fix. OneSignal shouldn’t have a space in it.

…there’s nothing wrong with me, really!

