### PR TITLE
chore: add per-user property example to alerting guide

### DIFF
--- a/content/guides/alerting.mdx
+++ b/content/guides/alerting.mdx
@@ -133,8 +133,19 @@ Subscriptions can also hold their [own unique properties](/concepts/subscription
 ```javascript title="Subscribe a user to an alert Object"
 knock.objects.addSubscriptions("alerts", alertId, {
   recipients: ["user_79bc96a9", "user_JG9NGAJQ", "user_391d92cd"],
+  properties: {
+    channels: ["email", "in_app"],
+    events: ["maintenance", "compliance"],
+    batchWindow: {
+      frequency: "weekly",
+      days: ["fri"],
+      hours: 17,
+    },
+  },
 });
 ```
+
+Once you've stored these properties on a subscription, you can access them inside the workflow run on `recipient.subscription.channel` or `recipient.subscription.events` for use in either templates or step conditions. This allows you to create a highly configurable alerting system that can be customized on a per-user basis.
 
 ### Triggering an alert
 


### PR DESCRIPTION
### Description

Expands a section of the docs to address storing per-user alerting options on the object subscription for use in templates and channel data. 

https://docs-git-je-update-alert-guide-knocklabs.vercel.app/guides/alerting#subscribe-users-to-the-alert
