### PR TITLE
fix: slack endpoint documentation (KNO-6503)

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -6423,51 +6423,32 @@ A `BulkOperation`
   />
 </Attributes>
 
-### Body parameters
+### Query parameters
 
 <Attributes>
   <Attribute
-    name="access_token_object"
-    type="AccessTokenObject"
-    description="An object containing the `object_id` and `collection` of the Object or Tenant that contains the access token for Slack."
-  />
-</Attributes>
-
-#### AccessTokenObject
-
-<Attributes>
-  <Attribute
-    name="objectId"
+    name="access_token_object[object_id]"
     type="string"
     description="ID of the Object or Tenant."
   />
   <Attribute
-    name="collection"
+    name="access_token_object[collection]"
     type="string"
     description="Collection of the Object or Tenant. If Tenant, should be `$tenants`."
   />
 </Attributes>
 
-### Response
+### Returns
 
-Connection data from the Slack API.
+- `200` Connection data from the Slack API.
+- `403` When no access token is set for the given object.
 
 </ContentColumn>
 <ExampleColumn>
 
-```json
-// Request (GET to /providers/slack/:channel_id)
-
-{
-  "access_token_object": {
-    "object_id": "jurassic-park",
-    "collection": "$tenants"
-  }
-}
-```
 
 ```json
-// Success response
+// Connection data success response
 
 {
   "connection": {
@@ -6482,13 +6463,24 @@ Connection data from the Slack API.
 ```
 
 ```json
-// Error response
+// Connection data error response
 
 {
   "connection": {
     "ok": false,
     "error": "invalid_auth"
   }
+}
+```
+
+```json
+// Missing access token error response
+
+{
+  "code": "authorization",
+  "message": "Access token not set.",
+  "status": 403,
+  "type": "authentication_error"
 }
 ```
 
@@ -6521,62 +6513,40 @@ Get a list of the Slack channels for the access token stored in the given access
   />
 </Attributes>
 
-### Body parameters
+### Query parameters
 
 <Attributes>
   <Attribute
-    name="access_token_object"
-    type="AccessTokenObject"
-    description="An object containing the `object_id` and `collection` of the Object or Tenant that contains the access token for Slack."
-  />
-  <Attribute
-    name="query_options"
-    type="object"
-    description="An optional object containing the query options passed to Slack. See Slack documentation for options: https://api.slack.com/methods/conversations.list#arg_cursor"
-  />
-</Attributes>
-
-#### AccessTokenObject
-
-<Attributes>
-  <Attribute
-    name="objectId"
+    name="access_token_object[object_id]"
     type="string"
     description="ID of the Object or Tenant."
   />
   <Attribute
-    name="collection"
+    name="access_token_object[collection]"
     type="string"
     description="Collection of the Object or Tenant. If Tenant, should be `$tenants`."
   />
+  <Attribute
+    name="query_options[:option]"
+    type="string"
+    description="An optional query option passed to Slack. One of `cursor`, `exclude_archived`, `limit`, `team_id`, `types`. 
+    See Slack documentation for more information: https://api.slack.com/methods/conversations.list#arg_cursor"
+    typeSlug="https://api.slack.com/methods/conversations.list#arg_cursor"
+  />
 </Attributes>
 
-### Response
+### Returns
 
-List of partial data about the Slack channels requested.
+- `200` List of partial data about the Slack channels requested.
+- `403` When no access token is set for the given object.
 
 </ContentColumn>
 <ExampleColumn>
 
 ```json
-// Request (GET to /providers/slack/:channel_id)
+// Success response
 
 {
-  "access_token_object": {
-    "object_id": "jurassic-park",
-    "collection": "$tenants"
-  },
-  "query_options": {
-    "limit": "200",
-    "exclude_archived": "true"
-  }
-}
-```
-
-```json
-// Response
-
-%{
   "slack_channels": {
     "name": "general",
     "id": "CMYK1234",
@@ -6585,6 +6555,16 @@ List of partial data about the Slack channels requested.
     "context_team_id": "",
   },
   "next_cursor": ""
+}
+```
+```json
+// Missing access token error response
+
+{
+  "code": "authorization",
+  "message": "Access token not set.",
+  "status": 403,
+  "type": "authentication_error"
 }
 ```
 
