### PR TITLE
chore (kno-7597): add FAQs to tracking docs

### DIFF
--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -213,3 +213,22 @@ Here are the email open tracking limitations we are currently aware of:
     }}
   ></iframe>
 </div>
+<br />
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="My channel provider supports link or engagement tracking natively. What are the advantages of using Knock tracking?">
+    Many of our [supported integrations](/integrations/overview) offer native link or engagement tracking that can be enabled in your Knock dashboard under that integration's [channel settings](/concepts/channels#channel-settings). Knock supports enabling these native tracking solutions alongside or instead of Knock tracking. 
+    
+    There are several Knock-tracking-specific features to keep in mind when configuring your channel's tracking settings:
+
+    - **Cross-channel reporting.** Knock link and open tracking allows you to analyze user engagement across all of your delivery channels in a single tool.
+    - **Step conditions.** With Knock tracking, you can use message engagement events to [power conditional logic in your workflows](/designing-workflows/step-conditions).
+    - **Capture events via webhooks.** When Knock tracking is enabled, you can power other event-based flows in your product with Knock's [outbound webhooks](/send-and-manage-data/outbound-webhooks).
+
+  </Accordion>
+  <Accordion title="Can my provider report engagement metrics back to Knock?">
+    No. While some providers offer native open and link tracking that can be enabled in your Knock dashboard under that integration's [channel settings](/concepts/channels#channel-settings), these native tracking solutions will not report back to Knock and do not enable the same functionality.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

This PR adds an FAQ section to our docs on link and click tracking, in order to clarify the difference between Knock tracking and provider-specific tracking.

https://docs-git-mk-tracking-clarifications-knocklabs.vercel.app/send-notifications/tracking#frequently-asked-questions

### Screenshots
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9212cea0-bb8e-4b69-a4a2-9d70f53f1509" />

### To-do

We need to add provider-specific documentation around this topic as well. I was originally going to do that as part of this PR, but as I started to dig in I found that we're pretty inconsistent in how we document even basic things like "Features" (i.e. does a given provider support Knock tracking vs. provider tracking) and "Provider settings" for each provider. I'm going to do a follow-on PR to attempt to address these inconsistencies, in the interest of shipping this FAQ more quickly. 

Example issues:
- Chat/SMS providers don't seem to have any of this documented on the provider-specific pages; rather, we document features on the Overview pages. Not sure whether this is intentional, but I think it would be less-confusing to have these replicated per-provider, for easy reference.
- There are inconsistencies with how we denote these features under **Provider settings**; AWS SES, for example, does not have any native tracking, but we document it the same way we do for providers that do. Providers which _do_ support both do not document both settings from the channel configuration.
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cd695a4f-6915-480f-9706-c6a35a79fc33" />
