### PR TITLE
chore: remove APNS cert update callout

### DIFF
--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -8,19 +8,6 @@ layout: integrations
 
 In this guide we'll walk through how to configure an Apple Push Notifications service (APNS) provider in Knock to send iOS push notifications. This guide assumes that you've already created an APNS channel in the Knock dashboard.
 
-<Callout
-  emoji="🔔"
-  text={
-    <>
-      <strong>APNS server certificate update.</strong> Your team may have received <a href="https://developer.apple.com/news/?id=09za8wzy" target="_blank">an update</a> from Apple regarding the need to update the server certificates in your application's Trust Store prior to February 24, 2025.
-      <br />
-      <br />
-      When you send notifications through Knock, we manage this server-side Trust Store on your behalf. You do not need to make any updates to your Knock channel configuration or to your mobile application in order to continue sending APNS push notifications via Knock.
-    </>
-
-}
-/>
-
 ## How to configure Apple Push Notifications service with Knock
 
 There are two ways to configure APNS with Knock. You can use a token-based authentication scheme or a certificate-based authentication scheme. Depending on which you choose, you'll need to get different information from Xcode and your Apple developer account.


### PR DESCRIPTION
### Description

This PR removes the callout on our APNS docs regarding the Apple cert update requirement, now that the deadline for that update has passed.