### PR TITLE
chore: remove beta tags from audiences, broadcasts, and 1-click

### DIFF
--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -5,20 +5,6 @@ tags: []
 section: Concepts
 ---
 
-<Callout
-  emoji="🚧"
-  text={
-    <>
-      Audiences is currently in beta. If you'd like early access, or this is
-      blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Audiences beta access">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
 An Audience is a user segment that you can notify. You can bring audiences into Knock programmatically with our API or a supported reverse-ETL source.
 
 Once you start creating audiences in Knock, you can use them to:

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -5,20 +5,6 @@ tags: []
 section: Concepts
 ---
 
-<Callout
-  emoji="🚧"
-  text={
-    <>
-      Broadcasts are currently in beta. If you'd like early access, or this is
-      blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Broadcasts%20beta%20access">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
 Broadcasts are a way to power one-time, cross-channel messaging to your users through Knock. They are built on Knock's [workflow engine](/concepts/workflows), giving you the power to create intelligent messaging across all of the [channels you've configured in Knock](/concepts/channels).
 
 ## Broadcasts and the environment model

--- a/data/sidebar.ts
+++ b/data/sidebar.ts
@@ -1,5 +1,4 @@
 import { SidebarSection } from "./types";
-import sidebarJson from "./sidebar.json";
 
 const sidebarContent: SidebarSection[] = [
   {
@@ -33,8 +32,8 @@ const sidebarContent: SidebarSection[] = [
       { slug: "/translations", title: "Translations" },
       { slug: "/conditions", title: "Conditions" },
       { slug: "/variables", title: "Variables" },
-      { slug: "/audiences", title: "Audiences", isBeta: true },
-      { slug: "/broadcasts", title: "Broadcasts", isBeta: true },
+      { slug: "/audiences", title: "Audiences" },
+      { slug: "/broadcasts", title: "Broadcasts" },
     ],
   },
   {
@@ -106,7 +105,7 @@ const sidebarContent: SidebarSection[] = [
           { slug: "/api", title: "With the API" },
           { slug: "/schedules", title: "On a schedule" },
           { slug: "/events", title: "From an event" },
-          { slug: "/audiences", title: "For an audience", isBeta: true },
+          { slug: "/audiences", title: "For an audience" },
         ],
       },
       { slug: "/canceling-workflows", title: "Canceling workflows" },
@@ -129,7 +128,6 @@ const sidebarContent: SidebarSection[] = [
       {
         slug: "/commercial-unsubscribe",
         title: "Commercial unsubscribe",
-        isBeta: true,
       },
     ],
   },


### PR DESCRIPTION
### Description
Remove beta tags from audiences, broadcasts, and 1-click. Will deploy Wed.


### Tasks
https://linear.app/knock/issue/KNO-8534/remove-beta-flag-from-audiences-and-broadcasts

### Screenshots
![CleanShot 2025-04-28 at 11 42 17](https://github.com/user-attachments/assets/1fbe142f-ccc7-41fb-bd5d-408ce7a33914)
