### PR TITLE
fix: missing and incorrect info in CLI ref

### DIFF
--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -203,7 +203,7 @@ knock workflow get my-workflow --environment=production
 
 You can pull and download workflows with its message templates from Knock to a local file system with the `workflow pull` command. Knock CLI will create a new workflow directory or update the existing workflow directory in the local file system.
 
-Note: if pulling the target workflow for the first time or all workflowws, Knock CLI will ask to confirm before writing to the local filesystem.
+Note: if pulling the target workflow for the first time (or all workflows), Knock CLI will ask to confirm before writing to the local file system.
 
 See how workflow files are structured in your system [here](/concepts/workflows#workflow-files-structure).
 
@@ -542,7 +542,7 @@ knock layout get default --environment=production
 <Section title="knock layout pull <layout_key> [flags]" slug="email-layout-pull" headingClassName="font-mono">
 <ContentColumn>
 
-Pulls the contents of one or all email layouts from Knock into your local filesystem. Using `<layout_key>` you can pull a single email layout, specified by the key or use the `--all` flag to pull all email layouts from Knock at once.
+Pulls the contents of one or all email layouts from Knock into your local file system. Using `<layout_key>` you can pull a single email layout specified by the key, or use the `--all` flag to pull all email layouts from Knock at once.
 
 See how layout files are structured in your system [here](/integrations/email/layouts#layout-files-structure).
 
@@ -595,7 +595,7 @@ knock layout pull --all
 <Section title="knock layout push <layout_key> [flags]" slug="email-layout-push" headingClassName="font-mono">
 <ContentColumn>
 
-Pushes local email layouts back to Knock and upserts them. Using `<layout_key>` you can push a single email layout, specified by the key or use the `--all` flag to push all email layouts from Knock at once.
+Pushes local email layouts back to Knock and upserts them. Using `<layout_key>` you can push a single email layout specified by the key, or use the `--all` flag to push all email layouts from Knock at once.
 
 See how layout files are structured in your system [here](/integrations/email/layouts#layout-files-structure).
 
@@ -994,7 +994,7 @@ knock partial list
 </ExampleColumn>
 </Section>
 
-<Section title="knock partial get <workflow_key> [flags]" slug="partial-get" headingClassName="font-mono">
+<Section title="knock partial get <partial_key> [flags]" slug="partial-get" headingClassName="font-mono">
 <ContentColumn>
 
 You can show more details about a given partial with the `partial get` command, followed by the target partial key.
@@ -1031,12 +1031,12 @@ knock partial get my-partial --environment=production
 </ExampleColumn>
 </Section>
 
-<Section title="knock partial pull [flags]" slug="partial-pull" headingClassName="font-mono">
+<Section title="knock partial pull <partial_key> [flags]" slug="partial-pull" headingClassName="font-mono">
 <ContentColumn>
 
 You can pull and download partial files from Knock to a local file system with the `partial pull` command. Knock CLI will create a new partial directory or update the existing partial directory in the local file system.
 
-Note: if pulling the target workflow for the first time or all workflowws, Knock CLI will ask to confirm before writing to the local filesystem.
+Note: if pulling the target partial for the first time (or all partials), Knock CLI will ask to confirm before writing to the local file system.
 
 See how partial files are structured in your system [here](/send-and-manage-data/partials#partial-files-structure).
 
@@ -1095,7 +1095,7 @@ knock partial pull --all
 </ExampleColumn>
 </Section>
 
-<Section title="knock partial push [flags]" slug="partial-push" headingClassName="font-mono">
+<Section title="knock partial push <partial_key> [flags]" slug="partial-push" headingClassName="font-mono">
 <ContentColumn>
 
 You can push and upload a partial directory to Knock with the `partial push` command. Knock will update an existing partial by the matching partial key, or create a new partial if it does not exist yet.
@@ -1151,7 +1151,7 @@ knock partial push --all --partials-dir=./partials
 </ExampleColumn>
 </Section>
 
-<Section title="knock partial validate <workflow_key> [flags]" slug="partial-validate" headingClassName="font-mono">
+<Section title="knock partial validate <partial_key> [flags]" slug="partial-validate" headingClassName="font-mono">
 <ContentColumn>
 
 Validates one or more partial files. Useful for checking if the file is valid before running the `partial push` method.


### PR DESCRIPTION
### Description

Fixes some typos, grammatical errors, and incorrect or missing identifiers on CLI commands