### PR TITLE
fix: fix typo on deep link docs

### DIFF
--- a/content/sdks/android/deep-links.mdx
+++ b/content/sdks/android/deep-links.mdx
@@ -15,7 +15,7 @@ section: SDKs
 
 ## 2. Include a deep link in your Knock message payload:
 
-- In you message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
+- In your message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
 - This can also be done in your Knock Dashboard in your [Payload overrides](https://docs.knock.app/integrations/push/overview#push-overrides).
 
 ![Deep link payload override](/images/deep-link-payload-override.png)

--- a/content/sdks/ios/deep-links.mdx
+++ b/content/sdks/ios/deep-links.mdx
@@ -17,7 +17,7 @@ section: SDKs
 
 ## 2. Include a deep link in your Knock message payload:
 
-- In you message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
+- In your message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
 - This can also be done in your Knock Dashboard in your [Payload overrides](https://docs.knock.app/integrations/push/overview#push-overrides).
 
 ![Deep link payload override](/images/deep-link-payload-override.png)


### PR DESCRIPTION
### Description

I noticed a small typo that this PR fixes (you -> your).