### PR TITLE
chore: fix definition typo

### DIFF
--- a/content/concepts/recipients.mdx
+++ b/content/concepts/recipients.mdx
@@ -22,7 +22,7 @@ Recipients have:
 - **Preferences.** The rules under which the recipient should or should not receive notifications.
 - **Channel data.** Channel data send a recipient a notification on a particular channel, such as tokens for sending push notifications to a given channel or access tokens to send notifications to a chat channel like Slack.
 
-## `RecipientIdentifier` definiton
+## `RecipientIdentifier` definition
 
 A recipient identifier can be one of:
 

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -511,7 +511,7 @@ Knock uses standard [HTTP response codes](https://developer.mozilla.org/en-US/We
 
 <ErrorExample
   title="workflow_missing"
-  description="The workflow you attemped to invoke could not be found. To resolve this error, confirm that you're calling the correct environment and that your workflow has been committed to it."
+  description="The workflow you attempted to invoke could not be found. To resolve this error, confirm that you're calling the correct environment and that your workflow has been committed to it."
 />
 
 </div>
@@ -586,14 +586,14 @@ The workflow trigger endpoint enforces the following payload size limits:
   <Attribute
     name="recipients"
     type="RecipientIdentifier[] (required)"
-    description="A list of user idenitifers, object references, or inline recipient definitions to run this workflow for"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    description="A list of user identifiers, object references, or inline recipient definitions to run this workflow for"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="actor"
     type="RecipientIdentifier (optional)"
     description="An identifier of who or what performed this action"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="cancellation_key"
@@ -766,7 +766,7 @@ The workflow cancellation endpoint enforces the following payload size limits:
     name="recipients"
     type="RecipientIdentifier[]"
     description="An optional list of user ids or object references to cancel the workflow for"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
 </Attributes>
 
@@ -804,13 +804,13 @@ A message is a notification delivered on a particular channel to a user.
     name="recipient"
     type="RecipientIdentifier"
     description="The ID of the user who received the message. If the recipient is an object, the result will be an object containing its id and collection"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="actors"
     type="RecipientIdentifier[]"
     description="One or more actors that are associated with this message. Note: this is a list that can contain up to 10 actors if the message is produced from a batch."
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="workflow"
@@ -3864,7 +3864,7 @@ Adds one or more recipients as subscribers to the object by creating subscriptio
     name="recipients"
     type="RecipientIdentifier[]"
     description="A list of recipient identifiers. You can subscribe up to 100 recipients to an object at a time."
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="properties"
@@ -4000,7 +4000,7 @@ A `BulkOperation`.
 </ExampleColumn>
 </Section>
 
-<Section title="Delete subscriptons" slug="delete-subscriptions">
+<Section title="Delete subscriptions" slug="delete-subscriptions">
 <ContentColumn>
 
 Removes one or more recipients as subscribers to the object.
@@ -4008,7 +4008,7 @@ Removes one or more recipients as subscribers to the object.
 ### Endpoint
 
 <Endpoint
-  name="delet-subscriptions"
+  name="delete-subscriptions"
   method="DELETE"
   path="/objects/:collection/:id/subscriptions"
 />
@@ -4038,8 +4038,8 @@ Removes one or more recipients as subscribers to the object.
   <Attribute
     name="recipients"
     type="RecipientIdentifier[]"
-    description="A list of recipient identifers"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    description="A list of recipient identifiers"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
 </Attributes>
 
@@ -5539,8 +5539,8 @@ Creates new schedules for the recipients provided. Up to 100 recipients may be s
   <Attribute
     name="recipients"
     type="RecipientIdentifier[]"
-    description="A list of recipient identifers"
-    typeSlug="/concepts/recipients#recipientidentifier-definiton"
+    description="A list of recipient identifiers"
+    typeSlug="/concepts/recipients#recipientidentifier-definition"
   />
   <Attribute
     name="actor"


### PR DESCRIPTION
### Description

Saw there was a little typo (definiton -> definition). Also made a few minor typo updates to the API reference file while I was in there 😄 

### Tasks

[KNO-7529](https://linear.app/knock/issue/KNO-7529/[docs]-fix-typo-for-recipientidentifier-definiton)
