### PR TITLE
chore: update courier migration guide

### DIFF
--- a/content/guides/migrate-from-courier.mdx
+++ b/content/guides/migrate-from-courier.mdx
@@ -13,7 +13,7 @@ Before migrating any data into Knock, it’s helpful to understand how the resou
 
 ### Integrations
 
-In order to deliver notifications with Courier, you installed one or more <a href="https://app.courier.com/integrations" target="_blank">Integrations</a> for downstream providers in your Courier dashboard. In Knock, we refer to these delivery platforms as [Channels](/concepts/channels).
+In order to deliver notifications with Courier, you installed one or more <a href="https://www.courier.com/docs/external-integrations/intro" target="_blank">Integrations</a> for downstream providers in your Courier dashboard. In Knock, we refer to these delivery platforms as [Channels](/concepts/channels).
 
 Channels are configured under the **Integrations** tab in your Knock dashboard. You can see a full list of supported Channel types and providers [here](/integrations/overview).
 
@@ -21,9 +21,11 @@ In addition to first-party integrations with message delivery platforms, Knock a
 
 ### Automations and Notification Templates
 
-In Courier, the content of your notifications is contained in <a href="https://www.courier.com/docs/reference/notifications/intro/" target="_blank">Notification Templates</a> and the orchestration and logic of sending your notifications is contained in <a href="https://www.courier.com/docs/platform/automations/" target="_blank">Automations</a>.
+In Courier, the content of your notifications is contained in <a href="https://www.courier.com/docs/platform/content/notification-designer/notification-designer-overview" target="_blank">templates</a> built in your dashboard, and the orchestration and logic of sending your notifications is contained in <a href="https://www.courier.com/docs/platform/automations/" target="_blank">Automations</a>.
 
-Knock combines both of these things into a single resource called a [Workflow](/concepts/workflows), which serves as a container for all of the logic and message templates associated with a given notification in your system. When you’re ready to start sending notifications, you’ll do so by [triggering](/send-notifications/triggering-workflows) these workflows.
+Knock combines both of these things into a single resource called a [Workflow](/concepts/workflows), which serves as a container for all of the logic and message templates associated with a given notification in your system. You can also create [Partials](/designing-workflows/partials), which are content blocks that can be used across multiple workflows.
+
+When you’re ready to start sending notifications, you’ll do so by [triggering](/send-notifications/triggering-workflows) your workflows. 
 
 ### Users and Profiles
 
@@ -62,7 +64,7 @@ Unlike Courier, per-tenant branding attributes are stored directly on a Tenant i
 
 ### User Preferences
 
-Courier’s <a href="" target="_blank">User Preferences API</a> allows you to set notifications preferences for a given user by a Topic categorization and a Preference Section (a group of multiple Topics), as well as by delivery channel.
+Courier’s <a href="https://www.courier.com/docs/reference/user-preferences/intro" target="_blank">User Preferences API</a> allows you to set notifications preferences for a given user by a Topic categorization and a Preference Section (a group of multiple Topics), as well as by delivery channel.
 
 Knock’s [Preferences](/preferences/overview) model has a single high-level `category` property that can be assigned on a Workflow; because a given workflow can have more than one `category`, you can use this property to map both Topics and Preference Sections to your notifications in Knock.
 
@@ -127,12 +129,18 @@ We recommend migrating data into Knock in the following order to ensure that cer
 
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
-          <a href="https://www.courier.com/docs/reference/notifications/list/" target="_blank" style={{textDecoration: 'none'}}>
+          <a href="https://www.courier.com/docs/reference/notifications/get-notifications" target="_blank" style={{textDecoration: 'none'}}>
             <Endpoint method="GET" path="https://api.courier.com/notifications" />
           </a>
           <a href="https://docs.knock.app/mapi#workflows-update" target="_blank" style={{textDecoration: 'none'}}>
             <Endpoint method="PUT" path="https://control.knock.app/v1/workflows/:workflow_key" />
           </a>
+          <a href="https://docs.knock.app/mapi#email-layouts-upsert" target="_blank" style={{textDecoration: 'none'}}>
+          <Endpoint method="PUT" path="https://control.knock.app/v1/email_layouts/:key" />
+        </a>
+        <a href="https://docs.knock.app/mapi#partials-upsert" target="_blank" style={{textDecoration: 'none'}}>
+          <Endpoint method="PUT" path="https://control.knock.app/v1/partials/:partial_key" />
+        </a>
       </Accordion>
     </AccordionGroup>
 

--- a/content/guides/migrate-from-courier.mdx
+++ b/content/guides/migrate-from-courier.mdx
@@ -25,7 +25,7 @@ In Courier, the content of your notifications is contained in <a href="https://w
 
 Knock combines both of these things into a single resource called a [Workflow](/concepts/workflows), which serves as a container for all of the logic and message templates associated with a given notification in your system. You can also create [Partials](/designing-workflows/partials), which are content blocks that can be used across multiple workflows.
 
-When you’re ready to start sending notifications, you’ll do so by [triggering](/send-notifications/triggering-workflows) your workflows. 
+When you’re ready to start sending notifications, you’ll do so by [triggering](/send-notifications/triggering-workflows) your workflows.
 
 ### Users and Profiles
 


### PR DESCRIPTION
### Description

Update Courier migration guide in light of some new documentation/product updates they've made. I also added a mention of Partials, plus additional mAPI endpoints for Partials and Layouts.

Note: some info is missing [here](https://www.courier.com/docs/reference/notifications/get-notifications), but I updated to that link because the old link (https://www.courier.com/docs/reference/notifications/list) is broken. It seems like they may be adding templates to their API, at which point I can update the section on migrating workflows/notification templates.


