### PR TITLE
feat: introduce isRequired for Attribute component

### DIFF
--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -40,7 +40,7 @@ const Attribute = ({
         )}
       </span>
       {isRequired && (
-        <span className="font-semibold text-brand bg-beige-light text-xs ml-2 py-0.5 px-1">
+        <span className="font-semibold text-brand dark:text-brand-light bg-beige-light dark:bg-zinc-800 text-xs ml-2 py-0.5 px-1">
           required
         </span>
       )}

--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -40,9 +40,15 @@ const Attribute = ({
         )}
       </span>
       {isRequired && (
-        <span className="font-semibold text-brand dark:text-brand-light bg-beige-light dark:bg-zinc-800 text-xs ml-2 py-0.5 px-1">
-          required
-        </span>
+        // option 1
+        <span className="font-semibold text-brand-dark bg-brand-light/20 dark:text-brand-light dark:bg-brand-dark/20 text-xs ml-2 py-0.5 px-1">
+  required
+</span>
+        // option 2
+//         <span className="font-semibold text-brand-dark bg-brand-light/10 dark:text-brand-light dark:bg-zinc-800/30 text-xs ml-2 py-0.5 px-1">
+//   required
+// </span>
+
       )}
     </span>
     <span className="block text-sm mt-0 text-gray-600 dark:text-gray-300">

--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -40,15 +40,9 @@ const Attribute = ({
         )}
       </span>
       {isRequired && (
-        // option 1
-        <span className="font-semibold text-brand-dark bg-brand-light/20 dark:text-brand-light dark:bg-brand-dark/20 text-xs ml-2 py-0.5 px-1">
-  required
-</span>
-        // option 2
-//         <span className="font-semibold text-brand-dark bg-brand-light/10 dark:text-brand-light dark:bg-zinc-800/30 text-xs ml-2 py-0.5 px-1">
-//   required
-// </span>
-
+        <span className="font-semibold text-brand-dark bg-brand-light/10 dark:text-brand-light dark:bg-zinc-800/30 dark:border dark:border-zinc-700/50 text-xs ml-2 py-0.5 px-1">
+          required
+        </span>
       )}
     </span>
     <span className="block text-sm mt-0 text-gray-600 dark:text-gray-300">

--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -4,7 +4,14 @@ const Attributes = ({ children }) => (
   </div>
 );
 
-const Attribute = ({ name, type, description, typeSlug, nameSlug, isRequired }) => (
+const Attribute = ({
+  name,
+  type,
+  description,
+  typeSlug,
+  nameSlug,
+  isRequired,
+}) => (
   <div className="attribute border-b dark:border-b-gray-800 py-2">
     <span>
       <span className="font-mono text-xs">
@@ -33,7 +40,9 @@ const Attribute = ({ name, type, description, typeSlug, nameSlug, isRequired }) 
         )}
       </span>
       {isRequired && (
-        <span className="font-semibold text-brand bg-beige-light text-xs ml-2 py-0.5 px-1">required</span>
+        <span className="font-semibold text-brand bg-beige-light text-xs ml-2 py-0.5 px-1">
+          required
+        </span>
       )}
     </span>
     <span className="block text-sm mt-0 text-gray-600 dark:text-gray-300">

--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -4,7 +4,7 @@ const Attributes = ({ children }) => (
   </div>
 );
 
-const Attribute = ({ name, type, description, typeSlug, nameSlug }) => (
+const Attribute = ({ name, type, description, typeSlug, nameSlug, isRequired }) => (
   <div className="attribute border-b dark:border-b-gray-800 py-2">
     <span>
       <span className="font-mono text-xs">
@@ -32,6 +32,9 @@ const Attribute = ({ name, type, description, typeSlug, nameSlug }) => (
           type
         )}
       </span>
+      {isRequired && (
+        <span className="font-semibold text-brand bg-beige-light text-xs ml-2 py-0.5 px-1">required</span>
+      )}
     </span>
     <span className="block text-sm mt-0 text-gray-600 dark:text-gray-300">
       {description}


### PR DESCRIPTION
### Description

Introduces the `isRequired`prop to the `<Attribute>` component, which, when provided, displays a "required" tag.

This PR is _only_ to introduce the prop. I will open a seperate PR with the updates to the API + mAPI docs. 

### Tasks

[KNO-7408](https://linear.app/knock/issue/KNO-7408/[docs]-add-missing-requirements-indicators-to-api-attributesparameters)

### Screenshots

Current:
![Screenshot 2024-12-12 at 12 54 45 PM](https://github.com/user-attachments/assets/eadf549a-465e-4132-9854-f649fb6e55b1)

With new `isRequired` prop:
![Screenshot 2024-12-12 at 12 49 47 PM](https://github.com/user-attachments/assets/49f909dc-2fb8-4e92-b3da-dcffa1e3e8d7)

Current:
![Screenshot 2024-12-12 at 12 55 30 PM](https://github.com/user-attachments/assets/977d4ecb-d282-446d-a00b-a8a5ac785fdb)

With new `isRequired` prop:
![Screenshot 2024-12-12 at 12 47 53 PM](https://github.com/user-attachments/assets/1c539da6-8e9b-4d5c-8ab2-2e6f853b1ad2)

