### PR TITLE
chore: update datadog metrics list

### DIFF
--- a/content/integrations/extensions/datadog.mdx
+++ b/content/integrations/extensions/datadog.mdx
@@ -101,7 +101,7 @@ Get started with our Datadog dashboard starter kit to start monitoring Knock met
   <Attribute
     name="knock.integration_event_received.total"
     type="count"
-    description="The raw number of events received by Knock from an [integration source](https://docs.knock.app/integrations/sources/overview), segmented by `source_type`."
+    description="The raw number of events received by Knock from an integration source, segmented by `source_type`."
   />
   <Attribute
     name="knock.integration_action_run.total"

--- a/content/integrations/extensions/datadog.mdx
+++ b/content/integrations/extensions/datadog.mdx
@@ -84,6 +84,11 @@ Get started with our Datadog dashboard starter kit to start monitoring Knock met
     description="How many deliveries ended in failure (not retryable), segmented by `channel` and `workflow` key."
   />
   <Attribute
+    name="knock.message_bounced_error.total"
+    type="count"
+    description="How many deliveries ended in non-retryable errors from downstream providers, segmented by `channel` and `workflow` key."
+  />
+  <Attribute
     name="knock.workflow_recipient_run.total"
     type="count"
     description="How many workflow recipient runs have been started, segmented by `workflow` key and `exec_mode`."
@@ -96,7 +101,7 @@ Get started with our Datadog dashboard starter kit to start monitoring Knock met
   <Attribute
     name="knock.integration_event_received.total"
     type="count"
-    description="Hhe raw number of events received by Knock from an [integration source](https://docs.knock.app/integrations/sources/overview), segmented by `source_type`."
+    description="The raw number of events received by Knock from an [integration source](https://docs.knock.app/integrations/sources/overview), segmented by `source_type`."
   />
   <Attribute
     name="knock.integration_action_run.total"


### PR DESCRIPTION
### Description

This PR adds the `knock.message_bounced_error.total` metric to our Datadog documentation, and fixes a typo on one of the other metrics. It also removes an attempted hyperlink from one of the metric descriptions, which doesn't work because markdown is not supported within the `Attribute` component.