### PR TITLE
chore: clarify supported values for truncated trigger data

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -283,7 +283,7 @@ If a batch step preceded the creation of your message, the trigger data availabl
 Knock truncates trigger data for filtering to ensure it can efficiently process your request. The current data truncation rules are:
 
 - Nested data structures (objects and arrays) are removed. Trigger data for filtering will be a JSON object with a single level of key-value pairs.
-- Supported values are strings, numbers, and booleans.
+- Supported values are the JSON scalars string, number, boolean, and `null`.
 - String values are limited to 256 characters in length. Strings that exceed this limit are truncated to the maximum.
 
 </ContentColumn>

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -282,7 +282,8 @@ If a batch step preceded the creation of your message, the trigger data availabl
 
 Knock truncates trigger data for filtering to ensure it can efficiently process your request. The current data truncation rules are:
 
-- Nested data structures are removed. Trigger data for filtering will be a JSON object with a single level of key-value pairs.
+- Nested data structures (objects and arrays) are removed. Trigger data for filtering will be a JSON object with a single level of key-value pairs.
+- Supported values are strings, numbers, and booleans.
 - String values are limited to 256 characters in length. Strings that exceed this limit are truncated to the maximum.
 
 </ContentColumn>


### PR DESCRIPTION
### Description

Clarify "nested data structure" for `combined_trigger_data` in our docs.
