### PR TITLE
fix: markdown -> a tag hyperlink syntax in callout component

### DIFF
--- a/content/send-notifications/triggering-workflows/overview.mdx
+++ b/content/send-notifications/triggering-workflows/overview.mdx
@@ -18,7 +18,8 @@ Knock executes workflow runs when workflows are triggered. A workflow can be tri
     <>
       <strong>Note:</strong> Recipients can opt out of notifications through
       preferences. Knock handles all preference-based opt-outs automatically.
-      Learn more about [preference management](/preferences/overview).
+      Learn more about <a href="/preferences/overview">preference management</a>
+      .
     </>
   }
 />

--- a/content/send-notifications/triggering-workflows/overview.mdx
+++ b/content/send-notifications/triggering-workflows/overview.mdx
@@ -19,7 +19,7 @@ Knock executes workflow runs when workflows are triggered. A workflow can be tri
       <strong>Note:</strong> Recipients can opt out of notifications through
       preferences. Knock handles all preference-based opt-outs automatically.
       Learn more about <a href="/preferences/overview">preference management</a>
-      .
+      {""}.
     </>
   }
 />


### PR DESCRIPTION
### Description

Small fix to update hyperlink syntax in a callout block
