### PR TITLE
chore: update cancelation to cancellation

### DIFF
--- a/content/designing-workflows/delay-function.mdx
+++ b/content/designing-workflows/delay-function.mdx
@@ -151,7 +151,7 @@ If the user completes the action you were going to remind them about, cancel the
 
   </Accordion>
   <Accordion title="How can I cancel an open delay?">
-    You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to cancel a delayed workflow. You must use a unique cancelation key to cancel a previously triggered workflow run.
+    You can use the [workflow cancellation API](/send-notifications/canceling-workflows) to cancel a delayed workflow. You must use a unique cancellation key to cancel a previously triggered workflow run.
   </Accordion>
   <Accordion title="How long can a workflow be delayed?">
     A workflow can be delayed for a maximum of 365 days (1 year).

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -730,7 +730,7 @@ Cancel a delayed workflow for one or more recipients.
 
 ### Payload size limit
 
-The workflow cancelation endpoint enforces the following payload size limits:
+The workflow cancellation endpoint enforces the following payload size limits:
 
 - The `recipients` list must not exceed 1000 entries
 


### PR DESCRIPTION
### Description

Found two lingering uses of "cancelation" and updated per our [style guide](https://www.notion.so/knockapp/Knock-writing-style-guide-9fd5eaf44be54994ad8741d1c86f20f1?pvs=4#62e29a1242e94ea192184f79b24d514e)

https://docs-git-rt-update-spelling-api-docs-knocklabs.vercel.app/reference#payload-size-limit-2
https://docs-git-rt-update-spelling-api-docs-knocklabs.vercel.app/designing-workflows/delay-function#frequently-asked-questions -> "How can I cancel an open delay?"