### PR TITLE
feat: add inserted_at filters for feed

### DIFF
--- a/content/reference.mdx
+++ b/content/reference.mdx
@@ -2059,39 +2059,59 @@ along with a user token to make this request**
   />
   <Attribute
     name="source"
-    type="string (optional)"
+    type="string"
     description="Limits the feed to only items of the source workflow"
   />
   <Attribute
     name="tenant"
-    type="string (optional)"
+    type="string"
     description="Limits the feed to only display items with the corresponding tenant, or where the tenant is empty"
   />
   <Attribute
     name="has_tenant"
-    type="boolean (optional)"
+    type="boolean"
     description="Scope the feed to display items with or without any tenancy"
   />
   <Attribute
     name="status"
-    type="string (optional)"
+    type="string"
     description="One of `unread`,`read`, `unseen`,`seen`, `all`"
   />
   <Attribute
     name="workflow_categories"
-    type="string[] (optional)"
+    type="string[]"
     description="Limits the feed to only display items related to any of the provided categories"
   />
   <Attribute
     name="archived"
-    type="string (optional)"
+    type="string"
     description="One of `include`, `exclude`, `only` (defaults to `exclude`)"
   />
   <Attribute
     name="trigger_data"
-    type="JSON string (optional)"
+    type="JSON string"
     description="Limits the results to only items that were generated with the given data"
     nameSlug="#trigger-data-filtering"
+  />
+  <Attribute
+    name="inserted_at.gt"
+    type="datetime (optional)"
+    description="Filter feed items created after the specified ISO-8601 timestamp (exclusive)"
+  />
+  <Attribute
+    name="inserted_at.gte"
+    type="datetime (optional)"
+    description="Filter feed items created at or after the specified ISO-8601 timestamp (inclusive)"
+  />
+  <Attribute
+    name="inserted_at.lt"
+    type="datetime (optional)"
+    description="Filter feed items created before the specified ISO-8601 timestamp (exclusive)"
+  />
+  <Attribute
+    name="inserted_at.lte"
+    type="datetime (optional)"
+    description="Filter feed items created at or before the specified ISO-8601 timestamp (inclusive)"
   />
 </Attributes>
 


### PR DESCRIPTION
### Description

Updates [the get feed endpoint](https://docs-git-rt-add-date-range-filters-feed-knocklabs.vercel.app/reference#query-parameters-6) to add the newly supported inserted_at filters. 
