### PR TITLE
fix(KNO-7439): add missing engagement status filters to API reference

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -1030,7 +1030,7 @@ Messages outside the account's retention window will not be included in the resu
   <Attribute
     name="engagement_status"
     type="string[] (optional)"
-    description="One or more of `read`, `unread`, `seen`, `unseen`. Limits results to messages with the given engagement status(es)."
+    description="One or more of `read`, `unread`, `seen`, `unseen`, `archived`, `unarchived`, `interacted`, `link_clicked`. Limits results to messages with the given engagement status(es)."
   />
   <Attribute
     name="channel_id"
@@ -1797,7 +1797,7 @@ For in-app channels, messages can be updated indefinitely via this operation. Fo
   <Attribute
     name="engagement_status"
     type="enum (optional)"
-    description="Limit messages to one of `seen`, `unseen`, `read`, `unread`, `archived`, `unarchived`, `interacted`"
+    description="Limit messages to one of `seen`, `unseen`, `read`, `unread`, `archived`, `unarchived`, `interacted`, `link_clicked`"
   />
 </Attributes>
 
@@ -2498,7 +2498,7 @@ Messages outside the account's retention window will not be included in the resu
   <Attribute
     name="engagement_status"
     type="string[] (optional)"
-    description="One or more of `read`, `unread`, `seen`, `unseen`. Limits results to messages with the given engagement status(es)."
+    description="One or more of `read`, `unread`, `seen`, `unseen`, `archived`, `unarchived`, `interacted`, `link_clicked`. Limits results to messages with the given engagement status(es)."
   />
   <Attribute
     name="channel_id"
@@ -3134,7 +3134,7 @@ Messages outside the account's retention window will not be included in the resu
   <Attribute
     name="engagement_status"
     type="string[] (optional)"
-    description="One or more of `read`, `unread`, `seen`, `unseen`. Limits results to messages with the given engagement status(es)."
+    description="One or more of `read`, `unread`, `seen`, `unseen`, `archived`, `unarchived`, `interacted`, `link_clicked`. Limits results to messages with the given engagement status(es)."
   />
   <Attribute
     name="channel_id"


### PR DESCRIPTION
### Description

This PR updates the API reference to include the missing values for engagement status filter attributes.

### Tasks

[KNO-7439](https://linear.app/knock/issue/KNO-7439/[switchboard]-update-message-endpoints-to-support-filtering-by)
