### PR TITLE
chore: MessageBird update

### DIFF
--- a/content/integrations/sms/messagebird.mdx
+++ b/content/integrations/sms/messagebird.mdx
@@ -19,23 +19,16 @@ Knock integrates with <a href="https://developers.messagebird.com/api/sms-messag
         MessageBird announced a rebrand as Bird
       </a>
       , along with the introduction of a BirdCRM product and new APIs for sending
-      messages.
-      <br />
-      <br />
-      This integration is with the{" "}
-      <a
+      messages. <br /> <br /> This integration is with the <a
         href="https://developers.messagebird.com/api/sms-messaging/"
         target="_blank"
       >
         legacy MessageBird SMS API
-      </a>
-      , which continues to be supported by Bird but is no longer accepting new
+      </a>, which continues to be supported by Bird but is no longer accepting new
       customers. If integrating with the new Bird API is a blocker to your Knock
-      integration, please reach out to{" "}
-      <a href="mailto:support@knock.com?subject=Bird%20API%20integration">
-        support@knock.com
-      </a>{" "}
-      to let us know.
+      integration, please reach out to <a href="mailto:support@knock.app?subject=Bird%20API%20integration">
+        support@knock.app
+      </a> to let us know.
     </>
   }
 />

--- a/content/integrations/sms/messagebird.mdx
+++ b/content/integrations/sms/messagebird.mdx
@@ -5,7 +5,40 @@ section: Integrations > SMS
 layout: integrations
 ---
 
-Knock integrates with <a href="https://messagebird.com/" target="_blank">MessageBird</a> to send SMS notifications to your recipients.
+Knock integrates with <a href="https://developers.messagebird.com/api/sms-messaging/" target="_blank">MessageBird</a> to send SMS notifications to your recipients.
+
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <span className="font-bold">Note:</span> On February 1, 2024,{" "}
+      <a
+        href="https://bird.com/en-us/blog/messagebird-is-now-bird"
+        target="_blank"
+      >
+        MessageBird announced a rebrand as Bird
+      </a>
+      , along with the introduction of a BirdCRM product and new APIs for sending
+      messages.
+      <br />
+      <br />
+      This integration is with the{" "}
+      <a
+        href="https://developers.messagebird.com/api/sms-messaging/"
+        target="_blank"
+      >
+        legacy MessageBird SMS API
+      </a>
+      , which continues to be supported by Bird but is no longer accepting new
+      customers. If integrating with the new Bird API is a blocker to your Knock
+      integration, please reach out to{" "}
+      <a href="mailto:support@knock.com?subject=Bird%20API%20integration">
+        support@knock.com
+      </a>{" "}
+      to let us know.
+    </>
+  }
+/>
 
 ## Features
 

--- a/content/integrations/sms/messagebird.mdx
+++ b/content/integrations/sms/messagebird.mdx
@@ -18,7 +18,7 @@ Knock integrates with <a href="https://developers.messagebird.com/api/sms-messag
       >
         MessageBird announced a rebrand as Bird
       </a>
-      , along with the introduction of a BirdCRM product and new APIs for sending
+      , along with the introduction of a Bird CRM product and new APIs for sending
       messages. <br /> <br /> This integration is with the <a
         href="https://developers.messagebird.com/api/sms-messaging/"
         target="_blank"


### PR DESCRIPTION
### Description

This PR updates the external link on our MessageBird integration page to point to MessageBird's documentation, because the current link (confusingly) redirects to the Bird homepage. It also adds a callout about Bird's rebrand, and that our current integration is with the legacy MessageBird API (which is no longer accepting new customers).

Finally, it also includes a link to get in touch if access to a Bird integration is a blocker.

https://docs-k6nkbx2pp-knocklabs.vercel.app/integrations/sms/messagebird

### Screenshots

<img width="550" alt="image" src="https://github.com/user-attachments/assets/6ddc9744-a1c5-4d07-b149-bcac966c82a6" />

