### PR TITLE
chore: add OneSignal to supported push channels

### DIFF
--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -82,8 +82,8 @@ Knock supports the following channel types and providers:
     Talking](/integrations/sms/africas-talking), [AWS
     SNS](/integrations/sms/aws-sns), [Mailersend](/integrations/sms/mailersend),
     [MessageBird](/integrations/sms/messagebird),
-    [Plivo](/integrations/sms/plivo), [Sinch](/integrations/sms/sinch),
-    [Sinch MessageMedia](/integrations/sms/sinch-message-media),
+    [Plivo](/integrations/sms/plivo), [Sinch](/integrations/sms/sinch), [Sinch
+    MessageMedia](/integrations/sms/sinch-message-media),
     [Telnyx](/integrations/sms/telnyx), [Twilio](/integrations/sms/twilio), and
     [Vonage](/integrations/sms/vonage).
   </Accordion>

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -83,6 +83,7 @@ Knock supports the following channel types and providers:
     SNS](/integrations/sms/aws-sns), [Mailersend](/integrations/sms/mailersend),
     [MessageBird](/integrations/sms/messagebird),
     [Plivo](/integrations/sms/plivo), [Sinch](/integrations/sms/sinch),
+    [Sinch MessageMedia](/integrations/sms/sinch-message-media),
     [Telnyx](/integrations/sms/telnyx), [Twilio](/integrations/sms/twilio), and
     [Vonage](/integrations/sms/vonage).
   </Accordion>

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -89,8 +89,9 @@ Knock supports the following channel types and providers:
   <Accordion title="Push">
     Knock supports sending push messages with [Apple Push Notification Service
     (iOS)](/integrations/push/apns), [Expo (React
-    Native)](/integrations/push/expo), and [Firebase Cloud Messaging
-    (Android)](/integrations/push/firebase).
+    Native)](/integrations/push/expo), [Firebase Cloud Messaging
+    (Android)](/integrations/push/firebase), and
+    [OneSignal](/integrations/push/onesignal).
   </Accordion>
   <Accordion title="Chat">
     Knock supports sending chat messages with [Slack](/integrations/chat/slack),

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -91,7 +91,7 @@ Knock supports the following channel types and providers:
     (iOS)](/integrations/push/apns), [Expo (React
     Native)](/integrations/push/expo), [Firebase Cloud Messaging
     (Android)](/integrations/push/firebase), and
-    [OneSignal](/integrations/push/onesignal).
+    [OneSignal](/integrations/push/one-signal).
   </Accordion>
   <Accordion title="Chat">
     Knock supports sending chat messages with [Slack](/integrations/chat/slack),

--- a/content/integrations/overview.md
+++ b/content/integrations/overview.md
@@ -87,6 +87,8 @@ Channel groups solve this problem. With a channel group, you can combine multipl
 
 Here are the providers we currently support within Knock. We're adding more each week. If you want us to add a new provider to this list, please let us know through the feedback button at the top of this page.
 
+<!-- Reminder: when adding a new integration provider to this list, please be sure to update the `getting-started/what-is-knock.mdx` file to include the new provider in the accordion. -->
+
 ### Email
 
 - [AWS SES](/integrations/email/aws-ses)

--- a/content/integrations/overview.md
+++ b/content/integrations/overview.md
@@ -87,8 +87,6 @@ Channel groups solve this problem. With a channel group, you can combine multipl
 
 Here are the providers we currently support within Knock. We're adding more each week. If you want us to add a new provider to this list, please let us know through the feedback button at the top of this page.
 
-<!-- Reminder: when adding a new integration provider to this list, please be sure to update the `getting-started/what-is-knock.mdx` file to include the new provider in the accordion. -->
-
 ### Email
 
 - [AWS SES](/integrations/email/aws-ses)


### PR DESCRIPTION
### Description

OneSignal was missing from the list of push channels supported on the [What is Knock?](https://docs.knock.app/getting-started/what-is-knock#channels) page, and this PR is to add it in: https://docs-git-rt-add-onesignal-to-channels-knocklabs.vercel.app/getting-started/what-is-knock#channels