### PR TITLE
chore: add conditions backlinks and examples to mapi reference (KNO-7163)

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -324,7 +324,8 @@ All workflow steps, regardless of its type, share a common set of core attribute
   />
   <Attribute
     name="conditions"
-    type="object"
+    type="object (optional)"
+    typeSlug="/concepts/conditions#modeling-conditions"
     description="A conditions object that describes one or more conditions to be met in order for the step to be executed."
   />
 </Attributes>
@@ -338,7 +339,15 @@ All workflow steps, regardless of its type, share a common set of core attribute
   "ref": "delay_1",
   "name": "Delay step",
   "description": null,
-  "conditions": null
+  "conditions": {
+    "all": [
+      {
+        "variable": "recipient.role",
+        "operator": "equal_to",
+        "argument": "admin"
+      }
+    ]
+  }
 }
 ```
 
@@ -950,6 +959,7 @@ Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`
   <Attribute
     name="conditions"
     type="object"
+    typeSlug="/concepts/conditions#modeling-conditions"
     description="A set of conditions to be evaluated for this branch."
   />
 </Attributes>
@@ -965,7 +975,15 @@ Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`
       "name": "Pro plan",
       "terminates": false,
       "steps": [],
-      "conditions": {}
+      "conditions": {
+        "all": [
+          {
+            "variable": "recipient.role",
+            "operator": "equal_to",
+            "argument": "admin"
+          }
+        ]
+      }
     },
     {
       "name": "Default",


### PR DESCRIPTION
### Description

This PR adds a bit more context on how to model `conditions` when working with the mAPI: backlinks to the usage explanation in the documentation, and better examples in the JSON.
