### PR TITLE
chore: document workflow status and versioning more clearly

### DIFF
--- a/content/concepts/commits.mdx
+++ b/content/concepts/commits.mdx
@@ -51,14 +51,12 @@ Changes must be made in the development environment, then staged and tested befo
   text={
     <>
       <span className="font-bold">Note:</span> There is one exception to the
-      commit and promote rule — the active/inactive status on a workflow lives
-      independently from the commit model so that you can immediately enable or
-      disable a workflow in any environment without needing to go through
-      environment promotion. This is your kill switch for a given workflow
-      should you need it; this status is displayed on each workflow in your
-      dashboard's "Workflows" section, and can be set by clicking on the
-      workflow and using the "Status" selector. It is environment-specific and
-      will only be applied to the current environment.
+      commit and promote rule — the active/inactive{" "}
+      <a href="/concepts/workflows#workflow-status">status</a> on a workflow
+      lives independently from the commit model so that you can immediately
+      enable or disable a workflow in any environment without needing to go
+      through environment promotion. A workflow's status is environment-specific
+      and will only be applied to the current environment.
     </>
   }
 />

--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -294,4 +294,10 @@ Knock supports a `timezone` property on the recipient that automatically makes a
     (or vice versa). This can be done by removing the `repeats` property and
     setting `scheduled_at` to the desired one-time execution time.
   </Accordion>
