### PR TITLE
chore: add token deregistration callouts

### DIFF
--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -57,7 +57,11 @@ You can follow the [quickstart guide](https://developer.apple.com/documentation/
 
 ## Managing tokens
 
-Knock makes no assumptions about managing your device tokens for you. Meaning if a recipient opts-out of receiving notifications on a device, or the token expires, it is up to you to remove the token from the recipients channel data. This behavior is subject to change in the future.
+By default, Knock makes no assumptions about managing your device tokens. This means you are responsible for removing tokens when a recipient opts out of notifications on a device or when their token expires.
+
+However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
+
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to APNS
 

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -29,7 +29,11 @@ You can follow the appropriate <a href="https://docs.expo.dev/push-notifications
 
 ## Managing tokens
 
-Knock makes no assumptions about managing your device tokens for you. Meaning if a recipient opts-out of receiving notifications on a device, or the token expires, it is up to you to remove the token from the recipients channel data. This behavior is subject to change in the future.
+By default, Knock makes no assumptions about managing your device tokens. This means you are responsible for removing tokens when a recipient opts out of notifications on a device or when their token expires.
+
+However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
+
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to Expo
 

--- a/content/integrations/push/firebase.mdx
+++ b/content/integrations/push/firebase.mdx
@@ -44,7 +44,11 @@ Once you have the device token, you can use the Knock SDK to set the channel dat
 
 ## Managing tokens
 
-Knock makes no assumptions about managing your device tokens for you. Meaning if a recipient opts-out of receiving notifications on a device, or the token expires, it is up to you to remove the token from the recipients channel data. This behavior is subject to change in the future.
+By default, Knock makes no assumptions about managing your device tokens. This means you are responsible for removing tokens when a recipient opts out of notifications on a device or when their token expires.
+
+However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
+
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to FCM
 

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -66,6 +66,18 @@ We have full support for overriding the payload sent to OneSignal for adding thi
 
 Overrides are merged into the notification payload sent to OneSignal. See the <a href="https://documentation.onesignal.com/reference/push-notification" target="_blank">OneSignal documentation for more details</a>. Knock uses the "Aliases" targeting strategy to send push notifications to specific users via External ID.
 
+## Managing tokens
+
+By default, Knock makes no assumptions about managing your device tokens. The way token management works depends on your chosen recipient mode:
+
+### When using `external_id` mode (recommended)
+Token management is handled automatically by OneSignal, as Knock only maintains the mapping between your user's ID and OneSignal's external ID. While Knock's token deregistration feature is technically enabled for this mode, it has no practical effect since Knock doesn't directly manage any tokens.
+
+### When using `player_id` mode
+You are responsible for managing the player IDs stored in your recipients' channel data. This includes updating or removing player IDs when a recipient opts out of notifications or when their token expires. Token deregistration is not available for OneSignal channels using `player_id` mode.
+
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details.
+
 ## Channel data requirements
 
 When your OneSignal push channel is configured to use `player_ids` you must supply ChannelData per-recipient that contains one or more `player_ids` for a user.

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -73,14 +73,11 @@ When your OneSignal push channel is configured to use `player_ids` you must supp
 ## Frequently asked questions
 
 <AccordionGroup>
-  <Accordion
-    title="Can I use both `player_ids` and `external_ids` for my OneSignal integration?"
-    defaultOpen={true}
-  >
+  <Accordion title="Can I use both `player_ids` and `external_ids` for my OneSignal integration?">
     No, you can currently only use one or the other.
   </Accordion>
   <Accordion title="Can I use a different identifier as an `external_id`?">
-    Currently this is not supported but we’d love to hear a use case you have
+    Currently this is not supported but we'd love to hear a use case you have
     for it!
   </Accordion>
   <Accordion title="Can I use a `template_id` stored in OneSignal?">

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -68,13 +68,9 @@ Overrides are merged into the notification payload sent to OneSignal. See the <a
 
 ## Managing tokens
 
-By default, Knock makes no assumptions about managing your device tokens. The way token management works depends on your chosen recipient mode:
+By default, Knock makes no assumptions about managing your device tokens. This means you are responsible for removing tokens when a recipient opts out of notifications on a device or when their token expires.
 
-### When using `external_id` mode (recommended)
-Token management is handled automatically by OneSignal, as Knock only maintains the mapping between your user's ID and OneSignal's external ID. While Knock's token deregistration feature is technically enabled for this mode, it has no practical effect since Knock doesn't directly manage any tokens.
-
-### When using `player_id` mode
-You are responsible for managing the player IDs stored in your recipients' channel data. This includes updating or removing player IDs when a recipient opts out of notifications or when their token expires. Token deregistration is not available for OneSignal channels using `player_id` mode.
+When using `player_id` mode, Knock provides an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. This feature is not available when using `external_id` mode since Knock doesn't directly manage any tokens in this case.
 
 You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details.
 

--- a/content/integrations/push/token-deregistration.mdx
+++ b/content/integrations/push/token-deregistration.mdx
@@ -36,11 +36,11 @@ Workflow overrides **are not** available for Token deregistration. This capabili
     </tr>
     <tr>
       <td>OneSignal (`player_id`)</td>
-      <td>❌</td>
+      <td><✅/td>
     </tr>
     <tr>
       <td>OneSignal (`external_id`)</td>
-      <td>✅</td>
+      <td>❌</td>
     </tr>
   </tbody>
 </table>

--- a/content/integrations/push/token-deregistration.mdx
+++ b/content/integrations/push/token-deregistration.mdx
@@ -36,7 +36,7 @@ Workflow overrides **are not** available for Token deregistration. This capabili
     </tr>
     <tr>
       <td>OneSignal (`player_id`)</td>
-      <td><✅/td>
+      <td>✅</td>
     </tr>
     <tr>
       <td>OneSignal (`external_id`)</td>

--- a/content/integrations/push/token-deregistration.mdx
+++ b/content/integrations/push/token-deregistration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Token deregistration
 description: How to use Knock token deregistration to manage recipient tokens by removing invalid tokens.
-tags: ["token deregistraiton", "channel data", "bounced"]
+tags: ["token deregistration", "channel data", "bounced"]
 section: Integrations > Push
 layout: integrations
 ---
@@ -18,7 +18,7 @@ Workflow overrides **are not** available for Token deregistration. This capabili
   <thead>
     <tr>
       <th>Provider</th>
-      <th>Token deregistraiton available?</th>
+      <th>Token deregistration available?</th>
     </tr>
   </thead>
   <tbody>

--- a/content/integrations/push/token-deregistration.mdx
+++ b/content/integrations/push/token-deregistration.mdx
@@ -8,9 +8,9 @@ layout: integrations
 
 For push providers only, Knock provides an opt-in, provider-agnostic token management capability known as token deregistration. Knock removes invalid tokens from a recipient's corresponding channel data if that token results in a `bounced` message on send.
 
-This setting is applicable across all push providers, excluding OneSignal when the `recipient_mode` is "ExternalID". In this case, Knock only has knowledge of the user's id and therefor cannot deregister the associated external token.
+This feature is available for all push providers, except OneSignal when the recipient mode is set to `external_id`. In this case, Knock only has access to the user's ID and therefore cannot deregister the associated external token.
 
-Workflow overrides **are not** available for Token deregistration. This capability can only be configured at the provider level.
+Workflow overrides are **not** available for token deregistration. This capability can only be configured at the provider level.
 
 ## Availability
 
@@ -57,16 +57,14 @@ You can configure Knock tracking on a per-environment basis using your channel's
   className="rounded-md mx-auto border border-gray-200"
 />
 
-## Working with Knock token deregistration
-
-### Knock Webhooks
-
-If you use Knock's outbound webhooks, you can view the invalid token in the `message.bounced` events captured. If token deregistration is `ON`, no further intervention is needed for token removal. See the [outbound webhooks guide](/send-and-manage-data/outbound-webhooks) for more details.
-
 ## How it works
 
-### Token deregistration
-
-When Knock attempts to send a message to one of the supported Push providers, any errors due to invalid or expired tokens will result in a `bounce`. If the message bounces, a corresponding `message.bounced` event is published containing the erroneous token.
+When Knock attempts to deliver a message through a supported push provider, any errors caused by invalid or expired tokens result in a bounce. This generates a `message.bounced` event containing the invalid token.
 
 Knock will remove the invalid token from the list of tokens present in the recipient's channel data. This allows for an automated audit of the tokens present for recipients.
+
+## Working with Knock token deregistration
+
+### Outbound webhooks
+
+If you use Knock's outbound webhooks, you can view the invalid token in the `message.bounced` events captured. If token deregistration is `ON`, no further intervention is needed for token removal. See the [outbound webhooks guide](/send-and-manage-data/outbound-webhooks) for more details.

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -13,6 +13,7 @@ At Knock we call this concept <a href="/reference#channel-data">`ChannelData`</a
 
 - For channel types that require channel data (such as [push](/integrations/push/overview) channels and [chat](/integrations/chat/overview) channels like Slack), the channel step will be skipped during a workflow run if the required `channel_data` is not stored on the recipient.
 - Knock stores channel data for you but makes no assumptions about whether the stored channel data is valid. That means that if a push token expires, it's your responsibility to omit/update that token for future notifications.
+  - For push providers, Knock offers an opt-in [token deregistration](/integrations/push/token-deregistration) feature that automatically removes invalid tokens from a recipient's channel data when messages bounce.
 - Setting channel data always requires a `channel_id`, which can be obtained in the Dashboard under **Integrations** > **Channels**. A channel ID is always a UUID v4.
 
 ## Setting channel data
@@ -97,6 +98,21 @@ channel data is not set for the recipient you'll receive a `404` response.
 ## Clearing channel data
 
 Any previously set channel data can be cleared by issuing an `unsetChannelData` call. Unsetting channel data for a recipient requires a valid channel ID to be passed.
+
+<Callout
+  emoji="🔁"
+  text={
+    <>
+      <strong>Token deregistration.</strong> For push providers, Knock can
+      automatically remove invalid tokens from a recipient's channel data when
+      messages bounce. Learn more about this opt-in feature in our{" "}
+      <a href="/integrations/push/token-deregistration">
+        token deregistration guide
+      </a>
+      .
+    </>
+  }
+/>
 
 <AccordionGroup>
   <Accordion title="Unset channel data for a User">


### PR DESCRIPTION
### Description

Adds token deregistration information to relevant pages across the docs. Also makes some updates to the token deregistration page itself. 

### Tasks

[KNO-7482](https://linear.app/knock/issue/KNO-7482/[docs]-add-calloutslinks-to-token-deregistration-on-setting-channel)

### Pages/sections updated
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/managing-recipients/setting-channel-data#things-to-know-about-channel-data
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/managing-recipients/setting-channel-data#clearing-channel-data
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/integrations/push/token-deregistration
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/integrations/push/apns#managing-tokens
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/integrations/push/firebase#managing-tokens
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/integrations/push/expo#managing-tokens
https://docs-git-rt-add-token-deregistration-callout-knocklabs.vercel.app/integrations/push/one-signal#managing-tokens
