### PR TITLE
chore: update layout docs for "no layout" option

### DIFF
--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -40,7 +40,7 @@ Here's a quick overview of the system-level variables Knock provides for use in 
 
 ## The Knock default layout
 
-Your Knock account starts with a pre-built default layout. If you navigate into the layouts page of the sidebar, you'll find this default layout. This default layout will be used by all new email templates when they're initially created, so if you want to change the default layout used by your emails, this is the layout to update.
+Your Knock account starts with a pre-built default layout. If you navigate to **Developers** > **Layouts** in the sidebar of your Knock dashboard, you'll find this default layout. This default layout will be used by all new email templates when they're initially created, so if you want to change the default layout used by your emails, this is the one to update.
 
 Click on the "Default" layout in your layouts list to enter the layout editor. You'll start by looking at the pre-built layout that Knock gives you out of the box. You'll find a footer design option in this visual builder where you can add footer links to this pre-built layout for HTML emails. You can update the logo, icon, and brand color of your email layout by going to **Settings** > **Branding** and updating these attributes.
 
@@ -48,17 +48,11 @@ If you'd rather create your own layout from scratch, you can click "Edit in code
 
 Every layout includes the text layout for plaintext emails, and the concept works the same as the HTML layout where the text content of your email template will be injected into the `{{content}}` variable. Click the "Text" tab to switch to the text layout, and edit it as you see fit.
 
-## Working with multiple layouts
+## Selecting a layout for a given email template
 
-You can create multiple layouts in Knock for cases when you want different email notifications to have different styling. As an example, you may want to use one layout for the transactional notifications you send and another layout for any onboarding emails you send users when they first sign up for your product.
+All new email templates created within workflows will use your `default` email layout by default. To change the layout used by a given step, go to the template editor, click the "Template settings" button in the top right corner, and select your layout from the "Email layout" dropdown in the modal that opens. Once you've selected your layout, you can navigate to the preview tab of the template editor to see how your template looks within the context of your selected layout.
 
-### Creating new layouts
-
-To create a new layout, go to the layouts page and click "Create layout." All new layouts start in Knock's visual layout editor but you can override this default by clicking "Edit in code editor."
-
-### Selecting a layout for a given email template
-
-When you have multiple email layouts in Knock, all new email templates created within workflows will use your `default` email layout by default. To change the layout used by a given step, go to the template editor, click the "..." menu in the top right corner, and select "Manage template overrides." You'll see a layout select dropdown in the modal that opens. Once you've selected your layout, you can navigate to the preview tab of the template editor to see how your template looks within the context of your selected layout.
+If you'd like to create an email step in your workflow that contains the full HTML document at the template level (without a layout wrapper), you can select "No layout" in this dropdown.
 
 <Callout
   emoji="🌠"
@@ -84,6 +78,10 @@ If you want to create your own custom email layouts, you can go into the layout 
     </>
   }
 />
+
+### Creating new layouts
+
+To create a new layout, go to **Developers** > **Layouts** and click "Create layout." All new layouts start in Knock's visual layout editor, but you can override this default by clicking "Edit in code editor."
 
 ### Using custom fonts
 
@@ -179,15 +177,7 @@ At notification runtime, your layout and pre-content would be rendered into the 
 
 ### Defining a blank email layout
 
-If you're looking to use a blank or empty email layout you should use the following layout code.
-
-```html title="A minimal blank HTML layout"
-<html>
-  <body>
-    {{ content }}
-  </body>
-</html>
-```
+If you're looking to create an email template in your workflow that doesn't use a layout to wrap the content of your email, you should select "No layout" in the "Email layout" dropdown within your email channel step's template settings.
 
 ## Layouts and the visual template editor
 
@@ -217,6 +207,7 @@ Regardless of the layout you've chosen for a given email step, you'll be able to
         &lt;body&gt;
       </code>{" "}
       tags prior to saving your email template within a Knock workflow.
+      Alternatively, you can select "No layout" on your email template.
     </>
   }
 />


### PR DESCRIPTION
### Description

Updates the Layouts page now that "No layout" is an option on email channel steps. Also fixes wording for some of the buttons etc. that have changed.

https://docs-git-mk-layouts-updates-knocklabs.vercel.app/integrations/email/layouts

### Questions

Should we call out more-loudly that selecting "No layout" and _not_ including a full HTML document in your email's template could cause errors?