### PR TITLE
chore: clarify SendGrid async bounce handling limitations

### DIFF
--- a/content/integrations/email/sendgrid.mdx
+++ b/content/integrations/email/sendgrid.mdx
@@ -12,8 +12,11 @@ In this guide you'll learn how to get started sending transactional email notifi
 ## Features
 
 - Attachments support
-- Delivery tracking (only supported for SendGrid accounts with Email Activity)
-- Bounce support (only supported for SendGrid accounts with Email Activity)
+- Delivery tracking
+  - Only supported for SendGrid accounts with Email Activity.
+- Bounce support
+  - Only supported for SendGrid accounts with Email Activity.
+  - Currently, only synchronous bounce updates are reflected.
 - Link and open tracking
 - Per environment configuration
 - Sandbox mode
@@ -118,4 +121,15 @@ Delivery tracking for SendGrid can result in the following status updates to you
 
 - The message delivery is confirmed and Knock updates the message to `delivered`
 - The message was not delivered and Knock updates the message to `undelivered`
-- The message was not delivered due to a bad recipient and Knock updates the message to `bounced`
+- The message was not delivered due to a synchronous bounce and Knock updates the message to `bounced`
+
+<Callout
+  emoji="🚨"
+  text={
+    <>
+      <span className="font-bold">Note:</span> Asynchronous bounces that occur
+      after initial delivery are not currently reflected in Knock's delivery
+      status.
+    </>
+  }
+/>


### PR DESCRIPTION
### Description

Adds callouts explaining that Knock currently only handles synchronous bounces for SendGrid through delivery status checks and that asynchronous bounces (which may occur after a message is marked as delivered) are not currently reflected in Knock's delivery status.

https://docs-git-rt-clarify-sendgrid-bounce-support-knocklabs.vercel.app/integrations/email/sendgrid