### PR TITLE
chore(kno-7451): update docs to use workflow trigger wording instead of event action mappings

### DIFF
--- a/content/integrations/sources/http.mdx
+++ b/content/integrations/sources/http.mdx
@@ -5,7 +5,7 @@ section: Integrations > Sources
 layout: integrations
 ---
 
-The HTTP source creates a generic event ingestion endpoint that you can use to stream events from your service, or a third-party platform into Knock. The events you stream into the HTTP source can then be used to trigger Knock notification workflows via configured action mappings.
+The HTTP source creates a generic event ingestion endpoint that you can use to stream events from your service, or a third-party platform into Knock. The events you stream into the HTTP source can then be used to trigger Knock notification workflows.
 
 Knock can receive any structured event data via the HTTP source, as long as you can format JSON and make an HTTP request from the service that produces or consumes events.
 
@@ -52,19 +52,23 @@ Your events must be structured as JSON with the following schema:
 
 ## Triggering workflows from received events
 
-Received events can be mapped to corresponding workflow triggers via Event actions under each environment's configured source.
+Received events can be configured as workflow triggers directly in the workflow editor. Click on the workflow's trigger step and change the type from "API" to "Source Event." Then you'll be able to select the event and map its properties into the data the workflow needs.
 
-[Read more on configuring event action mappings](/integrations/sources/overview#event-action-mapping)
+[Read more on configuring workflow triggers](/integrations/sources/overview#workflow-triggers)
+
+## Disabling a trigger
+
+Triggers are automatically enabled when you create them. If you want to stop an event from triggering a workflow, you can go to the trigger page and toggle its status to "Inactive." Keep in mind that this will disable that trigger for the current environment only. When you're ready to trigger the workflow again, you can set it back to "Active."
 
 ### Mapping workflow trigger properties
 
-When creating event actions from your events, you can optionally configure the schema mapping Knock will use to map your event properties into the corresponding workflow trigger properties.
+When creating workflow triggers from your events, you can optionally configure the schema mapping Knock will use to map your event properties into the corresponding workflow trigger properties.
 
 To target any items under the `properties` key, prefix the schema mapping with `data.propertyKey`. As an example, if you have a property `properties.recipientId` you would map this as `data.recipientId`.
 
 ## Debugging events
 
-You can see a log of all of the events received per source under **Developers** > **Sources** in the Knock dashboard under the "Logs" page for your configured source. You can also see any event actions that were triggered as part of the event ingestion, and any workflow runs that were triggered.
+You can see a log of all of the events received per source under **Developers** > **Sources** in the Knock dashboard under the "Logs" page for your configured source. You can also see any workflow triggers that were configured as part of the event ingestion, and any workflow runs that were triggered.
 
 ## Frequently asked questions
 

--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -36,7 +36,7 @@ Knock currently supports the following sources:
 
 _Need us to support another platform? [Let us know!](mailto:support@knock.app?subject=Integration%20Source%20Request)_
 
-You can configure sources from the **Integrations** > **Sources** page for your account. Initial creation of a source is managed at the account-level of your Knock account, though you'll configure any specific events and their mappings to your notification workflows within your Knock environments.
+You can configure sources from the **Integrations** > **Sources** page for your account. Initial creation of a source is managed at the account-level of your Knock account, though you'll configure any specific events and their workflow triggers within your Knock environments.
 
 ![A screenshot of where to find the Integrations - Sources page for your account](/images/sources/overview.png)
 
@@ -57,26 +57,25 @@ Knock will translate the incoming events from each source into a common format t
 - `data`. The primary contents of the event, e.g. for a Segment `track` with some associated `properties`, Knock would use those `properties` to set the `data` field for the event.
 - `event`. The original event, as originally received by Knock.
 
-### Event-action mappings
+### Workflow triggers
 
-When a source sends an event to a Knock environment, Knock will match that event with any configured event-action mappings in that environment.
+When Knock receives an event from an integration source, it will check for any workflows that have been configured to be triggered by that event in that environment.
 
-You can have any number of mappings for each event (e.g. if the same event should trigger more than one workflow).
-If there is no mapping matching that event, the event is logged but no action is taken.
+You can have any number of workflows triggered by each event. If there is no workflow configured to be triggered by that event, the event is logged but no action is taken.
 
 After configuring a source in Knock and in the source itself (e.g. adding Knock as a destination in your CDP), events will start to flow into your Knock environment.
 
-You can then select the event you want to trigger actions in Knock, and configure it accordingly.
+You can then select an event and connect it to a workflow as its trigger.
 
 <Callout
   emoji="🚨"
   text={
     <>
       <span className="font-bold">
-        For workflow trigger action mappings, no more than 1000 recipients can
+        For workflow triggers, no more than 1000 recipients can
         be included in each event.
       </span>{" "}
-      If you exceed this limit, Knock will not process your action mappings and
+      If you exceed this limit, Knock will not process your workflow trigger and
       instead generate an error log. <br />
       <br />
       If you need to manage a large list of recipients you might want to

--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -54,13 +54,13 @@ You will need to create a RudderStack destination for each Knock environment tha
 
 ## Viewing RudderStack track events in Knock
 
-Once your RudderStack destination is set up all events you trigger from the RudderStack source will be forwarded to Knock. Unique events will appear in your list of events under the Source so that you can set up actions to trigger your workflows.
+Once your RudderStack destination is set up all events you trigger from the RudderStack source will be forwarded to Knock. Unique events will appear in your list of events under the Source so that you can set up triggers for your workflows.
 
 From the source environment configuration page click the "View in environment" button on one of the source environments. You'll be taken to the RudderStack source in the environment you selected and you should see events sent. If you don't, try clicking the refresh button on the top of the list to refetch any incoming events.
 
-## Connecting a track event to an action
+## Triggering workflows from received events
 
-You can add a **track event** as a trigger to your workflow directly from the workflow builder. Click on the workflow's trigger step and change the type from "API" to "Event." Then you'll be able to select the event and map its properties into the data the workflow needs.
+You can add a **track event** as a trigger to your workflow directly from the workflow builder. Click on the workflow's trigger step and change the type from "API" to "Source Event." Then you'll be able to select the event and map its properties into the data the workflow needs.
 
 <Callout
   emoji="✨"
@@ -74,7 +74,7 @@ You can add a **track event** as a trigger to your workflow directly from the wo
           <code>{eventPayload}</code>
         </pre>
       </div>
-      and you wanted the commenter from the action to appear as the{" "}
+      and you wanted the commenter from the event to appear as the{" "}
       <span className="font-bold">Actor</span> in the workflow, then in the{" "}
       <span className="font-bold">Actor</span> field you would write{" "}
       <code>data.commenter.id</code> to supply their ID as the actor.
@@ -82,27 +82,12 @@ You can add a **track event** as a trigger to your workflow directly from the wo
   }
 />
 
-## Committing the event action configuration
+[Read more on configuring workflow triggers](/integrations/sources/overview#workflow-triggers)
 
-Event action configurations are stored in the commit history, just like workflows and email layouts. Once you're happy with the mapping, you can save it and commit it to your development environment using the same commit button as your workflow. When you're ready you can publish this event action configuration to your other environments from the commit page.
 
-<Callout
-  emoji="✨"
-  text={
-    <>
-      <span className="font-bold">
-        Committing actions that trigger workflows.
-      </span>{" "}
-      Keep in mind that when you commit your workflows to development and
-      publish them to other environments, you'll have to do the same with your
-      actions to make them trigger that workflow in those environments as well.
-    </>
-  }
-/>
+## Disabling a trigger
 
-## Disabling an action
-
-Actions are automatically enabled when you create them. If you want to stop an event from triggering an action, you can go to the action page and toggle its status to "Inactive." Keep in mind that this will disable that action for the current environment only. When you're ready to trigger the action again, you can set it back to "Active."
+Triggers are automatically enabled when you create them. If you want to stop an event from triggering a workflow, you can go to the trigger page and toggle its status to "Inactive." Keep in mind that this will disable that trigger for the current environment only. When you're ready to trigger the workflow again, you can set it back to "Active."
 
 ## Enabling Identify Events
 

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -30,7 +30,7 @@ To start routing your Segment events to Knock, click the "Create Source" button 
 />
 
 <Steps>
-  <Step title="Add webhook destination in Segment"> 
+  <Step title="Add webhook destination in Segment">
     In your Segment workspace, navigate to the **Destinations** tab and click "Add Destination." From here, search for **Webhooks** or navigate to **Raw Data** in the sidebar and click the "Webhooks (Actions)" option. This is the destination type we'll use for Knock.
     ![Configure webhooks](/images/configure-webhooks.png)
   </Step>
@@ -57,32 +57,30 @@ To start routing your Segment events to Knock, click the "Create Source" button 
 
 ## Viewing Segment track events in Knock
 
-Once your Segment destination is set up, all events you trigger from the Segment source will be forwarded to Knock. Unique events will appear in your list of events under the Source so that you can set up actions to trigger your workflows.
+Once your Segment destination is set up, all events you trigger from the Segment source will be forwarded to Knock. Unique events will appear in your list of events under the Source so that you can set up triggers for your workflows.
 
 From the source environment configuration page, click the "View in environment" button on one of the source environments. You'll be taken to the Segment source in the environment you selected, and you should see events sent. If you don't, try clicking the refresh button at the top of the list to refetch any incoming events.
 
-## Connecting a track event to a workflow
+## Triggering workflows from received events
 
-To start sending notifications using your Segment track event, you'll need to connect it to a workflow.
-
-You can do this directly within the workflow builder by selecting a trigger type of **event** and selecting the event. Once you've selected the event, you can map its properties to any of Knock's workflow parameters, including `recipients`, `actor`, `tenant`, and `cancellation_key`.
+You can add a **track event** as a trigger to your workflow directly from the workflow builder. Click on the workflow's trigger step and change the type from "API" to "Source Event." Then you'll be able to select the event and map its properties into the data the workflow needs.
 
 <Callout
   emoji="✨"
   text={
     <>
-      <span className="font-bold">Using event data in workflow trigger mappings.</span> When connecting an event to a workflow, you can use any data available within the event payload in the workflow's parameters. For example, if your payload looks like this:
+      <span className="font-bold">Using event data in workflow triggers.</span> When connecting an event to a workflow, you can use any data available within the event payload in the workflow's parameters. For example, if your payload looks like this:
       <div className="mt-2 mb-2">
         <pre>
           <code>{eventPayload}</code>
         </pre>
       </div>
-      and you wanted the commenter from the action to appear as the{" "}
+      and you wanted the commenter from the event to appear as the{" "}
       <code>actor</code> in the workflow, then in the{" "}
       <code>actor</code> field, you would write{" "}
       <code>properties.commenter.id</code> to supply their ID as the actor.
       <br/><br/>
-      If you wanted to supply the event's <code>userId</code> as the workflow's recipient, 
+      If you wanted to supply the event's <code>userId</code> as the workflow's recipient,
       you'd write <code>userId</code> in the <code>Recipients</code> field.
       <br/><br/>
 
@@ -94,27 +92,12 @@ You can do this directly within the workflow builder by selecting a trigger type
 }
 />
 
-## Committing the event action configuration
+[Read more on configuring workflow triggers](/integrations/sources/overview#workflow-triggers)
 
-Event action configurations are stored in the commit history, just like workflows and email layouts. Once you're happy with the mapping, you can save it and commit it to your development environment using the same commit button as your workflow. When you're ready, you can publish this event action configuration to your other environments from the commit page.
 
-<Callout
-  emoji="✨"
-  text={
-    <>
-      <span className="font-bold">
-        Committing actions that trigger workflows.
-      </span>{" "}
-      Keep in mind that when you commit your workflows to development and
-      publish them to other environments, you'll have to do the same with your
-      actions to make them trigger that workflow in those environments as well.
-    </>
-  }
-/>
+## Disabling a trigger
 
-## Disabling an action
-
-Actions are automatically enabled when you create them. To stop an event from triggering an action, go to the action page and toggle its status to **Inactive.** Keep in mind that this will only disable that action for the current environment. When you're ready to trigger the action again, you can set it back to **Active.**
+Triggers are automatically enabled when you create them. If you want to stop an event from triggering a workflow, you can go to the trigger page and toggle its status to "Inactive." Keep in mind that this will disable that trigger for the current environment only. When you're ready to trigger the workflow again, you can set it back to "Active."
 
 ## Enabling Identify events
 
@@ -227,17 +210,18 @@ You can learn more about inline identification in [our guide on identifying reci
 <AccordionGroup>
   <Accordion title="Can I use a single Segment event to trigger multiple workflows?">
     Yes. Under the **Developers** > **Sources** section in your Knock dashboard,
-    select an event from Segment to view a list of actions configured for that
-    event. Then, in the upper right-hand corner, click the "Create action"
+    select an event from Segment to view a list of triggers configured for that
+    event. Then, in the upper right-hand corner, click the "Create workflow trigger"
     button to select the additional workflow you want this event to trigger,
     then click "Create." You can then make any changes to the schema mapping
-    before saving and committing this new action to your Development
-    environment.
+    before saving and committing the workflow with its new trigger.
   </Accordion>
   <Accordion title="Can I use multiple different Segment events to trigger the same workflow?">
     Yes. To do so, go to the **Developers** > **Sources** section in your Knock
-    dashboard, select an event, and then click the "Create action" button in the
+    dashboard, select an event, and then click the "Create workflow trigger" button in the
     upper right-hand corner. You will choose the same workflow from the **Create
-    workflow trigger mapping** modal.
+    workflow trigger** modal.
   </Accordion>
 </AccordionGroup>
+
+

--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -2834,7 +2834,7 @@ A partial object
 <Section title="Commits" slug="commits-overview">
 <ContentColumn>
 
-To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow, a layout, a translation or an event action mapping, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
+To version the changes you make in your environments, Knock uses a commit model. When you make changes to a workflow, a layout, or a translation, you will need to commit them in your development environment, then promote to subsequent environments before those changes will appear in the respective environments.
 
 You can retrieve all commits in a given environment, or show the details of one single commit based on the target commit id.
 

--- a/content/send-notifications/testing-workflows.mdx
+++ b/content/send-notifications/testing-workflows.mdx
@@ -13,14 +13,14 @@ You can use the Knock workflow test runner to test an end-to-end workflow and ve
 
 To use the workflow test runner, navigate to the workflow you want to test and click "Run a test." You'll have options to select the workflow's recipient, actor, tenant, and input any data that you'd like to pass to the workflow.
 
-Two fun things to know about workflow test configuration:
+Two things to know about workflow test configuration:
 
 - The data field is populated using the workflow's schema as defined in your templates. You can click "Reset" at any time to reset the data field to the latest and greatest schema for your workflow.
 - The recipient and actor fields can contain either a [user](/concepts/users) or an [object](/concepts/objects). Use the toggle above the field to switch between these options.
 
 When you run a test workflow, every step of the workflow will execute as it normally would. You'll see an affordance to "View log" when the workflow runs to see its output and what was sent. You can learn more about Knock logs and our debugger [here](/send-notifications/debugging-workflows).
 
-You can also use the workflow test runner to run a test payload for a [source event trigger](/integrations/sources/overview#event-action-mapping). If your workflow is triggered by an event, you will automatically see a JSON payload of the last received event that you can use to run a test. You can edit this payload or click "Fetch the latest event" to get the most recent from your source.
+You can also use the workflow test runner to run a test payload for a [source event trigger](/integrations/sources/overview#workflow-triggers). If your workflow is triggered by an event, you will automatically see a JSON payload of the last received event that you can use to run a test. You can edit this payload or click "Fetch the latest event" to get the most recent from your source.
 
 <Callout
   emoji="🚨"


### PR DESCRIPTION
### Description
Uses the "workflow trigger" wording instead of event action mappings and also removes instructions on how to commit them.

### Tasks
[kno-7451](https://linear.app/knock/issue/KNO-7451/docs)