### PR TITLE
chore: add sms template overrides to mapi

### DIFF
--- a/content/mapi.mdx
+++ b/content/mapi.mdx
@@ -460,6 +460,18 @@ Contains all properties of the <a href="#workflowstep-definition">`WorkflowStep`
     type="string"
     description="A text template for the SMS notification message."
   />
+  <Attribute
+    name="settings.payload_overrides"
+    type="string"
+    typeSlug="/integrations/sms/settings-and-overrides#provider-json-overrides"
+    description="A JSON template for any custom overrides to merge into the API payload that is sent to the SMS provider."
+  />
+  <Attribute
+    name="settings.to_number"
+    type="string"
+    typeSlug="/integrations/sms/settings-and-overrides#overriding-the-default-to-number"
+    description="An override for the phone number to send the SMS to. When not set, defaults to `recipient.phone_number`."
+  />
 </Attributes>
 
 #### Push template attributes


### PR DESCRIPTION
### Description

Add [SMS settings and overrides](https://docs.knock.app/integrations/sms/settings-and-overrides) to the mAPI reference.

### Screenshots

<img width="450" alt="image" src="https://github.com/user-attachments/assets/67882ba5-e41e-4ce1-91bb-82c7e1fa0452" />

