### PR TITLE
fix: correct rate limit for user identify endpoint

### DIFF
--- a/content/integrations/sources/hightouch.mdx
+++ b/content/integrations/sources/hightouch.mdx
@@ -63,7 +63,7 @@ An example configuration for your sync may look something like this:
     "hasRateLimit": true,
     "bodyType": "template",
     "body": "{\n \"name\": \"{{ row.first_name }} {{ row.last_name }}\",\n \"email\": \"{{ row.email_address }}\",\n \"phone_number\": \"{{ row.phone_number }}\"\n}",
-    "rateLimit": 1000,
+    "rateLimit": 60,
     "rateLimitTime": "second",
     "onError": "retryRequest",
     "retries": 3

--- a/content/integrations/sources/hightouch.mdx
+++ b/content/integrations/sources/hightouch.mdx
@@ -44,7 +44,7 @@ For this example, we're going to make a call to the [Knock API users identify en
 6. Set the HTTP request method to `PUT` and the URL to `https://api.knock.app/v1/users/{{ row.user_id }}` where `{{ row.user_id }}` corresponds to the user identifier in the table
 7. Select a "JSON" payload and "Use the JSON editor" to craft the request
 8. Add at least a `name`, `email`, or `phone_number` field from your users table
-9. For the rate limit, you can specify 1000 requests per second
+9. For the rate limit, you can specify 60 requests per second
 10. You'll likely want to "backfill" all of the available rows meaning that any existing data will also be synced to Knock
 11. Click "Continue"
 12. Select your sync frequency


### PR DESCRIPTION
### Description

This PR updates the rate limit on our Hightouch guide for the user identification endpoint. This [endpoint](https://docs.knock.app/reference#identify-user) is categorized as `Tier 3`, which supports 60 requests per second.
