### PR TITLE
chore: fix union type display

### DIFF
--- a/components/ApiReference/SchemaProperties/SchemaProperties.tsx
+++ b/components/ApiReference/SchemaProperties/SchemaProperties.tsx
@@ -15,7 +15,7 @@ const SchemaProperties = ({ schema, hideRequired = false }: Props) => {
   return (
     <PropertyRow.Wrapper>
       {Object.entries(schema.properties || {}).map(
-        ([propertyName, property]: [string, OpenAPIV3.SchemaObject]) => (
+        ([propertyName, property]) => (
           <SchemaProperty
             key={propertyName}
             name={propertyName}

--- a/components/ApiReference/SchemaProperties/SchemaProperties.tsx
+++ b/components/ApiReference/SchemaProperties/SchemaProperties.tsx
@@ -15,12 +15,12 @@ const SchemaProperties = ({ schema, hideRequired = false }: Props) => {
   return (
     <PropertyRow.Wrapper>
       {Object.entries(schema.properties || {}).map(
-        ([propertyName, property]) => (
+        ([propertyName, property]: [string, OpenAPIV3.SchemaObject]) => (
           <SchemaProperty
             key={propertyName}
             name={propertyName}
             schema={{
-              ...(property as OpenAPIV3.SchemaObject),
+              ...property,
               required: !hideRequired
                 ? property.required || schema.required?.includes(propertyName)
                 : false,

--- a/components/ApiReference/SchemaProperties/SchemaProperty.tsx
+++ b/components/ApiReference/SchemaProperties/SchemaProperty.tsx
@@ -36,14 +36,18 @@ const SchemaProperty = ({ name, schema }: Props) => {
       <PropertyRow.Header>
         {name && <PropertyRow.Name>{name}</PropertyRow.Name>}
         <PropertyRow.Types>
-          {typesForDisplay.slice(0, MAX_TYPES_TO_DISPLAY).map((type) => (
-            <PropertyRow.Type key={type} href={schemaReferences[type]}>
-              {type}
+          {typesForDisplay.length === 1 && (
+            <PropertyRow.Type
+              key={typesForDisplay[0]}
+              href={schemaReferences[typesForDisplay[0]]}
+            >
+              {typesForDisplay[0]}
             </PropertyRow.Type>
-          ))}
-          {hasAdditionalTypes && (
+          )}
+
+          {typesForDisplay.length > 1 && (
             <span className="text-xs text-gray-500 dark:text-gray-300">
-              +{typesForDisplay.length - MAX_TYPES_TO_DISPLAY} more
+              {typesForDisplay.length} possible types
             </span>
           )}
         </PropertyRow.Types>

--- a/components/ApiReference/SchemaProperties/helpers.ts
+++ b/components/ApiReference/SchemaProperties/helpers.ts
@@ -31,7 +31,9 @@ function getTypesForDisplay(schema: OpenAPIV3.SchemaObject): string[] {
   const union = schema.anyOf || schema.oneOf || schema.allOf;
 
   if (union) {
-    return union.map((item) => getTypeForDisplay(item));
+    return union
+      .map((item) => getTypeForDisplay(item))
+      .filter((t) => t !== "null");
   }
 
   return [getTypeForDisplay(schema)];


### PR DESCRIPTION
### Description

Minor API spec fixes:

- Filter `null` type
- Show count of possible types

