### PR TITLE
fix: Ruby set object example code

### DIFF
--- a/data/code/objects/set.ts
+++ b/data/code/objects/set.ts
@@ -57,7 +57,7 @@ Knock.key = "sk_12345"
 Knock::Objects.set(
   collection: "projects",
   id: "project-1",
-  data: {
+  properties: {
     name: "My project",
     total_assets: 10,
     tags: ["cool", "fun", "project"],


### PR DESCRIPTION
### Description

Fixes a small error in the Set Object code example for Ruby. We were showing a `data` key rather than the `properties:` keyword argument that is expected (https://github.com/knocklabs/knock-ruby/blob/main/lib/knock/objects.rb#L55-L63)
