### PR TITLE
fix: rate limits of Slack endpoints

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -6411,7 +6411,7 @@ A `BulkOperation`
 
 ### Rate limit
 
-<RateLimit tier={3} />
+<RateLimit tier={2} />
 
 ### Path parameters
 
@@ -6500,7 +6500,7 @@ Get a list of the Slack channels for the access token stored in the given access
 
 ### Rate limit
 
-<RateLimit tier={3} />
+<RateLimit tier={2} />
 
 ### Path parameters
 
@@ -6587,7 +6587,7 @@ Revoke an access token from Slack and remove it from the access token object.
 
 ### Rate limit
 
-<RateLimit tier={3} />
+<RateLimit tier={2} />
 
 ### Path parameters
 


### PR DESCRIPTION
All of our API endpoints related to Slack are actually rate limited with Tier 2, not Tier 3.