### PR TITLE
chore(kno-8186): improve mobile deep linking docs

### DIFF
--- a/content/sdks/android/deep-links.mdx
+++ b/content/sdks/android/deep-links.mdx
@@ -9,7 +9,11 @@ section: SDKs
   text={
     <>
       <span className="font-bold">Note:</span> We recommend taking advantage of
-      our <a href="/sdks/android/reference#knockmessagingservice--knockactivity">KnockMessagingService & KnockActivity</a> to simplify deep link handling.
+      our{" "}
+      <a href="/sdks/android/reference#knockmessagingservice--knockactivity">
+        KnockMessagingService & KnockActivity
+      </a>{" "}
+      to simplify deep link handling.
     </>
   }
 />

--- a/content/sdks/android/deep-links.mdx
+++ b/content/sdks/android/deep-links.mdx
@@ -1,58 +1,89 @@
 ---
 title: Handling deep links
-description: Usage guides to help you get started with deep linking in the Android Knock SDK.
+description: Follow this guide to get started with deep linking in the Knock Android SDK.
 section: SDKs
 ---
 
-**Note:** We Recommend taking advantage of our [KnockMessagingService & KnockActivity](/sdks/android/reference#knockmessagingservice--knockactivity) to make handling deep links simpler.
-
-## 1. Define URL Schemes:
-
-- In Xcode, navigate to your app target's **Info** tab.
-- Add a new URL type under **URL Types** with a unique scheme.
-
-<Image
-  src="/images/xcode-project-info.png"
-  alt="Xcode Project Info"
-  className="rounded-md mx-auto border border-gray-200"
-  width={1020}
-  height={802}
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <span className="font-bold">Note:</span> We recommend taking advantage of
+      our <a href="/sdks/android/reference#knockmessagingservice--knockactivity">KnockMessagingService & KnockActivity</a> to simplify deep link handling.
+    </>
+  }
 />
 
-## 2. Include a deep link in your Knock message payload:
+## App links
 
-- In your message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
-- This can also be done in your Knock Dashboard in your [payload overrides](/integrations/push/firebase#using-overrides-to-customize-notifications).
+Follow the steps below to configure URLs that deeply link to specific content in your Android application. You can read more about app links in the Android Developer documentation <a href="https://developer.android.com/studio/write/app-link-indexing" target="_blank">here</a>.
 
-```json title="FCM payload override configuration"
-{
-  "data": {
-    "link": "https://example.com/deep-link"
-  }
-}
-```
+<Steps titleSize="h3">
+  <Step title="Define intent filters" >
+    In your `AndroidManifest.xml` file, add intent filters for the app link schemes you want to use. The App Links Assistant in Android Studio simplifies this process with a step-by-step wizard.
 
-## 3. Handle Incoming URLs:
+    ```xml title="Add intent filters to your AndroidManifest.xml file"
+    <activity
+        android:name="com.example.android.GizmosActivity"
+        android:label="@string/title_gizmos" >
+        <intent-filter>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <!-- Accepts URIs that begin with "http://www.example.com/gizmos" -->
+            <data android:scheme="http"
+                  android:host="www.example.com"
+                  android:pathPrefix="/gizmos" />
+            <!-- note that the leading "/" is required for pathPrefix-->
+        </intent-filter>
+    </activity>
+    ```
 
-```kotlin title="Example for handling deep links"
-class MainActivity: KnockActivity() {
-  override fun onKnockPushNotificationTappedInBackGround(intent: Intent) {
-    super.onKnockPushNotificationTappedInBackGround(intent)
+  </Step>
 
-    intent?.extras?.getString("link")?.let { deepLink ->
-        // Handle your deep link routing here
+  <Step title="Include an app link in your Knock message payload" >
+    - In your trigger `data` payload that you send to Knock, include a property with a value for your app link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
+    - You can configure the format of the API request sent to FCM in your workflow step's [payload overrides](/integrations/push/firebase#using-overrides-to-customize-notifications).
+
+    ```json title="Payload override configuration for an FCM notification in Knock"
+    {
+      "data": {
+        "link": "https://example.com/app-link"
+      }
     }
-  }
+    ```
 
-  override fun onKnockPushNotificationTappedInForeground(message: RemoteMessage) {
-      super.onKnockPushNotificationTappedInForeground(message)
+  </Step>
 
-      remoteMessage.data.isNotEmpty().let {
-          val deepLink = remoteMessage.data["link"]
-          deepLink?.let {
-            // Handle your deep link routing here
+  <Step title="Handle incoming URLs from a push notification" >
+    Handle incoming URLs in your `KnockActivity` or `KnockMessagingService`.
+
+    ```kotlin title="Example for handling app links"
+    class MainActivity: KnockActivity() {
+      override fun onKnockPushNotificationTappedInBackGround(intent: Intent) {
+        super.onKnockPushNotificationTappedInBackGround(intent)
+
+        intent?.extras?.getString("link")?.let { appLink ->
+            // Handle your app link routing here
+        }
+      }
+
+      override fun onKnockPushNotificationTappedInForeground(message: RemoteMessage) {
+          super.onKnockPushNotificationTappedInForeground(message)
+
+          remoteMessage.data.isNotEmpty().let {
+              val appLink = remoteMessage.data["link"]
+              appLink?.let {
+                // Handle your app link routing here
+              }
           }
       }
-  }
-}
-```
+    }
+    ```
+
+  </Step>
+</Steps>
+
+## Verify app links
+
+You can optionally <a href="https://developer.android.com/training/app-links/verify-android-applinks#web-assoc" target="_blank">associate your app links with your website</a>.

