### PR TITLE
fix: add multi_select field to message types doc

### DIFF
--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -423,7 +423,7 @@ A multi-line plain text area
 
 - `required` (boolean): indicates this field is required
 - `description` (string): an optional friendly description
-- `default` (string): The default value to set
+- `default` (boolean): The default value to set
 
 **Example**
 
@@ -440,25 +440,53 @@ A multi-line plain text area
 
   </Accordion>
   <Accordion title="Select">
-  A single select box that defines a static list of options for editors to pick from.
+    A single select box that defines a static list of options for editors to pick from.
 
-**Settings**
+    **Settings**
 
-- `options` (object[]): A list of option objects that must include a `label` and a `value`
-- `required` (boolean): indicates this field is required
+    - `options` (object[]): A list of option objects that must include a `label` and a `value`
+    - `required` (boolean): indicates this field is required
+    - `default` (string): The value of the default option to set
 
-**Example**
+    **Example**
 
-```json
-{
-  "type": "select",
-  "key": "icon",
-  "label": "Icon",
-  "settings": {
-    "options": [{ "label": "Skull", "value": "skull" }]
-  }
-}
-```
+    ```json
+    {
+      "type": "select",
+      "key": "icon",
+      "label": "Icon",
+      "settings": {
+        "options": [{ "label": "Skull", "value": "skull" }]
+      }
+    }
+    ```
+
+  </Accordion>
+  <Accordion title="Multi-select">
+    A multi-select box that defines a static list of options for editors to pick from.
+
+    **Settings**
+
+    - `options` (object[]): A list of option objects that must include a `label` and a `value`
+    - `required` (boolean): indicates this field is required
+    - `default` (string[]): The values of the default options to set
+
+      **Example**
+
+    ```json
+    {
+      "type": "multi_select",
+      "key": "icons",
+      "label": "Icons",
+      "settings": {
+        "options": [
+          { "label": "Skull", "value": "skull" },
+          { "label": "Heart", "value": "heart" }
+        ],
+        "default": ["skull"]
+      }
+    }
+    ```
 
   </Accordion>
   <Accordion title="Button">


### PR DESCRIPTION
The `multi_select` field was missing from our in-app message types docs. 🤷🏻‍♂️ 