### PR TITLE
fix(kno-7971): Adds `autoRegister` prop to docs for `KnockExpoPushNotificationProviderProps`

### DIFF
--- a/content/sdks/expo/reference.mdx
+++ b/content/sdks/expo/reference.mdx
@@ -109,6 +109,11 @@ Accepts `KnockExpoPushNotificationProviderProps`:
     type="Promise<Notifications.NotificationBehavior>"
     description="Allows developers to define custom behavior for handling notifications, including whether to show alerts, play sounds, or set badge counts"
   />
+  <Attribute
+    name="autoRegister"
+    type="boolean"
+    description="When true, the Expo provider automatically retrieves a push token from Expo and stores it as channel data on the user."
+  />
 </Attributes>
 
 ## Hooks


### PR DESCRIPTION
## fix(kno-7971): Adds `autoRegister` prop to docs for `KnockExpoPushNotificationProviderProps`

### Description
Updating the docs to add `autoRegister`. It was previously missing.

Surfaced via [this issue in `javascript` repo](https://github.com/knocklabs/javascript/issues/430)

### Tasks

Related to [Linear KNO-7971](https://linear.app/knock/issue/KNO-7971/knockexpopushnotificationprovider-autoregister-prop-isnt-reactive-not)