@@ -6599,7 +6579,7 @@ Revoke an access token from Slack and remove it from the access token object.
 
 <Endpoint
   name="channels"
-  method="GET"
+  method="PUT"
   path="/providers/slack/:channel_id/revoke_access"
 />
 
@@ -6617,49 +6597,45 @@ Revoke an access token from Slack and remove it from the access token object.
   />
 </Attributes>
 
-### Body parameters
+### Query parameters
 
 <Attributes>
-  <Attribute
-    name="access_token_object"
-    type="AccessTokenObject"
-    description="An object containing the `object_id` and `collection` of the Object or Tenant that contains the access token for Slack."
-  />
-</Attributes>
-
-#### AccessTokenObject
-
-<Attributes>
-  <Attribute
-    name="objectId"
+   <Attribute
+    name="access_token_object[object_id]"
     type="string"
     description="ID of the Object or Tenant."
   />
   <Attribute
-    name="collection"
+    name="access_token_object[collection]"
     type="string"
     description="Collection of the Object or Tenant. If Tenant, should be `$tenants`."
   />
 </Attributes>
 
+### Returns
+
+- `200` Success response
+- `403` When no access token is set for the given object.
+
 </ContentColumn>
 <ExampleColumn>
 
-```json
-// Request (GET to /providers/slack/:channel_id)
-
-{
-  "access_token_object": {
-    "object_id": "jurassic-park",
-    "collection": "$tenants"
-  }
-}
-```
 
 ```json
 // Success response
 
 "ok"
+```
+
+```json
+// Missing access token error response
+
+{
+  "code": "authorization",
+  "message": "Access token not set.",
+  "status": 403,
+  "type": "authentication_error"
+}
 ```
 
 </ExampleColumn>

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -6446,7 +6446,6 @@ A `BulkOperation`
 </ContentColumn>
 <ExampleColumn>
 
-
 ```json
 // Connection data success response
 
@@ -6552,11 +6551,12 @@ Get a list of the Slack channels for the access token stored in the given access
     "id": "CMYK1234",
     "is_private": "false",
     "is_im": "false",
-    "context_team_id": "",
+    "context_team_id": ""
   },
   "next_cursor": ""
 }
 ```
+
 ```json
 // Missing access token error response
 
@@ -6600,7 +6600,7 @@ Revoke an access token from Slack and remove it from the access token object.
 ### Query parameters
 
 <Attributes>
-   <Attribute
+  <Attribute
     name="access_token_object[object_id]"
     type="string"
     description="ID of the Object or Tenant."
@@ -6619,7 +6619,6 @@ Revoke an access token from Slack and remove it from the access token object.
 
 </ContentColumn>
 <ExampleColumn>
-
 
 ```json
 // Success response

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -6546,13 +6546,15 @@ Get a list of the Slack channels for the access token stored in the given access
 // Success response
 
 {
-  "slack_channels": {
-    "name": "general",
-    "id": "CMYK1234",
-    "is_private": "false",
-    "is_im": "false",
-    "context_team_id": ""
-  },
+  "slack_channels": [
+    {
+      "name": "general",
+      "id": "CMYK1234",
+      "is_private": "false",
+      "is_im": "false",
+      "context_team_id": ""
+    }
+  ],
   "next_cursor": ""
 }
 ```


### PR DESCRIPTION
### Description

This PR updates our API reference for [Slack endpoints](https://docs-6yk682tpc-knocklabs.vercel.app/reference#slack):
- Move body parameters to query parameters
- Remove examples that show required params as a JSON request body
- Document expected response when no `access_token` has been stored in `channel_data` for the given object or tenant
- Update example response for `/channels` endpoint to reflect that it returns a list of `slack_channels`
- Update HTTP method for revoke access endpoint from `GET` -> `PUT`
