### PR TITLE
chore: add RS256 requirement to SlackKit docs

### DIFF
--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -358,7 +358,7 @@ Continue reading for a deeper dive on access and how these grants are structured
 
 ### Grants in the user token
 
-You may already be familiar with generating a user token to be used with your public API key when making client side calls if you've used [authentication with enhanced security](/in-app-ui/security-and-authentication#authentication-with-enhanced-security). You'll use the same process to generate the user token as described here, but you'll also be sending a list of grants to the the user needs to work with SlackKit.
+You may already be familiar with generating a user token to be used with your public API key when making client side calls if you've used [authentication with enhanced security](/in-app-ui/security-and-authentication#authentication-with-enhanced-security). You'll use the same process to generate the user token as described here, including signing it with an RS256 algorithm using your private signing key, but you'll also be sending a list of grants that the user needs to work with SlackKit.
 
 The two resources you'll be granting access to are:
 


### PR DESCRIPTION
### Description
This clarifies the technical requirement that the Slack user token must be signed using an RS256 algorithm. While we link to the security and auth docs that state this, this adds the information directly to the Slack docs for token generation.

[KNO-7508](https://linear.app/knock/issue/KNO-7508/[docs]-add-callout-for-using-rs256-algo-in-slackkit-token-generation)

https://docs-git-rt-slack-token-algo-knocklabs.vercel.app/in-app-ui/react/slack-kit#grants-in-the-user-token
