### PR TITLE
chore: clarify conditions usage for preferences

### DIFF
--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -141,6 +141,20 @@ In cases where data is not found at the path given by the variable, Knock falls 
 
 ### Combining conditions
 
+<Callout
+  emoji="📤"
+  text={
+    <>
+      <span className="font-bold">Preference conditions note.</span> The
+      following syntax does not apply to preference conditions. See the{" "}
+      <a href="/preferences/preference-conditions#frequently-asked-questions">
+        preference conditions FAQs
+      </a>{" "}
+      for more information on combining multiple conditions on a preference.
+    </>
+  }
+/>
+
 You can combine multiple conditions together via either `AND` or `OR` operators.
 
 - `AND` combined conditions require all conditions to be true for the evaluation to pass.

--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -9,9 +9,9 @@ Preference conditions are [Knock condition models](/send-and-manage-data/conditi
 
 ## Overview
 
-Typically, a `PreferenceSet` evaluates to boolean values representing if your recipient has opted in or out of receiving notifications on a given channel, workflow, or category.
+Typically, a `PreferenceSet` evaluates to boolean values representing whether your recipient has opted in or out of receiving notifications on a given channel, workflow, or category.
 
-With preference conditions you can add additional custom expressions to a `PreferenceSet`, where the notification is only sent if all preferences (including the preference condition statement) evaluate to `true`.
+With preference conditions you can add additional custom expressions to a `PreferenceSet`, where the notification is only sent if all preferences (including every condition in the preference `conditions` list) evaluate to `true` at runtime.
 
 <Callout
   emoji="⚠️"
@@ -85,5 +85,29 @@ Here's how to set preference conditions for a user.
   </Accordion>
   <Accordion title="How do I debug preference conditions?">
     Knock will capture conditions evaluation details for all preference conditions resolved while executing your workflows. See the [guide on debugging conditions](/send-and-manage-data/conditions#debugging-conditions) for more info.
+  </Accordion>
+  <Accordion title="Can I use multiple conditions on a single preference?">
+    Yes. You can use multiple conditions within a single preference `conditions` array. Note that all conditions in the array must evaluate to `true` in order for the notification to be sent; this is a logical `AND` operation.
+
+    ```json title="An example of multiple conditions on a single preference"
+    {
+      "conditions": [
+        {
+          "variable": "recipient.muted_dinos",
+          "operator": "not_contains",
+          "argument": "data.dino"
+        },
+        {
+          "variable": "recipient.id",
+          "operator": "not_equal_to",
+          "argument": "actor.id"
+        }
+      ]
+    }
+    ```
+
+  </Accordion>
+  <Accordion title="Can I set OR conditions on a preference?">
+    No, this is not currently supported. Each condition in the `conditions` array must evaluate to `true` for a notification to be sent.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

This PR clarifies that preference conditions only support a list of `conditions` that must _all_ evaluate to `true` (i.e. a logical `AND` operation), and that we don't allow `OR` operations or the `any`/`all` syntax from step and channel conditions within the preferences model.

- [Preference conditions](https://docs-git-mk-prefs-conditions-callouts-knocklabs.vercel.app/preferences/preference-conditions)
- [Combining conditions callout](https://docs-git-mk-prefs-conditions-callouts-knocklabs.vercel.app/concepts/conditions#combining-conditions) 
