### PR TITLE
fix: update link to direct to preference conditions page

### DIFF
--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -22,7 +22,7 @@ You can use conditions in three areas of the Knock model:
 
 1. [**Step conditions**](/designing-workflows/step-conditions) — Used to determine if a single step in one of your workflows should execute during each workflow run. For example, only send an email if the preceding in-app notification has not yet been read or seen.
 2. [**Channel conditions**](/integrations/overview#channel-conditions) — Used to determine if any step using the given channel should execute across all workflow runs. For example, only execute your Postmark email channel steps in your production environment.
-3. [**Preference conditions**](/send-and-manage-data/preferences#preference-conditions) — Used to determine the complete set of preferences available to the current workflow run. For example, allow a recipient to mute notifications for specific resources in your product.
+3. [**Preference conditions**](/preferences/preference-conditions) — Used to determine the complete set of preferences available to the current workflow run. For example, allow a recipient to mute notifications for specific resources in your product.
 
 Each of these three cases share the same underlying data model and UI editor, which we outline in detail here.
 


### PR DESCRIPTION
### Description

The link for preference conditions wasn't updated on the conditions page when we split the preference pages out. This updates the link to direct users to the preference conditions page. 