### PR TITLE
chore: fix descriptions for GET channel data endpoints to be specific to each endpoint

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -6083,7 +6083,7 @@ Unsets (removes) channel data for the user and the channel specified.
 <Section title="Getting object channel data" slug="get-object-channel-data">
 <ContentColumn>
 
-Retrieves the channel data for the provided user object on the channel specified.
+Retrieves the channel data for the provided object on the channel specified.
 
 ### Endpoint
 

--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -5925,7 +5925,7 @@ The shape of the `data` payload varies depending on the channel type; you can le
 <Section title="Getting user channel data" slug="get-user-channel-data">
 <ContentColumn>
 
-Retrieves the channel data for the provided user (or object) on the channel specified.
+Retrieves the channel data for the provided user on the channel specified.
 
 ### Endpoint
 
@@ -6083,7 +6083,7 @@ Unsets (removes) channel data for the user and the channel specified.
 <Section title="Getting object channel data" slug="get-object-channel-data">
 <ContentColumn>
 
-Retrieves the channel data for the provided user (or object) on the channel specified.
+Retrieves the channel data for the provided user object on the channel specified.
 
 ### Endpoint
 


### PR DESCRIPTION
### Description

Following up on our pairing session, updating the description for the GET user channel data and GET object channel data descriptions to be more specific to each endpoint. 