### PR TITLE
fix(KNO-7658): fix return type of updateConnectedChannels

### DIFF
--- a/content/sdks/react/reference.mdx
+++ b/content/sdks/react/reference.mdx
@@ -1063,7 +1063,7 @@ This hook returns partial data about the Slack channels that are present on the 
   />
   <Attribute
     name="updateConnectedChannels"
-    type="(connectedChannels: SlackChannelConnection[]) => void;"
+    type="(connectedChannels: SlackChannelConnection[]) => Promise<void>;"
     description="Function to set the connected channels. Updates all connected channels for the object, does not add to the current ones."
   />
   <Attribute


### PR DESCRIPTION
### Description

As per [my comment](https://github.com/knocklabs/javascript/pull/361#discussion_r1919216141) on knocklabs/javascript#361, `updateConnectedChannels` returns a promise.

### Tasks

[KNO-7658](https://linear.app/knock/issue/KNO-7658/[slackkit]-fix-useconnectedslackchannels-types)
