### PR TITLE
feat: support passing multiple tags to mailgun

### DIFF
--- a/content/integrations/email/mailgun.mdx
+++ b/content/integrations/email/mailgun.mdx
@@ -111,3 +111,15 @@ Delivery tracking for Mailgun can result in the following status updates to your
 - The message delivery is confirmed and Knock updates the message to `delivered`
 - The message was not delivered and Knock updates the message to `undelivered`
 - The message was not delivered due to bad recipient(s) and Knock updates the message to `bounced`
+
+## Passing additional tags to Mailgun
+
+It's possible to pass additional tags to Mailgun by setting the "JSON overrides" attribute in the channel configuration or at the message template level.
+
+To pass one or more tags, you can set the `o:tag` attribute to an array of tag names:
+
+```json
+{
+  "o:tag": ["tag1", "{{ workflow.key }}"]
+}
+```


### PR DESCRIPTION
### Description

document `o:tag` overrides for mailgun

