### PR TITLE
chore: add content-id info for email attachments

### DIFF
--- a/content/integrations/email/attachments.mdx
+++ b/content/integrations/email/attachments.mdx
@@ -13,13 +13,14 @@ layout: integrations
 
 ## The attachment object
 
-Every attachment you send to Knock in your `data` payload should have the following properties:
+Every attachment you send to Knock in your `data` payload should include the following properties (those marked with an `*` are required):
 
-| Property       | Description                                  |
-| -------------- | -------------------------------------------- |
-| name\*         | The name of the file                         |
-| content_type\* | A mime type for the file                     |
-| content\*      | The base64 encoded file content (up-to 10mb) |
+| Property         | Description                                                                                                                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`\*         | The name of the file                                                                                                                                                                                                             |
+| `content_type`\* | A mime type for the file                                                                                                                                                                                                         |
+| `content`\*      | The base64 encoded file content (up to 10mb)                                                                                                                                                                                     |
+| `content_id`     | An optional unique `Content-ID` for the attachment, which will automatically set the attachment as `inline`. Currently only supported for [SendGrid](/integrations/email/sendgrid) and [Postmark](/integrations/email/postmark). |
 
 ```js title="An example attachment object"
 {
@@ -29,7 +30,7 @@ Every attachment you send to Knock in your `data` payload should have the follow
 }
 ```
 
-**Note**: each attachment object must be less than 10mb but check with your email provider to see if they set a lower limit.
+**Note**: each attachment object must be less than 10mb, but you should confirm whether your email provider has a lower limit.
 
 ## Sending attachments in your trigger call
 


### PR DESCRIPTION
### Description

Adds information about our support of `Content-ID` with inline email attachments for certain providers.

### Screenshots
<img width="600" alt="image" src="https://github.com/user-attachments/assets/bbe894a8-afee-4580-9387-312383fbff4a" />

