### PR TITLE
feat: expose new rag search endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -18,3 +18,6 @@ NEXT_PUBLIC_ANALYTICS_WRITE_KEY=
 
 # Used for triggering the docs feedback workflow
 KNOCK_API_KEY=
+
+# Used for the search API
+INKEEP_API_KEY=

--- a/pages/api/search.ts
+++ b/pages/api/search.ts
@@ -1,0 +1,47 @@
+import fetch from "isomorphic-unfetch";
+
+const API_KEY = process.env.INKEEP_API_KEY;
+
+const handler = async (req, res) => {
+  if (req.method !== "POST") {
+    return res
+      .status(405)
+      .setHeader("Allow", "POST")
+      .json({ error: `${req.method} method is not accepted.` });
+  }
+
+  const { query } = req.body;
+
+  if (!query) {
+    return res.status(400).json({ error: "Query is required." });
+  }
+
+  try {
+    const response = await fetch("https://api.inkeep.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "inkeep-rag",
+        messages: [{ role: "user", content: query }],
+        response_format: {
+          type: "json_object",
+        },
+      }),
+    });
+
+    const data = await response.json();
+
+    const results = JSON.parse(
+      data.choices[0].message.content ?? { content: [] },
+    ).content;
+
+    return res.status(200).json({ results });
+  } catch (error) {
+    return res.status(500).json({ error: (error as Error).message });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
### Description

Exposes a new `POST /api/search` endpoint that proxies through to inkeep to expose search results over their RAG completions API.

We'll expose this as a `search_documentation` tool in the MCP server/agent tooklit

### Tasks

KNO-8245

