### PR TITLE
chore: remove near-term language from object feed mentions

### DIFF
--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -21,18 +21,17 @@ You can use objects to:
 
 - Send out-of-app notifications to non-user recipients (such as a [Slack channel](#slack-channel-notifications)).
 - [Reference mutable data in your notification templates](/designing-workflows/template-editor/referencing-data) (such as when a user edits a comment before a notification is sent).
-- **Coming soon:** send in-app notifications to non-user resources in your product (the activity feed you see on a Notion page is a good example).
 
 <Callout
   emoji="🛣"
   text={
     <>
       <span className="font-bold">Knock roadmap alert.</span> We have Objects
-      API support for in-app notifications on our near-term roadmap.
+      API support for in-app feed notifications on our roadmap.
       <br />
-      <br /> If you're interested in trying this functionality, please shoot us
-      a note at <a href="mailto:support@knock.app">support@knock.app</a> or use
-      the feedback button at the top of this page.
+      <br /> If you have a use case for this functionality, please send a note
+      to <a href="mailto:support@knock.app">support@knock.app</a> or use the
+      feedback button at the top of this page to let us know.
     </>
   }
 />


### PR DESCRIPTION
### Description

This PR removes "coming soon" and "near-term" language from our messaging about Object support on the in-app feed.

### Screenshots

**Before**
<img width="550" alt="image" src="https://github.com/user-attachments/assets/ebec95f3-0630-49e3-a379-8d8ce25beeaa" />

**After**
<img width="550" alt="image" src="https://github.com/user-attachments/assets/185ce731-4fcd-4317-b703-0c280e5e6de3" />
