### PR TITLE
chore: update tenant preferences callout

### DIFF
--- a/content/preferences/tenant-preferences.mdx
+++ b/content/preferences/tenant-preferences.mdx
@@ -16,8 +16,8 @@ section: Preferences
   emoji="✨"
   text={
     <>
-      <span className="font-bold">Enterprise plan feature.</span> Tenant
-      preference defaults are only available on our{" "}
+      <span className="font-bold">Enterprise plan feature.</span> Per-tenant
+      user preferences and tenant preference defaults are only available on our{" "}
       <a href="https://knock.app/pricing">Enterprise plan</a>.
     </>
   }


### PR DESCRIPTION
### Description

Updates the callout on the tenant preferences page to align with what is under the [tenants page](https://docs.knock.app/concepts/tenants#per-tenant-user-preferences-and-tenant-preference-defaults) to be more explicit about enterprise-only features. 

https://docs-git-rt-update-tenant-preferences-enterpri-8e040f-knocklabs.vercel.app/preferences/tenant-preferences
