### PR TITLE
adds v1 api reference docs

### DIFF
--- a/components/ui/Page.tsx
+++ b/components/ui/Page.tsx
@@ -19,9 +19,26 @@ const Wrapper = ({ children }) => (
 
 const Masthead = ({ title }) => <PageHeader title={title} />;
 
-const Content = ({ children }) => (
-  <Stack direction="row" py="6" width="full" ml="60" position="relative">
-    <Box style={{ maxWidth: "600px" }} ml="24">
+const Content = ({ children, maxWidth }) => (
+  <Stack
+    direction="row"
+    py="6"
+    ml="60"
+    position="relative"
+    w={maxWidth ? "auto" : "full"}
+    style={{
+      maxWidth: maxWidth
+        ? `calc(${maxWidth} - var(--tgph-spacing-60))`
+        : "inherit",
+    }}
+  >
+    <Box
+      ml="24"
+      pr={maxWidth ? "24" : "0"}
+      style={{
+        width: maxWidth ? `calc(100% - var(--tgph-spacing-24))` : "600px",
+      }}
+    >
       {children}
     </Box>
   </Stack>

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -17,7 +17,7 @@ function selectedTab(pathname: string) {
   if (pathname.startsWith("/developer-tools")) {
     return "developer-tools";
   }
-  if (pathname.startsWith("/api-reference")) {
+  if (pathname.startsWith("/reference")) {
     return "api-reference";
   }
   if (pathname.startsWith("/cli-reference")) {

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -231,6 +231,7 @@ const developerToolsContent: SidebarSection[] = [
     slug: "/developer-tools",
     desc: "Use our powerful developer tools in order to integrate Knock seamlessly into your development workflow.",
     pages: [
+      { slug: "/overview", title: "Overview" },
       { slug: "/api-keys", title: "API keys" },
       { slug: "/service-tokens", title: "Service tokens" },
       { slug: "/knock-cli", title: "Knock CLI" },
@@ -257,6 +258,10 @@ const guidesContent: SidebarSection[] = [
     title: "Guides",
     slug: "/guides",
     pages: [
+      {
+        slug: "/overview",
+        title: "Overview",
+      },
       {
         slug: "/implementation-guide",
         title: "Knock implementation guide",

--- a/layouts/ApiReferenceLayout.tsx
+++ b/layouts/ApiReferenceLayout.tsx
@@ -1,21 +1,75 @@
-import React from "react";
-import { Page } from "./Page";
-import ApiReferenceSidebar from "../components/ApiReferenceSidebar";
-import MinimalHeader from "../components/Header/MinimalHeader";
+import React, { useEffect, useMemo } from "react";
+import { useRouter } from "next/router";
+import { Page } from "../components/ui/Page";
+import sidebarContent from "../data/sidebar";
+import {
+  guidesContent,
+  developerToolsContent,
+  inAppUiContent,
+} from "../data/sidebar";
+import apiReferenceSidebar from "../data/apiReferenceSidebar";
+import Meta from "../components/Meta";
+import { getSidebarInfo, slugToPaths } from "../lib/content";
 
-export const ApiReferenceLayout = ({ frontMatter, children }) => (
-  <Page
-    header={<MinimalHeader pageType="API" />}
-    sidebar={<ApiReferenceSidebar />}
-    metaProps={{
-      title: `${frontMatter.title} | Knock`,
-      description: frontMatter.description,
-    }}
-  >
-    <div className="w-full max-w-5xl lg:flex mx-auto relative">
-      <div className="w-full flex-auto">
-        <div className="docs-content api-docs-content">{children}</div>
-      </div>
-    </div>
-  </Page>
-);
+function useSidebarContent() {
+  const { asPath } = useRouter();
+  if (asPath.startsWith("/guides")) {
+    return guidesContent;
+  }
+  if (asPath.startsWith("/developer-tools")) {
+    return developerToolsContent;
+  }
+  if (asPath.startsWith("/in-app-ui")) {
+    return inAppUiContent;
+  }
+  if (asPath.startsWith("/reference")) {
+    return apiReferenceSidebar;
+  }
+  return sidebarContent;
+}
+
+export const ApiReferenceLayout = ({ frontMatter, sourcePath, children }) => {
+  const router = useRouter();
+  const paths = slugToPaths(router.query.slug);
+
+  useEffect(() => {
+    const content = document.querySelector(".main-content");
+
+    // Right now we need this hack to ensure that we scroll the main content to
+    // the top of the view when navigating.
+    if (content) {
+      content.scrollTop = 0;
+    }
+  }, [paths]);
+
+  const sidebarContent = useSidebarContent();
+
+  const { breadcrumbs, nextPage, prevPage } = useMemo(
+    () => getSidebarInfo(paths, sidebarContent),
+    [paths, sidebarContent],
+  );
+
+  return (
+    <Page.Container>
+      <Meta
+        title={`${frontMatter.title} | Knock Docs`}
+        description={frontMatter.description}
+      />
+      <Page.Masthead title={frontMatter.title} />
+      <Page.Wrapper>
+        <Page.Sidebar content={sidebarContent} />
+        <Page.Content maxWidth="1400px">
+          {breadcrumbs && <Page.Breadcrumbs pages={breadcrumbs} />}
+          <Page.ContentHeader
+            title={frontMatter.title}
+            description={frontMatter.description}
+          />
+          <Page.ContentBody maxWidth="lg">{children}</Page.ContentBody>
+        </Page.Content>
+        {frontMatter.showNav !== false && (
+          <Page.OnThisPage title={frontMatter.title} sourcePath={sourcePath} />
+        )}
+      </Page.Wrapper>
+    </Page.Container>
+  );
+};

--- a/styles/index.css
+++ b/styles/index.css
@@ -21,6 +21,12 @@ html {
   scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /*
+    Adjust the calculated top of the page to account for the sticky header
+    This prevents #id element navigation from being hidden behind the header.
+    Our header is 85px right now, 96px adds a buffer.
+  */
+  scroll-padding-top: 96px;
 }
 
 /* Remove default margin in favour of better control in authored CSS */


### PR DESCRIPTION
Things to fix:
- hydration issues when a URL uses a `#id` to reference on a page
- sidebar highlighting on scroll
<img width="1512" alt="Screenshot 2025-04-21 at 8 06 11 PM" src="https://github.com/user-attachments/assets/a7c24c15-1a62-4bf3-94bd-b8d66e32f851" />