### PR TITLE
chore(pla-966): dw messages actor export docs

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -74,6 +74,7 @@ Below is a description of the columns included in the table and the data type of
             has_been_clicked bigint ENCODE az64,
             has_been_interacted bigint ENCODE az64,
             has_been_archived bigint ENCODE az64,
+            actors character varying(65535) ENCODE lzo
             PRIMARY KEY (message_id)
         ) DISTSTYLE KEY SORTKEY (message_id, updated_at);
     ```
@@ -239,6 +240,13 @@ Below is a description of the columns included in the table and the data type of
           "has_been_archived",
           "integer (0 = false, 1 = true)",
           "Whether the message has been archived",
+        ],
+        [
+          "actors",
+          "json",
+          <div key="actors">
+            A JSON array of actor users or objects. Users are provided as string IDs. Objects are provided as JSON dictionaries with keys for "id" and "collection". See the <a target="_blank" rel="noreferrer" href="/concepts/recipients#recipientidentifier-definition"><code>RecipientIdentifier</code> definition</a> for more info.
+          </div>
         ],
       ]}
     />


### PR DESCRIPTION
### Description

Adds `actors` to the messages table on the data export page.

