### PR TITLE
chore: add callout for rate limit tiers

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -77,18 +77,21 @@ Authorization: Bearer sk_test_12345
 
 Each endpoint in the Knock API is rate limited. Knock uses a tier system to determine the rate limit scale for each endpoint. When your request has been rate limited, the Knock API will return a `429 Too Many Requests` error in response.
 
-Knock's default behavior scopes rate limits based on the authorizing credential used in your requests. When you use a public or private API key to authorize a request, Knock will scope the rate limit for each endpoint by the [environment](/send-and-manage-data/environments) associated with the key. If you use a signed user token as your authorizing credential, Knock will scope the rate limit by both the key's environment and the signing user. See our guide on [enhanced security mode](/in-app-ui/security-and-authentication#authentication-with-enhanced-security) for more details on working with signed user tokens.
-
 <Callout
   emoji="💡"
   text={
     <>
-      <strong>Concerned about exceeding a Knock rate limit?</strong>{" "}
-      <a href="https://knock.app/contact-sales">Contact us</a> and we can help
-      figure out a usage rate that's right for your specific needs.
+      <strong>Rate limit tiers are assigned per-endpoint.</strong> Knock does
+      not have separate rate limit tiers for different accounts or pricing
+      plans. Each endpoint in this reference has a rate limit tier label that
+      indicates the scale of requests you can make to that endpoint.
     </>
   }
 />
+
+Knock's default behavior scopes rate limits based on the authorizing credential used in your requests. When you use a public or private API key to authorize a request, Knock will scope the rate limit for each endpoint by the [environment](/send-and-manage-data/environments) associated with the key. If you use a signed user token as your authorizing credential, Knock will scope the rate limit by both the key's environment and the signing user. See our guide on [enhanced security mode](/in-app-ui/security-and-authentication#authentication-with-enhanced-security) for more details on working with signed user tokens.
+
+If you're concerned about exceeding a Knock rate limit, please [contact us](https://knock.app/contact-sales) and we can help figure out a usage rate that's right for your specific needs.
 
 </ContentColumn>
 <ExampleColumn>


### PR DESCRIPTION
### Description

Add [a callout](https://docs-7jrzabsxs-knocklabs.vercel.app/reference#rate-limits) to further clarify that rate limit tiers are _not_ an account or plan setting.

### Screenshots

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6554931f-e690-4b75-b171-521e59e418fe">