--- a/content/sdks/android/deep-links.mdx
+++ b/content/sdks/android/deep-links.mdx
@@ -64,8 +64,8 @@ Follow the steps below to configure URLs that deeply link to specific content in
 
     ```kotlin title="Example for handling app links"
     class MainActivity: KnockActivity() {
-      override fun onKnockPushNotificationTappedInBackGround(intent: Intent) {
-        super.onKnockPushNotificationTappedInBackGround(intent)
+      override fun onKnockPushNotificationTappedInBackground(intent: Intent) {
+        super.onKnockPushNotificationTappedInBackground(intent)
 
         intent?.extras?.getString("link")?.let { appLink ->
             // Handle your app link routing here

--- a/content/sdks/ios/deep-links.mdx
+++ b/content/sdks/ios/deep-links.mdx
@@ -9,7 +9,8 @@ section: SDKs
   text={
     <>
       <span className="font-bold">Note:</span> We recommend taking advantage of
-      our <a href="/sdks/ios/reference#knockappdelegate">KnockAppDelegate</a> to simplify deep link handling.
+      our <a href="/sdks/ios/reference#knockappdelegate">KnockAppDelegate</a> to
+      simplify deep link handling.
     </>
   }
 />
@@ -30,6 +31,7 @@ Follow the steps below to configure URLs that deeply link to specific content in
       width={1020}
       height={802}
     />
+
   </Step>
 
   <Step title="Include a deep link in your Knock message payload">
@@ -43,6 +45,7 @@ Follow the steps below to configure URLs that deeply link to specific content in
       width={500}
       height={507}
     />
+
   </Step>
 
   <Step title="Handle incoming URLs from a push notification">
@@ -103,6 +106,7 @@ Follow the steps below to configure URLs that deeply link to specific content in
             ```
         </Accordion>
     </AccordionGroup>
+
   </Step>
 </Steps>
 
@@ -130,11 +134,13 @@ Universal links will redirect users to a browser when the app is not installed.
          return true
      }
     ```
+
   </Step>
 
   <Step title="Server configuration">
     - Ensure your server hosts an Apple App Site Association (AASA) file at **`https://yourdomain.com/.well-known/apple-app-site-association`**.
 
     For more detailed instructions on configuring universal links, visit <a href="https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app" target="_blank">Apple's Official Documentation</a>.
+
   </Step>
 </Steps>

--- a/content/sdks/ios/deep-links.mdx
+++ b/content/sdks/ios/deep-links.mdx
@@ -1,130 +1,140 @@
 ---
 title: Handling deep/universal links
-description: Usage guides to help you get started with deep/universal linking in the iOS Knock SDK.
+description: Follow this guide to get started with deep/universal linking in the Knock iOS SDK.
 section: SDKs
 ---
 
