### PR TITLE
fix: override example for fcm with android sdk

### DIFF
--- a/content/sdks/android/deep-links.mdx
+++ b/content/sdks/android/deep-links.mdx
@@ -22,19 +22,19 @@ section: SDKs
 ## 2. Include a deep link in your Knock message payload:
 
 - In your message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
-- This can also be done in your Knock Dashboard in your [Payload overrides](/integrations/push/overview#push-overrides).
+- This can also be done in your Knock Dashboard in your [payload overrides](/integrations/push/firebase#using-overrides-to-customize-notifications).
 
-<Image
-  src="/images/deep-link-payload-override.png"
-  alt="Deep link payload override"
-  className="rounded-md mx-auto border border-gray-200"
-  width={500}
-  height={507}
-/>
+```json title="FCM payload override configuration"
+{
+  "data": {
+    "link": "https://example.com/deep-link"
+  }
+}
+```
 
 ## 3. Handle Incoming URLs:
 
-```kotlin
+```kotlin title="Example for handling deep links"
 class MainActivity: KnockActivity() {
   override fun onKnockPushNotificationTappedInBackGround(intent: Intent) {
     super.onKnockPushNotificationTappedInBackGround(intent)


### PR DESCRIPTION
### Description

This PR updates the example payload override (and backlink to more info on overrides) in our Android SDK documentation. FCM requires a specific payload override structure (everything needs to be nested under a `data` key), and the current example caused confusion for a customer. The link now points to FCM-specific docs.

I also opted for a copyable JSON example as opposed to a screenshot from the dashboard, but can update it to be in an image again if people like that better. Original is [here](https://docs.knock.app/sdks/android/deep-links#2-include-a-deep-link-in-your-knock-message-payload) for reference.