### PR TITLE
chore: add multiple object grant example

### DIFF
--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -306,7 +306,7 @@ We've made it easy for you to tell Knock which resources your users should have 
 
 ### With the Node SDK
 
-You'll need to generate a token for your user that includes access to the tenant storing the Slack access token as well as any recipient objects storing Slack channel data described in [SlackKit ](/integrations/chat/slack/overview#channel-data-requirements).
+You'll need to generate a token for your user that includes access to the tenant storing the Slack access token as well as any recipient objects storing Slack channel data described in [SlackKit ](/integrations/chat/slack/overview#channel-data-requirements). If you need to enable access to multiple recipient objects, you can include multiple grants in the user token.
 
 Example:
 
@@ -327,6 +327,10 @@ await Knock.signUserToken("user-1", {
     ]),
     Knock.buildUserTokenGrant(
       { type: "object", id: "dinosaurs-loose", collection: "videos" },
+      [Grants.ChannelDataRead, Grants.ChannelDataWrite],
+    ),
+    Knock.buildUserTokenGrant(
+      { type: "object", id: "raptor-feeding-guide", collection: "videos" },
       [Grants.ChannelDataRead, Grants.ChannelDataWrite],
     ),
   ],


### PR DESCRIPTION
### Description

In some cases, you might need to include multiple object recipient resource grants on one token, either because they appear on the same page (as requested by someone in Slack) or because you're minting the token at a place in the app that might not know exactly which resource I need to write to, but have permissions to write to more than one. 