-**Note:** We Recommend taking advantage of our [KnockAppDelegate](/sdks/ios/reference#knockappdelegate) to make handling deep links simpler.
-
-# Deep Links:
-
-## 1. Define URL Schemes:
-
-- In Xcode, navigate to your app target's **Info** tab.
-- Add a new URL type under **URL Types** with a unique scheme.
-
-<Image
-  src="/images/xcode-project-info.png"
-  alt="Xcode Project Info"
-  className="rounded-md mx-auto border border-gray-200"
-  width={1020}
-  height={802}
+<Callout
+  emoji="💡"
+  text={
+    <>
+      <span className="font-bold">Note:</span> We recommend taking advantage of
+      our <a href="/sdks/ios/reference#knockappdelegate">KnockAppDelegate</a> to simplify deep link handling.
+    </>
+  }
 />
 
-## 2. Include a deep link in your Knock message payload:
+## Deep Links
 
-- In your message payload that you send to Knock, include a property with a value of your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
-- This can also be done in your Knock Dashboard in your [Payload overrides](/integrations/push/overview#push-overrides).
+Follow the steps below to configure URLs that deeply link to specific content in your iOS application.
 
-<Image
-  src="/images/deep-link-payload-override.png"
-  alt="Deep link payload override"
-  className="rounded-md mx-auto border border-gray-200"
-  width={500}
-  height={507}
-/>
+<Steps titleSize="h3">
+  <Step title="Define URL schemes">
+    - In Xcode, navigate to your app target's **Info** tab.
+    - Add a new URL type under **URL Types** with a unique scheme.
 
-## 3. Handle Incoming URLs:
+    <Image
+      src="/images/xcode-project-info.png"
+      alt="Xcode Project Info"
+      className="rounded-md mx-auto border border-gray-200"
+      width={1020}
+      height={802}
+    />
+  </Step>
 
-- To handle a push notification being tapped while the app is closed:
+  <Step title="Include a deep link in your Knock message payload">
+    - In your trigger `data` payload that you send to Knock, include a property with a value for your deep link. The name of the property doesn't matter, so long as you know beforehand what it will be called.
+    - You can configure the format of the API request sent to APNs in your workflow step's [payload overrides](/integrations/push/apns#using-overrides-to-customize-notifications).
 
-**KnockAppDelegate:**
+    <Image
+      src="/images/deep-link-payload-override.png"
+      alt="Deep link payload override"
+      className="rounded-md mx-auto border border-gray-200"
+      width={500}
+      height={507}
+    />
+  </Step>
 
-```swift
-class MyAppDelegate: KnockAppDelegate {
-     override func pushNotificationTapped(userInfo: [AnyHashable : Any]) {
-         super.pushNotificationTapped(userInfo: userInfo)
-         if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
-             UIApplication.shared.open(url)
-         }
-     }
-}
-```
+  <Step title="Handle incoming URLs from a push notification">
+    You can handle incoming URLs from a push notification by implementing the `pushNotificationTapped` method in your `KnockAppDelegate`. This can also be done manually.
+    
+    <AccordionGroup>
+      <Accordion title="Handle a push notification being tapped while the app is closed">
 
-**Manually:**
+        ```swift title="Handle with KnockAppDelegate"
+        class MyAppDelegate: KnockAppDelegate {
+            override func pushNotificationTapped(userInfo: [AnyHashable : Any]) {
+                super.pushNotificationTapped(userInfo: userInfo)
+                if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
+                    UIApplication.shared.open(url)
+                }
+            }
+        }
+        ```
+        <br />
+        ```swift title="Handle manually"
+        class MyAppDelegate: UIResponder, UIApplicationDelegate {
+            open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+                // Check if launched from the tap of a notification
+                if let launchOptions = launchOptions, let userInfo = launchOptions[.remoteNotification] as? [String: AnyObject] {
+                    // retrieve url
+                    if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                return true
+            }
+        }
+        ```
+    </Accordion>
 
-```swift
-class MyAppDelegate: UIResponder, UIApplicationDelegate {
-     open func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-         // Check if launched from the tap of a notification
-         if let launchOptions = launchOptions, let userInfo = launchOptions[.remoteNotification] as? [String: AnyObject] {
-             // retrieve url
-             if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
-                 UIApplication.shared.open(url)
+        <Accordion title="Handle a push notification being tapped while the app is in the foreground or background">
+
+            ```swift title="Handle with KnockAppDelegate"
+            class MyAppDelegate: KnockAppDelegate {
+                override func pushNotificationTapped(userInfo: [AnyHashable : Any]) {
+                    super.pushNotificationTapped(userInfo: userInfo)
+                    if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            }
+            ```
+            <br />
+            ```swift title="Handle manually"
+            class MyAppDelegate: UIResponder, UIApplicationDelegate {
+                open func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+                    if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
+                        UIApplication.shared.open(url)
+                    }
+                    completionHandler()
+                }
+            }
+            ```
+        </Accordion>
+    </AccordionGroup>
+  </Step>
+</Steps>
+
+## Universal Links
+
+Universal links will redirect users to a browser when the app is not installed.
+
+<Steps titleSize="h3">
+  <Step title="Enable Associated Domains">
+    - Add the **Associated Domains** capability in your app target's **Signing & Capabilities** tab.
+    - Add your domain in the format **`applinks:yourdomain.com`**.
+  </Step>
+
+  <Step title="Handle incoming links">
+    Implement `application(_:continue:restorationHandler:)` in your `AppDelegate` or `SceneDelegate`.
+
+    ```swift title="Handle incoming universal links"
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity,
+                      restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+         if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
+             if let incomingURL = userActivity.webpageURL {
+                 // Handle the incoming URL appropriately
              }
          }
          return true
      }
