### PR TITLE
chore: update trigger step anchor

### DIFF
--- a/content/designing-workflows/step-conditions.mdx
+++ b/content/designing-workflows/step-conditions.mdx
@@ -31,7 +31,7 @@ In this guide, we cover features specific to step conditions, most importantly m
 
 ### Trigger step conditions
 
-A [trigger step](/designing-workflows/overview#the-trigger-step#the-trigger-step) can have one or more step conditions, which will be evaluated on the trigger of the workflow for the recipient. When the conditions evaluate to false then the workflow **will be halted** and no other steps will be executed.
+A [trigger step](/designing-workflows/overview#the-trigger-step) can have one or more step conditions, which will be evaluated on the trigger of the workflow for the recipient. When the conditions evaluate to false then the workflow **will be halted** and no other steps will be executed.
 
 ### Other step conditions
 


### PR DESCRIPTION
### Description

Looks like the anchor `#the-trigger-step` was added twice, so it wasn't directing the user to that location on the page. 