### PR TITLE
chore: add guidance on using knock as template source of truth

### DIFF
--- a/content/designing-workflows/template-editor/overview.mdx
+++ b/content/designing-workflows/template-editor/overview.mdx
@@ -183,32 +183,22 @@ To test your notification, click "Save" and navigate back to the workflow canvas
 
 All test runner notifications are tracked under "Messages" and have a source of "Test runner" to distinguish them from notifications you've triggered via the Knock API.
 
-## Why store all of my notification templates in Knock?
+## Frequently asked questions
 
-This is a common question that we hear from many of our customers, particularly those who currently maintain templates for their notifications in other third-party tools (often more than one!).
+<AccordionGroup>
+  <Accordion title="Why store all of my notification templates in Knock?">
+    This is a common question that we hear from our customers, particularly those who currently maintain templates for their notifications in other third-party tools (often more than one!).
 
-While [planning a migration](/guides/implementation-guide) will require some upfront effort, we recommend using Knock as the source of truth for your notification templates for a number of reasons:
+    While [planning a migration](/guides/implementation-guide) will require some upfront effort, we recommend using Knock as the source of truth for your notification templates for a number of reasons:
 
-<Steps>
-  <Step title="A consistent editing experience">
-    When you manage all of your templates in Knock, your content authors have access to a unified template editor for a consistent experience across all delivery channels. Teams who collaborate on messaging can work with a single templating language (Liquid) for dynamic content.
-  </Step>
-  <Step title="Cross-channel engagement analytics">
-    With Knock [link and open tracking](/send-notifications/tracking) in your message templates, you have access to cross-channel engagement analytics for each of your notification use cases in a centralized tool.
-  </Step>
-  <Step title="Unlock greater efficiency">
-    In the same way that Knock combines the logic and delivery of all of your notifications into a single API, using Knock as the source of truth for your templates means streamlining your process for cross-functional work on notifications. All changes to your message content, regardless of delivery channel, will follow the same steps for previewing, testing, and committing updates to production.
-  </Step>
-  <Step title="Work with your templates programmatically">
-    With our [Management API](/mapi) or [CLI](/cli), you can work with all of your cross-channel templates as code via a single API. This enables you to integrate your templates with other tools, automate updates, and more.
-  </Step>
-  <Step title="Reusable content blocks">
-    Our [Partials](/designing-workflows/partials) feature allows you to create content blocks of various types that can be reused across all of your notification templates. This enables updates across all delivery channels with a single change when necessary.
-  </Step>
-  <Step title="Reference data from other resources stored in Knock">
-    In addition to the context that you pass to Knock on your workflow trigger calls and [reference as dynamic content](/designing-workflows/template-editor/variables) in your notifications (like `recipient` and `tenant` properties, or custom `data` payload variables), the Knock template editor also allows you to [reference data](/designing-workflows/template-editor/referencing-data) from any Users, Objects, and Tenants that exist within your Knock environment.
+    - **A consistent editing experience.** When you manage all of your templates in Knock, your content authors have access to a unified template editor for a consistent experience across all delivery channels. Teams who collaborate on messaging can work with a single templating language (Liquid) for dynamic content.
+    - **Cross-channel engagement analytics.** With Knock [link and open tracking](/send-notifications/tracking) in your message templates, you have access to cross-channel engagement analytics for each of your notification use cases in a centralized tool.
+    - **Unlock greater efficiency.** In the same way that Knock combines the logic and delivery of all of your notifications into a single API, using Knock as the source of truth for your templates means streamlining your process for cross-functional work on notifications. All changes to your message content, regardless of delivery channel, will follow the same steps for previewing, testing, and committing updates to production.
+    - **Work with your templates programmatically.** With our [Management API](/mapi) or [CLI](/cli), you can work with all of your cross-channel templates as code via a single API. This enables you to integrate your templates with other tools, automate updates, and more.
+    - **Reusable content blocks.** Our [Partials](/designing-workflows/partials) feature allows you to create content blocks of various types that can be reused across all of your notification templates. This enables updates across all delivery channels with a single change when necessary.
+    - **Reference data from other resources stored in Knock.** In addition to the context that you pass to Knock on your workflow trigger calls and [reference as dynamic content](/designing-workflows/template-editor/variables) in your notifications (like `recipient` and `tenant` properties, or custom `data` payload variables), the Knock template editor also allows you to [reference data](/designing-workflows/template-editor/referencing-data) from any Users, Objects, and Tenants that exist within your Knock environment.
 
-    Referencing data is a powerful way to share context across entities in your templates without needing to manually pass the data in the `data` argument of your workflow trigger, and isn't possible with other templating solutions.
+        Referencing data is a powerful way to share context across entities in your templates without needing to manually pass the data in the `data` argument of your workflow trigger, and isn't possible with other templating solutions.
 
-  </Step>
-</Steps>
+  </Accordion>
+</AccordionGroup>

