### PR TITLE
feat(KNO-8215): add button, url, and image fields to message types doc

### DIFF
--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -461,6 +461,51 @@ A multi-line plain text area
 ```
 
   </Accordion>
+  <Accordion title="Button">
+    A button, with text to display and an action to perform when clicked.
+
+    Every button field contains two subfields:
+
+    - `text`: A text field that represents the button's text
+    - `action`: A text field that represents the button's action
+
+    **Settings**
+
+    - `required` (boolean): indicates this field is required
+    - `description` (string): an optional friendly description
+
+    **Example**
+
+    ```json
+    {
+      "type": "button",
+      "key": "primary_button",
+      "label": "Primary button",
+      "text": {
+        "type": "text",
+        "key": "text",
+        "label": "Button text",
+        "settings": {
+          "required": true,
+          "default": "Learn more"
+        }
+      },
+      "action": {
+        "type": "text",
+        "key": "action",
+        "label": "Button action",
+        "settings": {
+          "required": true,
+          "default": "https://example.com/"
+        }
+      },
+      "settings": {
+        "required": true
+      }
+    }
+    ```
+
+  </Accordion>
   <Accordion title="URL">
     **Settings**
 

--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -461,6 +461,28 @@ A multi-line plain text area
 ```
 
   </Accordion>
+  <Accordion title="URL">
+    **Settings**
+
+    - `required` (boolean): indicates this field is required
+    - `description` (string): an optional friendly description
+    - `default` (string): The default URL to display
+
+    **Example**
+
+    ```json
+    {
+      "type": "url",
+      "key": "contact_url",
+      "label": "Contact link",
+      "settings": {
+        "required": true,
+        "default": "https://example.com/"
+      }
+    }
+    ```
+
+  </Accordion>
   <Accordion title="Image 🔜">
 *This type is not yet available, but we’re going to be adding it in the near future.*
   </Accordion>

--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -528,8 +528,60 @@ A multi-line plain text area
     ```
 
   </Accordion>
-  <Accordion title="Image 🔜">
-*This type is not yet available, but we’re going to be adding it in the near future.*
+  <Accordion title="Image">
+    An image field, used to display an image with alt text and an optional action to perform when clicked.
+
+    Every image field contains three subfields:
+
+    - `url`: A URL field that represents the source of the image to be displayed
+    - `alt`: A text field that represents the image's alt text
+    - `action`: An optional text field that represents an action to perform when the image is clicked
+
+    **Settings**
+
+    - `required` (boolean): indicates this field is required
+    - `description` (string): an optional friendly description
+
+    **Example**
+
+    ```json
+    {
+      "type": "image",
+      "key": "hero_image",
+      "label": "Hero image",
+      "url": {
+        "type": "url",
+        "key": "url",
+        "label": "Image URL",
+        "settings": {
+          "required": true,
+          "default": "https://example.com/image.png"
+        }
+      },
+      "alt": {
+        "type": "text",
+        "key": "alt",
+        "label": "Image alt text",
+        "settings": {
+          "required": true,
+          "default": "Lorem ipsum"
+        }
+      },
+      "action": {
+        "type": "text",
+        "key": "action",
+        "label": "Image action",
+        "settings": {
+          "required": true,
+          "default": "https://example.com/"
+        }
+      },
+      "settings": {
+        "required": true
+      }
+    }
+    ```
+
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
### Description

This PR updates the in-app message types doc to include the following message types:

- `"button"`
- `"url"`
- `"image"`

### Tasks

[KNO-8215](https://linear.app/knock/issue/KNO-8215/[docs]-update-message-types-doc)
