### PR TITLE
chore: remove "notify call" callout and add preferences backlink

### DIFF
--- a/content/concepts/tenants.mdx
+++ b/content/concepts/tenants.mdx
@@ -138,7 +138,7 @@ To support this use case within Knock, we can pass a `tenant` identifier into ou
 
 <MultiLangCodeBlock
   snippet="workflows.trigger-with-tenant"
-  title="Notify with tenant"
+  title="Trigger a workflow with a tenant"
 />
 
 When retrieving our feed to be displayed, we can then scope the feed to only show items relevant

--- a/content/send-notifications/triggering-workflows.mdx
+++ b/content/send-notifications/triggering-workflows.mdx
@@ -7,18 +7,7 @@ section: Send notifications
 
 Workflows that you design within Knock are triggered from within your codebase by calling the workflow trigger endpoint.
 
-<Callout
-  emoji="🌠"
-  text={
-    <>
-      <span className="font-bold">Knock terminology clarification.</span>{" "}
-      Throughout our documentation, you'll see us refer to notify calls and
-      workflow triggers. These terms are synonymous.
-    </>
-  }
-/>
-
-It's important to realize that triggering a workflow in Knock may result in no messages being sent to your recipients. This is because your recipients may have indicated through their `preferences` that they don't wish to be notified by workflows of that type. The good news is that Knock handles all preference-based opt-outs for you automatically.
+It's important to realize that triggering a workflow in Knock may result in no messages being sent to your recipients. This is because your recipients may have indicated through their `preferences` that they don't wish to be notified by workflows of that type. The good news is that Knock handles all [preference-based opt-outs](/preferences/overview) for you automatically.
 
 ## Triggering workflows
 


### PR DESCRIPTION
### Description

This PR removes the "terminology clarification" callout on the [Triggering workflows page](https://docs-git-mk-remove-notify-call-reference-knocklabs.vercel.app/send-notifications/triggering-workflows). I double-checked the full docs site, and the only place that we still referenced a "notify call" was in the title of a code example, which this PR also updates.

While I was here, I also added a backlink to the Preferences overview page from the mention of automatically evaluating user preferences.

What's being removed:
<img width="743" alt="image" src="https://github.com/user-attachments/assets/ee6fa935-30d5-4947-912e-45e216924535" />