--- a/content/designing-workflows/template-editor/overview.mdx
+++ b/content/designing-workflows/template-editor/overview.mdx
@@ -206,7 +206,7 @@ While [planning a migration](/guides/implementation-guide) will require some upf
     Our [Partials](/designing-workflows/partials) feature allows you to create content blocks of various types that can be reused across all of your notification templates. This enables updates across all delivery channels with a single change when necessary.
   </Step>
   <Step title="Reference data from other resources stored in Knock">
-    In addition to the context that you pass to Knock on your workflow trigger calls and [reference as dynamic content](/designing-workflows/template-editor/variables) in your notifications (like recipient and `tenant` properties, or custom `data` payload variables), the Knock template editor also allows you to [reference data](/designing-workflows/template-editor/referencing-data) from any Users, Objects, and Tenants that exist within your Knock environment.
+    In addition to the context that you pass to Knock on your workflow trigger calls and [reference as dynamic content](/designing-workflows/template-editor/variables) in your notifications (like `recipient` and `tenant` properties, or custom `data` payload variables), the Knock template editor also allows you to [reference data](/designing-workflows/template-editor/referencing-data) from any Users, Objects, and Tenants that exist within your Knock environment.
 
     Referencing data is a powerful way to share context across entities in your templates without needing to manually pass the data in the `data` argument of your workflow trigger, and isn't possible with other templating solutions.
 

--- a/content/designing-workflows/template-editor/overview.mdx
+++ b/content/designing-workflows/template-editor/overview.mdx
@@ -20,10 +20,11 @@ In this page we'll walk through the key features of the Knock template editor an
 
 We'll cover:
 
-- Inserting variables from your trigger call into your notification template
-- Using liquid syntax to add logic and control flow to your notification template
-- Visual editing with drag-and-drop components
-- How to preview and test your notification template
+- Inserting variables from your trigger call into your notification template.
+- Using liquid syntax to add logic and control flow to your notification template.
+- Visual editing with drag-and-drop components.
+- How to preview and test your notification template.
+- Why we recommend storing all of your notification templates in Knock.
 
 <Callout
   emoji="💡"
@@ -181,3 +182,33 @@ Your notification preview is populated with the data available in the lefthand v
 To test your notification, click "Save" and navigate back to the workflow canvas by clicking the back arrow in the top-left corner. You can run actual notification tests by clicking "Run a test" in the top-right corner. Just choose your actor and recipient, provide and trigger call data that you'd like included in your test, and click "Run test."
 
 All test runner notifications are tracked under "Messages" and have a source of "Test runner" to distinguish them from notifications you've triggered via the Knock API.
+
+## Why store all of my notification templates in Knock?
+
+This is a common question that we hear from many of our customers, particularly those who currently maintain templates for their notifications in other third-party tools (often more than one!).
+
+While [planning a migration](/guides/implementation-guide) will require some upfront effort, we recommend using Knock as the source of truth for your notification templates for a number of reasons:
+
+<Steps>
+  <Step title="A consistent editing experience">
+    When you manage all of your templates in Knock, your content authors have access to a unified template editor for a consistent experience across all delivery channels. Teams who collaborate on messaging can work with a single templating language (Liquid) for dynamic content.
+  </Step>
+  <Step title="Cross-channel engagement analytics">
+    With Knock [link and open tracking](/send-notifications/tracking) in your message templates, you have access to cross-channel engagement analytics for each of your notification use cases in a centralized tool.
+  </Step>
+  <Step title="Unlock greater efficiency">
+    In the same way that Knock combines the logic and delivery of all of your notifications into a single API, using Knock as the source of truth for your templates means streamlining your process for cross-functional work on notifications. All changes to your message content, regardless of delivery channel, will follow the same steps for previewing, testing, and committing updates to production.
+  </Step>
+  <Step title="Work with your templates programmatically">
+    With our [Management API](/mapi) or [CLI](/cli), you can work with all of your cross-channel templates as code via a single API. This enables you to integrate your templates with other tools, automate updates, and more.
+  </Step>
+  <Step title="Reusable content blocks">
+    Our [Partials](/designing-workflows/partials) feature allows you to create content blocks of various types that can be reused across all of your notification templates. This enables updates across all delivery channels with a single change when necessary.
+  </Step>
+  <Step title="Reference data from other resources stored in Knock">
+    In addition to the context that you pass to Knock on your workflow trigger calls and [reference as dynamic content](/designing-workflows/template-editor/variables) in your notifications (like recipient and `tenant` properties, or custom `data` payload variables), the Knock template editor also allows you to [reference data](/designing-workflows/template-editor/referencing-data) from any Users, Objects, and Tenants that exist within your Knock environment.
+
+    Referencing data is a powerful way to share context across entities in your templates without needing to manually pass the data in the `data` argument of your workflow trigger, and isn't possible with other templating solutions.
+
+  </Step>
+</Steps>


### PR DESCRIPTION
### Description

This PR [adds an FAQ](https://docs-8z71sj3av-knocklabs.vercel.app/designing-workflows/template-editor/overview#frequently-asked-questions) to the docs on **Why store all of my notification templates in Knock?**

### Screenshots

<img width="600" alt="image" src="https://github.com/user-attachments/assets/fa48b891-c726-423f-8b66-1c66f71e9540" />

