### PR TITLE
chore: "on this page" sidebar improvements (KNO-7487)

### DIFF
--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -122,7 +122,10 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
         >
           Edit this page on GitHub &rarr;
         </a>
-        <div id="gradient" className="sticky bottom-0 left-0 right-0 h-24 pointer-events-none bg-gradient-to-t from-white dark:from-gray-900 to-transparent" />
+        <div
+          id="gradient"
+          className="sticky bottom-0 left-0 right-0 h-24 pointer-events-none bg-gradient-to-t from-white dark:from-gray-900 to-transparent"
+        />
       </div>
     </aside>
   );

--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -70,7 +70,7 @@ const HeaderList: React.FC<{ headers: IHeader[]; nesting: number }> = ({
           <Link
             href={`#${h.id}`}
             className={cn({
-              "text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100":
+              "pr-3 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100":
                 true,
             })}
           >
@@ -103,24 +103,27 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
 
   return (
     <aside
-      className="fixed top-30 pl-5 pb-4 w-64 overflow-y-auto"
-      style={{ height: "calc(100vh - 15.8rem)" }}
+      className="fixed top-30 pl-5 w-72 overflow-y-auto"
+      style={{ maxHeight: "calc(100vh - 15rem)" }}
     >
-      <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">
-        On this page
-      </h5>
-      <ul className="space-y-2">
-        <HeaderList headers={headers} nesting={0} />
-      </ul>
-      <div className="my-4 border-t border-gray-200 dark:border-gray-800"></div>
-      <a
-        href={`https://github.com/knocklabs/docs/edit/main/${sourcePath}`}
-        className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-        target="_blank"
-        rel="noreferrer"
-      >
-        Edit this page on GitHub &rarr;
-      </a>
+      <div className="pb-4">
+        <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">
+          On this page
+        </h5>
+        <ul className="space-y-2">
+          <HeaderList headers={headers} nesting={0} />
+        </ul>
+        <div className="my-4 border-t border-gray-200 dark:border-gray-800"></div>
+        <a
+          href={`https://github.com/knocklabs/docs/edit/main/${sourcePath}`}
+          className="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Edit this page on GitHub &rarr;
+        </a>
+        <div id="gradient" className="sticky bottom-0 left-0 right-0 h-24 pointer-events-none bg-gradient-to-t from-white dark:from-gray-900 to-transparent" />
+      </div>
     </aside>
   );
 };

--- a/components/PageNav.tsx
+++ b/components/PageNav.tsx
@@ -104,7 +104,7 @@ const PageNav: React.FC<Props> = ({ title, sourcePath }) => {
   return (
     <aside
       className="fixed top-30 pl-5 w-72 overflow-y-auto"
-      style={{ maxHeight: "calc(100vh - 15rem)" }}
+      style={{ height: "calc(100vh - 15rem)" }}
     >
       <div className="pb-4">
         <h5 className="text-xs uppercase text-gray-900 dark:text-gray-500 font-semibold tracking-wider mb-3">


### PR DESCRIPTION
### Description

This PR includes a few improvements to the "On this page" `<aside>` element that renders a sidebar of the headings on the current page above certain screen widths:

- Increases the width of the sidebar slightly so the instances where we need a horizontal scroll are less likely to occur
- Adds some padding-right to the listed headers so that _when_ horizontal overflow occurs, there is some space on the right side when scrolled all the way to the right
- Slight adjustment to height of the sidebar to make it slightly taller
- Adds a gradient to the bottom of the sidebar so that you can visually tell when there is overflowed content to scroll (in both light and dark mode)
- Wraps the inner content in an additional div so that bottom padding doesn't make the gradient appear above the padding

### Notes

I went back and forth on how fancy to get with this -- we could try to do something that renders conditionally based on whether or not the content overflows the container, for example -- but for simplicity I opted to just go the route of always displaying the gradient and you'll only see it if the content reaches the full container height.

This meant also making a decision about CSS positioning, and whether the gradient div "takes up space" or is a simple overlay. Here I decided to have it take up space at the bottom of the container, because otherwise scrolling all the way to the bottom (or, in instances where there is no overflow but the content takes up the full height of the element) would mean that some of the content at the bottom would always be behind the gradient.

These are definitely compromises, but I wasn't sure if this was worth totally re-working in the short term.

### Screenshots

<img width="600" alt="image" src="https://github.com/user-attachments/assets/561a0d9f-e7f3-4358-ad5b-a4685cf1aa8d" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/97d4d17a-4ca1-4111-8cde-12672d4665f4" />