-}
-```
+    ```
+  </Step>
 
----
+  <Step title="Server configuration">
+    - Ensure your server hosts an Apple App Site Association (AASA) file at **`https://yourdomain.com/.well-known/apple-app-site-association`**.
 
-- To handle a push notification being tapped while the app is in the foreground or background:
-
-**KnockAppDelegate:**
-
-```swift
- class MyAppDelegate: KnockAppDelegate {
-     override func pushNotificationTapped(userInfo: [AnyHashable : Any]) {
-         super.pushNotificationTapped(userInfo: userInfo)
-         if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
-             UIApplication.shared.open(url)
-         }
-     }
-}
-```
-
-**Manually:**
-
-```swift
-class MyAppDelegate: UIResponder, UIApplicationDelegate {
-     open func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-         if let deeplink = userInfo["link"] as? String, let url = URL(string: deeplink) {
-             UIApplication.shared.open(url)
-         }
-         completionHandler()
-     }
-}
-```
-
----
-
-# Universal Links:
-
-## 1. Enable Associated Domains:
-
-- Add the **Associated Domains** capability in your app target's **Signing & Capabilities** tab.
-- Add your domain in the format **`applinks:yourdomain.com`**.
-
-## 2. Handle Incoming Links:
-
-- Implement **`application(_:continue:restorationHandler:)`** in your AppDelegate or SceneDelegate.
-
-```swift
-func application(_ application: UIApplication, continue userActivity: NSUserActivity,
-                  restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-     if userActivity.activityType == NSUserActivityTypeBrowsingWeb {
-         if let incomingURL = userActivity.webpageURL {
-             // Handle the incoming URL appropriately
-         }
-     }
-     return true
- }
-```
-
-## 3. Server Configuration:
-
-- Ensure your server hosts an Apple App Site Association (AASA) file at **`https://yourdomain.com/.well-known/apple-app-site-association`**.
-
-For more detailed instructions on configuring universal links, visit [Apple's Official Documentation](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app).
+    For more detailed instructions on configuring universal links, visit <a href="https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app" target="_blank">Apple's Official Documentation</a>.
+  </Step>
+</Steps>


### PR DESCRIPTION
### Description

This PR fixes erroneous information on the Android deep linking guide (removes mentions of XCode and adds information about Android Studio and intent filters). It also:

- Updates usage to comply with style guide for both Android and iOS
- Adds Step and Accordion components for better organization 
- Adds a brief mention w/ link to more info about verifying app links on Android to correlate with "universal links" on iOS.

[iOS](https://docs-c15b9wa03-knocklabs.vercel.app/sdks/ios/deep-links)
[Android](https://docs-c15b9wa03-knocklabs.vercel.app/sdks/android/deep-links)

### TODO

We should also make similar improvements to the "Push notifications" pages under each of these sections.