### PR TITLE
chore: add redirect for old docs link to message types

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -280,6 +280,11 @@ const nextConfig = {
         destination: "/in-app-ui/react/filtering-in-app-feeds",
         permanent: false,
       },
+      {
+        source: "/concepts/message-types",
+        destination: "/in-app-ui/message-types",
+        permanent: true,
+      },
       // Reference redirects
       {
         source: "/in-app-ui/:sdk/reference",


### PR DESCRIPTION
### Description

Fix broken link to message types docs with a redirect