### PR TITLE
feat(KNO-8385): add example JSON for MS Teams Adaptive Cards

### DIFF
--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -202,9 +202,34 @@ By default, we provide a basic markdown editor that you can use for sending simp
 
 ### Advanced Teams notifications
 
-If you find yourself wanting to send notifications that include more advanced formatting and interactivity, such as buttons, data layouts, and so on, you'll need to use Microsoft's <a href="https://adaptivecards.microsoft.com/" target="_blank">adaptive card format</a> to build your notification templates in Knock. This is essentially a JSON block language you use to lay out your Teams message.
+If you find yourself wanting to send notifications that include more advanced formatting and interactivity, such as buttons, data layouts, and so on, you'll need to use Microsoft's <a href="https://adaptivecards.microsoft.com/" target="_blank">adaptive card format</a> to build your notification templates in Knock. This is essentially a JSON block language you use to lay out your Microsoft Teams message.
 
-To switch to the JSON editor in the Knock template designer, look for the "Switch to JSON editor" button at the bottom of the template editor page. When you're in JSON editing mode, you can provide adaptive card JSON and we'll pass it to Teams on your behalf.
+To switch to the JSON editor in the Knock template designer, look for the "Switch to JSON editor" button at the bottom of the template editor page. When you're in JSON editing mode, you can provide adaptive card JSON and we'll pass it to Microsoft Teams on your behalf.
+
+Here's an example of the JSON you'll need to provide. Note that you must include your adaptive card JSON within the `attachments` array and set the `contentType` to `application/vnd.microsoft.card.adaptive`.
+
+```json title="Example JSON for sending an adaptive card to Microsoft Teams"
+{
+  "attachments": [
+    {
+      "content": {
+        "type": "AdaptiveCard",
+        "$schema": "https://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.5",
+        "body": [
+          {
+            "type": "TextBlock",
+            "text": "Lorem ipsum dolor sit"
+          }
+        ]
+      },
+      "contentType": "application/vnd.microsoft.card.adaptive",
+      "contentUrl": null
+    }
+  ],
+  "type": "message"
+}
+```
 
 <Callout
   emoji="⚠️"

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -202,13 +202,13 @@ By default, we provide a basic markdown editor that you can use for sending simp
 
 ### Advanced Teams notifications
 
-If you find yourself wanting to send notifications that include more advanced formatting and interactivity, such as buttons, data layouts, and so on, you'll need to use Microsoft's <a href="https://adaptivecards.microsoft.com/" target="_blank">adaptive card format</a> to build your notification templates in Knock. This is essentially a JSON block language you use to lay out your Microsoft Teams message.
+If you find yourself wanting to send notifications that include more advanced formatting and interactivity, such as buttons, data layouts, and so on, you'll need to use Microsoft's <a href="https://adaptivecards.microsoft.com/" target="_blank">Adaptive Card format</a> to build your notification templates in Knock. This is essentially a JSON block language you use to lay out your Microsoft Teams message.
 
 To switch to the JSON editor in the Knock template designer, look for the "Switch to JSON editor" button at the bottom of the template editor page. When you're in JSON editing mode, you can provide adaptive card JSON and we'll pass it to Microsoft Teams on your behalf.
 
-Here's an example of the JSON you'll need to provide. Note that you must include your adaptive card JSON within the `attachments` array and set the `contentType` to `application/vnd.microsoft.card.adaptive`.
+Here's an example of the JSON you'll need to provide. Note that you must include your Adaptive Card JSON within the `attachments` array and set the `contentType` to `application/vnd.microsoft.card.adaptive`.
 
-```json title="Example JSON for sending an adaptive card to Microsoft Teams"
+```json title="Example JSON for sending an Adaptive Card to Microsoft Teams"
 {
   "attachments": [
     {

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -221,7 +221,8 @@ Here's an example of the JSON you'll need to provide. Note that you must include
             "type": "TextBlock",
             "text": "Lorem ipsum dolor sit"
           }
-        ]
+        ],
+        "speak": "Lorem ipsum dolor sit"
       },
       "contentType": "application/vnd.microsoft.card.adaptive",
       "contentUrl": null

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -231,6 +231,8 @@ Here's an example of the JSON you'll need to provide. Note that you must include
 }
 ```
 
+<br />
+
 <Callout
   emoji="⚠️"
   text={


### PR DESCRIPTION
### Description

It’s not clear from our docs what the JSON payload should look like when a user wants to send a custom Adaptive Card to Microsoft Teams, so this PR adds an example.

### Tasks

[KNO-8385](https://linear.app/knock/issue/KNO-8385/update-ms-teams-docs-to-better-describe-using-custom-adaptive-cards)
