### PR TITLE
chore: add context on subscriber fanout cancellations

### DIFF
--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -210,4 +210,11 @@ Knock always deduplicates recipients when executing a notification fan out, incl
     for subscribers of an object. Each individual subscriber will need to be
     added as a recipient when creating the workflow schedule.
   </Accordion>
+  <Accordion title="Can I cancel a workflow run for a specific recipient if they were notified via an object subscription?">
+    Yes, you can. [Workflow
+    cancellation](/send-notifications/canceling-workflows) requests can be
+    scoped to one or more specific recipients. You can target any recipient who
+    was notified via an object subscription, even if that recipient was not
+    explicitly included in the workflow trigger request.
+  </Accordion>
 </AccordionGroup>

--- a/content/send-notifications/canceling-workflows.mdx
+++ b/content/send-notifications/canceling-workflows.mdx
@@ -52,3 +52,14 @@ There are a few fundamentals to consider when using workflow cancellations:
 3. Workflow cancellations are both deferred and executed concurrently to the workflow run itself. The [cancel workflow API](/reference#cancel-workflow) will return a `204 No Content` response on success, but this only means Knock has successfully enqueued the cancellation request, _not_ that the cancellation has been performed. **We recommend against issuing a cancellation request within 5 seconds of a given workflow trigger**. Cancellations issued too soon after a workflow trigger may not cancel the intended target. Cancellations issued prior to a workflow trigger may overtake and cancel the subsequent workflow.
 
 4. Canceling a workflow with a [batch step](/send-notifications/designing-workflows/batch-function) will not close the open batch window. Read more [here](/designing-workflows/batch-function#using-workflow-cancellation-with-batches).
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Can I cancel a workflow run for a specific recipient if they were notified via an object subscription?">
+    Yes, you can. Because workflow cancellation requests can be scoped to one or
+    more specific recipients, you can target any recipient who was notified via
+    an object subscription, even if that recipient was not explicitly included
+    in the workflow trigger request.
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

Add FAQs to call out that it is possible to cancel fanned-out workflow recipient runs, even if a given recipient was not explicitly included in the workflow trigger's `recipients`.
