### PR TITLE
chore: update status code 400 -> 4xx because we return additional codes

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -412,7 +412,7 @@ Knock uses standard [HTTP response codes](https://developer.mozilla.org/en-US/We
 <span className="mb-6">
   {"Here's a list of common "}
   <span className="bg-code-background text-code rounded text-sm font-normal py-0.75 px-1.5 font-mono inline-block border-1 border-gray-200">
-    400
+    4xx
   </span>
   {
     " error codes you may encounter while working with the Knock API. We also provide additional context on how to resolve them."


### PR DESCRIPTION
### Description

We sometimes return `4xx` status codes that are not explicitly a `400`. This PR updates the explicit `400` mention to be less specific.
