### PR TITLE
feat(KNO-7687): add ms_teams_team_id to MS Teams channel data

### DIFF
--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -144,6 +144,7 @@ An `MsTeamsConnection` can have one of two schemas, depending on whether you're 
     | Property            | Type     | Description                    |
     | ------------------- | -------- | ------------------------------ |
     | ms_teams_tenant_id  | `string` | A Microsoft Entra tenant ID    |
+    | ms_teams_team_id    | `string` | A Microsoft Teams team ID      |
     | ms_teams_channel_id | `string` | A Microsoft Teams channel ID   |
     | ms_teams_user_id    | `string` | A Microsoft Teams user ID      |
 

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -216,6 +216,7 @@ Channel data requirements for each provider are listed below. Typically `channel
     | Property            | Type     | Description                    |
     | ------------------- | -------- | ------------------------------ |
     | ms_teams_tenant_id  | `string` | A Microsoft Entra tenant ID    |
+    | ms_teams_team_id    | `string` | A Microsoft Teams team ID      |
     | ms_teams_channel_id | `string` | A Microsoft Teams channel ID   |
     | ms_teams_user_id    | `string` | A Microsoft Teams user ID      |
 


### PR DESCRIPTION
### Description

knocklabs/switchboard#3434 added `ms_teams_team_id` to the channel data for MS Teams channels, and this PR updates the docs accordingly.

### Tasks

[KNO-7687](https://linear.app/knock/issue/KNO-7687/[switchboard]-store-ms-teams-team-id-in-channel-data)