+  <Accordion title="If I update a workflow, how will it affect the workflow version used for previously-scheduled workflow runs?">
+    Scheduled workflow runs will always reference the workflow version that is
+    current when the scheduled run is executed. Any scheduled workflow runs that
+    are not already in flight when you commit your changes will use the updated
+    workflow version.
+  </Accordion>
 </AccordionGroup>

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -178,7 +178,11 @@ You can learn more about automating workflow management in the [Knock CLI refere
     overrides](/concepts/tenants#custom-branding) and
     [preferences](/concepts/preferences) to control individual workflows.
   </Accordion>
-  <Accordion title="What happens to in-progress workflow runs when I set a workflow to Inactive?">
+  <Accordion title="Is there a way to disable a workflow without archiving it?">
+    Yes, you can set a workflow's [status](/concepts/workflows#workflow-status)
+    to `Inactive` to disable it.
+  </Accordion>
+  <Accordion title="What happens to in-progress workflow runs when I set a workflow's status to Inactive?">
     Any in-progress workflow runs will be immediately terminated.
   </Accordion>
 </AccordionGroup>

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -83,6 +83,12 @@ All changes to workflows, including changes made to the templates inside of a wo
 
 Read more about [environments](/concepts/environments) and [versioning](/concepts/commits) in Knock.
 
+### Workflow status
+
+Each workflow has an `Active`/`Inactive` status that is displayed in your dashboard's **Workflows** section. The status defaults to `Active` and can be set by clicking on the workflow and using the "Status" selector.
+
+This is your kill switch for a given workflow should you need it; any attempt to trigger an `Inactive` workflow will result in a `workflow_inactive` [error](/reference#error-codes). The status setting operates independently from the commit model so that you can immediately enable or disable a workflow in any environment without needing to go through environment promotion. **It is environment-specific and will only be applied to the current environment.**
+
 ### Archiving workflows
 
 Archiving a workflow allows you to permanently remove a workflow from Knock. When you archive a workflow it will be removed from **all environments** and cannot be called via API. Once a workflow is archived, it **cannot be undone**. If you have delayed runs for a workflow that is archived, when the workflow run resumes after the delay it will immediately terminate.
@@ -171,5 +177,8 @@ You can learn more about automating workflow management in the [Knock CLI refere
     API, we recommend avoiding doing this in favor of using [per-tenant
     overrides](/concepts/tenants#custom-branding) and
     [preferences](/concepts/preferences) to control individual workflows.
+  </Accordion>
+  <Accordion title="What happens to in-progress workflow runs when I set a workflow to Inactive?">
+    Any in-progress workflow runs will be immediately terminated.
   </Accordion>
 </AccordionGroup>

--- a/content/designing-workflows/delay-function.mdx
+++ b/content/designing-workflows/delay-function.mdx
@@ -162,4 +162,7 @@ If the user completes the action you were going to remind them about, cancel the
   <Accordion title="How can I see delayed workflow runs?">
     We currently don't have a way to view all delayed workflow runs with pending messages. If this is a feature you need, please reach out as we'd love to hear your use case.
   </Accordion>
+  <Accordion title="What happens to paused workflow runs when I update the underlying workflow?">
+    Workflow recipient runs will always reference the workflow version that was current when the run was triggered, so your changes will not be reflected in workflow runs that are already in flight. If you need to stop a delayed workflow run because you've updated your workflow, you can use the [workflow cancellation API](/send-notifications/canceling-workflows).
+  </Accordion>
 </AccordionGroup>

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -501,8 +501,7 @@ Knock uses standard [HTTP response codes](https://developer.mozilla.org/en-US/We
       >
         status
       </a>
-      . To resolve this error, activate the workflow on its page in the
-      dashboard.
+      . To resolve this error, activate the workflow on its page in the dashboard.
     </p>
   }
 />

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -492,7 +492,19 @@ Knock uses standard [HTTP response codes](https://developer.mozilla.org/en-US/We
 
 <ErrorExample
   title="workflow_inactive"
-  description="The workflow you attempted to invoke is marked as inactive. To resolve this error, activate the workflow on its page in the dashboard."
+  description={
+    <p>
+      The workflow you attempted to invoke is marked with an inactive{" "}
+      <a
+        href="/concepts/workflows#workflow-status"
+        className="text-brand underline"
+      >
+        status
+      </a>
+      . To resolve this error, activate the workflow on its page in the
+      dashboard.
+    </p>
+  }
 />
 
 <ErrorExample
@@ -538,7 +550,7 @@ Read more about [triggering a workflow](/send-notifications/triggering-workflows
 This endpoint will return errors in the following cases:
 
 - The workflow does not exist, or has not been committed to the environment
-- The workflow is inactive
+- The workflow's [status](/concepts/workflows#workflow-status) is set to inactive
 - The trigger data does not match the schema defined for the workflow ([learn more](/send-notifications/triggering-workflows#validating-workflow-trigger-data))
 
 ### Endpoint

--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -242,3 +242,13 @@ In some situations, you may want to limit the number of times that a recipient c
 Workflow trigger frequency lets you control the number of times that a recipient can run through a workflow, controlling if the workflow should trigger every time, or at most once for the recipient. By default, a workflow will trigger every time for a recipient.
 
 If you specify a workflow trigger frequency of "Once per recipient", then you can also optionally choose to include the tenant in the frequency control. When set, your workflow will only trigger once per-recipient, per-tenant.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="What happens when I trigger a workflow whose status is set to Inactive?">
+    A workflow whose [status](/concepts/workflows#workflow-status) is set to
+    `Inactive` will return a `workflow_inactive` [error](/reference#error-codes)
+    when triggered and will not generate any workflow recipient runs.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

This PR:
- [Adds a section to the Workflows concept page about the status setting](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/concepts/workflows#workflow-status)
- [Updates the existing callout on the Commits page to tighten the copy and link back to the new section instead](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/concepts/commits#promoting-commits)
- Adds FAQs about workflow status and expected behavior when set to `Inactive` ([here](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/concepts/workflows#frequently-asked-questions) and [here](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/send-notifications/triggering-workflows#frequently-asked-questions))
- Adds FAQs about expected behavior for [scheduled](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/concepts/schedules#frequently-asked-questions) and [delayed](https://docs-git-mk-add-workflow-faqs-knocklabs.vercel.app/designing-workflows/delay-function#frequently-asked-questions) workflows when the underlying workflow is updated
- Adds links to the workflow status explanation to the API reference
