### PR TITLE
chore: update message delivery statuses

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -825,7 +825,7 @@ A message is a notification delivered on a particular channel to a user.
   <Attribute
     name="status"
     type="string"
-    description="The delivery status for the message. One of `queued`, `sent`, `delivered`, `delivery_attempted`, `undelivered`, `seen`, `unseen`."
+    description="The delivery status for the message. One of `queued`, `sent`, `delivered`, `delivery_attempted`, `undelivered`, `not_sent`, `bounced`."
   />
   <Attribute
     name="engagement_statuses"


### PR DESCRIPTION
### Description

Slack community user pointed out that the `status` options in API reference don't match what's called out on message status docs. I cross-referenced with `MessageStatus` type in Node SDK and updated the API ref: https://github.com/knocklabs/knock-node/blob/f08210b60707f862a21de6b15d1856c3ce47e262/src/resources/messages/interfaces.ts#L64
