### PR TITLE
fix(kno-8189): user properties should be optional in the go sdk

### DIFF
--- a/data/code/users/bulk-identify.ts
+++ b/data/code/users/bulk-identify.ts
@@ -127,14 +127,16 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 result, _ := knockClient.Users.BulkIdentify(ctx, &knock.&BulkIdentifyUserRequest{
   Users: []*User{
     {
-      ID:     "1",
-      Name:   "John Hammond",
-      Email:  "jhammond@ingen.net"
+      ID: "1",
+      // Optional fields:
+      // Name: "John Hammond",
+      // Email: "jhammond@ingen.net"
     },
     {
-      ID:     "2",
-      Name:   "Ellie Sattler",
-      Email:  "esattler@ingen.net"
+      ID: "2",
+      // Optional fields:
+      // Name: "Ellie Sattler",
+      // Email: "esattler@ingen.net"
     }
   }
 })

--- a/data/code/users/identify.ts
+++ b/data/code/users/identify.ts
@@ -77,8 +77,9 @@ knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
 
 user, _ := knockClient.Users.Identify(ctx, &knock.IdentifyUserRequest{
   ID: "1",
-  Name: "John Hammond",
-  Email: "jhammond@ingen.net"
+  // Optional fields:
+  // Name: "John Hammond",
+  // Email: "jhammond@ingen.net"
 })
 `,
   java: `


### PR DESCRIPTION
### Description
Shows these properties as optional.
