### PR TITLE
fix(kno-8549): fix message status schemas

### DIFF
--- a/components/ui/ApiReference/ApiReferenceMethod/ApiReferenceMethod.tsx
+++ b/components/ui/ApiReference/ApiReferenceMethod/ApiReferenceMethod.tsx
@@ -10,7 +10,10 @@ import { SchemaProperties } from "../SchemaProperties";
 import OperationParameters from "../OperationParameters/OperationParameters";
 import { PropertyRow } from "../SchemaProperties/PropertyRow";
 import MultiLangExample from "../MultiLangExample";
-import { augmentSnippetsWithCurlRequest, resolveResponseSchemas } from "../helpers";
+import {
+  augmentSnippetsWithCurlRequest,
+  resolveResponseSchemas,
+} from "../helpers";
 import { Heading } from "@telegraph/typography";
 import { AnimatePresence, motion } from "framer-motion";
 import RateLimit from "@/components/ui/RateLimit";
@@ -43,9 +46,8 @@ function ApiReferenceMethod({ methodName, methodType, endpoint, path }: Props) {
     (p) => p.in === "query",
   ) as OpenAPIV3.ParameterObject[];
 
-  const responseSchemas: OpenAPIV3.SchemaObject[] = resolveResponseSchemas(
-    method,
-  );
+  const responseSchemas: OpenAPIV3.SchemaObject[] =
+    resolveResponseSchemas(method);
 
   const requestBody: OpenAPIV3.SchemaObject | undefined =
     method.requestBody?.content?.["application/json"]?.schema;

--- a/components/ui/ApiReference/ApiReferenceMethod/ApiReferenceMethod.tsx
+++ b/components/ui/ApiReference/ApiReferenceMethod/ApiReferenceMethod.tsx
@@ -10,13 +10,12 @@ import { SchemaProperties } from "../SchemaProperties";
 import OperationParameters from "../OperationParameters/OperationParameters";
 import { PropertyRow } from "../SchemaProperties/PropertyRow";
 import MultiLangExample from "../MultiLangExample";
-import { augmentSnippetsWithCurlRequest } from "../helpers";
+import { augmentSnippetsWithCurlRequest, resolveResponseSchemas } from "../helpers";
 import { Heading } from "@telegraph/typography";
 import { AnimatePresence, motion } from "framer-motion";
 import RateLimit from "@/components/ui/RateLimit";
 import Callout from "@/components/ui/Callout";
 import { Box } from "@telegraph/layout";
-import { Text } from "@telegraph/typography";
 
 type Props = {
   methodName: string;
@@ -44,9 +43,10 @@ function ApiReferenceMethod({ methodName, methodType, endpoint, path }: Props) {
     (p) => p.in === "query",
   ) as OpenAPIV3.ParameterObject[];
 
-  const responseSchemas: OpenAPIV3.SchemaObject[] = Object.values(
-    responses,
-  ).map((r) => r.content?.["application/json"]?.schema);
+  const responseSchemas: OpenAPIV3.SchemaObject[] = resolveResponseSchemas(
+    method,
+  );
+
   const requestBody: OpenAPIV3.SchemaObject | undefined =
     method.requestBody?.content?.["application/json"]?.schema;
 

--- a/components/ui/ApiReference/helpers.ts
+++ b/components/ui/ApiReference/helpers.ts
@@ -16,13 +16,13 @@ function resolveEndpointFromMethod(
   return [methodType, endpoint];
 }
 
-function resolveResponseSchemas(
-  method: OpenAPIV3.OperationObject,
-) {
+function resolveResponseSchemas(method: OpenAPIV3.OperationObject) {
   const responseSchemas: OpenAPIV3.SchemaObject[] = Object.values(
     method.responses || {},
-  ).map((r) => r.content?.["application/json"]?.schema).map(responseSchema => {
-    if (responseSchema?.allOf) {
+  )
+    .map((r) => r.content?.["application/json"]?.schema)
+    .map((responseSchema) => {
+      if (responseSchema?.allOf) {
         return responseSchema.allOf[0];
       }
       return responseSchema;

--- a/components/ui/ApiReference/helpers.ts
+++ b/components/ui/ApiReference/helpers.ts
@@ -16,6 +16,21 @@ function resolveEndpointFromMethod(
   return [methodType, endpoint];
 }
 
+function resolveResponseSchemas(
+  method: OpenAPIV3.OperationObject,
+) {
+  const responseSchemas: OpenAPIV3.SchemaObject[] = Object.values(
+    method.responses || {},
+  ).map((r) => r.content?.["application/json"]?.schema).map(responseSchema => {
+    if (responseSchema?.allOf) {
+        return responseSchema.allOf[0];
+      }
+      return responseSchema;
+    });
+
+  return responseSchemas;
+}
+
 function buildSchemaReferencesForResource(
   resource: StainlessResource,
   openApiSpec: OpenAPIV3.Document,
@@ -199,4 +214,5 @@ export {
   buildSidebarPages,
   augmentSnippetsWithCurlRequest,
   buildSchemaReferences,
+  resolveResponseSchemas,
 };

--- a/data/specs/api/openapi.yml
+++ b/data/specs/api/openapi.yml
@@ -4329,6 +4329,23 @@ components:
             workflow.
       title: PreferenceSetRequest
       type: object
+    BulkDeleteObjectsRequest:
+      description: Request body for bulk deleting objects.
+      example:
+        object_ids:
+          - obj_123
+          - obj_456
+          - obj_789
+      properties:
+        object_ids:
+          description: List of object IDs to delete.
+          items:
+            type: string
+          type: array
+      required:
+        - object_ids
+      title: BulkDeleteObjectsRequest
+      type: object
     TeamsForMsTeamsProviderResponse:
       description: The response from a Microsoft Teams provider request, containing a list of teams.
       example:
@@ -4822,8 +4839,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -4921,8 +4938,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5055,8 +5072,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5263,8 +5280,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5381,8 +5398,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5539,8 +5556,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5651,8 +5668,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5792,8 +5809,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5899,8 +5916,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -5998,8 +6015,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6160,8 +6177,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6292,8 +6309,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6544,8 +6561,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6784,8 +6801,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6887,7 +6904,7 @@ paths:
                 - obj_456
                 - obj_789
             schema:
-              $ref: '#/components/schemas/'
+              $ref: '#/components/schemas/BulkDeleteObjectsRequest'
         description: Params
         required: true
       responses:
@@ -6912,7 +6929,7 @@ paths:
 
           async function main() {
             const bulkOperation = await client.objects.bulk.delete('collection', {
-              body: { object_ids: ['obj_123', 'obj_456', 'obj_789'] },
+              object_ids: ['obj_123', 'obj_456', 'obj_789'],
             });
 
             console.log(bulkOperation.id);
@@ -6928,9 +6945,7 @@ paths:
           )
           bulk_operation = client.objects.bulk.delete(
               collection="collection",
-              body={
-                  "object_ids": ["obj_123", "obj_456", "obj_789"]
-              },
+              object_ids=["obj_123", "obj_456", "obj_789"],
           )
           print(bulk_operation.id)
         go: |
@@ -6940,8 +6955,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -6952,13 +6967,7 @@ paths:
               context.TODO(),
               "collection",
               knock.ObjectBulkDeleteParams{
-                Body: map[string]interface{}{
-                "object_ids": map[string]interface{}{
-                "0": "obj_123",
-                "1": "obj_456",
-                "2": "obj_789",
-                },
-                },
+                ObjectIDs: knock.F([]string{"obj_123", "obj_456", "obj_789"}),
               },
             )
             if err != nil {
@@ -6971,11 +6980,9 @@ paths:
 
           import app.knock.api.client.KnockClient;
           import app.knock.api.client.okhttp.KnockOkHttpClient;
-          import app.knock.api.core.JsonValue;
           import app.knock.api.models.bulkoperations.BulkOperation;
           import app.knock.api.models.objects.bulk.BulkDeleteParams;
           import java.util.List;
-          import java.util.Map;
 
           public final class Main {
               private Main() {}
@@ -6986,13 +6993,11 @@ paths:
 
                   BulkDeleteParams params = BulkDeleteParams.builder()
                       .collection("collection")
-                      .body(JsonValue.from(Map.of(
-                        "object_ids", List.of(
-                          "obj_123",
-                          "obj_456",
-                          "obj_789"
-                        )
-                      )))
+                      .objectIds(List.of(
+                        "obj_123",
+                        "obj_456",
+                        "obj_789"
+                      ))
                       .build();
                   BulkOperation bulkOperation = client.objects().bulk().delete(params);
               }
@@ -7006,8 +7011,8 @@ paths:
           )
 
 
-          bulk_operation = knock.objects.bulk.delete("collection", body: {object_ids: ["obj_123", "obj_456",
-          "obj_789"]})
+          bulk_operation = knock.objects.bulk.delete("collection", object_ids: ["obj_123", "obj_456",
+          "obj_789"])
 
 
           puts(bulk_operation)
@@ -7115,8 +7120,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -7263,8 +7268,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -7428,9 +7433,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -7632,8 +7637,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -7808,8 +7813,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -7953,8 +7958,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8088,8 +8093,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8198,8 +8203,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8311,8 +8316,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8441,8 +8446,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8586,8 +8591,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8704,8 +8709,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -8840,8 +8845,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9015,8 +9020,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9189,8 +9194,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9307,8 +9312,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9580,8 +9585,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9736,8 +9741,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -9876,8 +9881,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -10011,8 +10016,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -10159,9 +10164,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -10332,8 +10337,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -10444,8 +10449,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -10583,8 +10588,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -10744,9 +10749,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -10928,9 +10933,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -11074,8 +11079,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11213,8 +11218,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11413,8 +11418,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11524,8 +11529,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11692,8 +11697,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11805,8 +11810,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -11978,9 +11983,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -12113,8 +12118,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -12243,8 +12248,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -12425,8 +12430,8 @@ paths:
             "fmt"
             "time"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -12590,8 +12595,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -12733,8 +12738,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -12863,8 +12868,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13012,8 +13017,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13152,8 +13157,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13268,8 +13273,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13539,8 +13544,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13695,8 +13700,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13813,8 +13818,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -13972,8 +13977,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14158,8 +14163,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14315,8 +14320,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14443,8 +14448,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14577,8 +14582,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14708,8 +14713,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -14865,8 +14870,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -15000,8 +15005,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -15177,8 +15182,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -15443,8 +15448,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -15583,8 +15588,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -15757,8 +15762,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -16005,8 +16010,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -16179,8 +16184,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -16367,8 +16372,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -16492,9 +16497,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -16749,9 +16754,9 @@ paths:
             "fmt"
             "time"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -16904,9 +16909,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -17025,8 +17030,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17195,8 +17200,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17365,8 +17370,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17479,8 +17484,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17596,8 +17601,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17757,8 +17762,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -17890,9 +17895,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -18072,8 +18077,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -18212,9 +18217,9 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
-            "github.com/stainless-sdks/knock-go/shared"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
+            "github.com/knocklabs/knock-go/shared"
           )
 
           func main() {
@@ -18414,8 +18419,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {
@@ -18587,8 +18592,8 @@ paths:
             "context"
             "fmt"
 
-            "github.com/stainless-sdks/knock-go"
-            "github.com/stainless-sdks/knock-go/option"
+            "github.com/knocklabs/knock-go"
+            "github.com/knocklabs/knock-go/option"
           )
 
           func main() {

--- a/data/specs/api/stainless.yml
+++ b/data/specs/api/stainless.yml
@@ -45,69 +45,69 @@ resources:
       inline_identify_user_request: '#/components/schemas/InlineIdentifyUserRequest'
     methods:
       get: get /v1/users/{user_id}
-      list: 
+      list:
         endpoint: get /v1/users
       update: put /v1/users/{user_id}
       merge: post /v1/users/{user_id}/merge
       delete: delete /v1/users/{user_id}
-      list_messages: 
+      list_messages:
         endpoint: get /v1/users/{user_id}/messages
-      list_schedules: 
+      list_schedules:
         endpoint: get /v1/users/{user_id}/schedules
-      list_subscriptions: 
+      list_subscriptions:
         endpoint: get /v1/users/{user_id}/subscriptions
-      list_preferences: 
+      list_preferences:
         endpoint: get /v1/users/{user_id}/preferences
         paginated: false
-      get_preferences: 
+      get_preferences:
         type: http
         endpoint: get /v1/users/{user_id}/preferences/{id}
-        positional_params: [user_id, id]
-      set_preferences: 
+        positional_params: [ user_id, id ]
+      set_preferences:
         type: http
         endpoint: put /v1/users/{user_id}/preferences/{id}
-        positional_params: [user_id, id]
-      get_channel_data: 
+        positional_params: [ user_id, id ]
+      get_channel_data:
         type: http
         endpoint: get /v1/users/{user_id}/channel_data/{channel_id}
-        positional_params: [user_id, channel_id]
-      set_channel_data: 
+        positional_params: [ user_id, channel_id ]
+      set_channel_data:
         type: http
         endpoint: put /v1/users/{user_id}/channel_data/{channel_id}
-        positional_params: [user_id, channel_id]
-      unset_channel_data: 
+        positional_params: [ user_id, channel_id ]
+      unset_channel_data:
         type: http
         endpoint: delete /v1/users/{user_id}/channel_data/{channel_id}
-        positional_params: [user_id, channel_id]
+        positional_params: [ user_id, channel_id ]
     subresources:
       feeds:
         methods:
-          list_items: 
+          list_items:
             type: http
             endpoint: get /v1/users/{user_id}/feeds/{id}
-            positional_params: [user_id, id]
-          get_settings: 
+            positional_params: [ user_id, id ]
+          get_settings:
             type: http
             endpoint: get /v1/users/{user_id}/feeds/{id}/settings
-            positional_params: [user_id, id]
+            positional_params: [ user_id, id ]
       guides:
         methods:
           get_channel:
             type: http
             endpoint: get /v1/users/{user_id}/guides/{channel_id}
-            positional_params: [user_id, channel_id]
+            positional_params: [ user_id, channel_id ]
           mark_message_as_seen:
             type: http
             endpoint: put /v1/users/{user_id}/guides/messages/{message_id}/seen
-            positional_params: [user_id, message_id]
+            positional_params: [ user_id, message_id ]
           mark_message_as_interacted:
             type: http
             endpoint: put /v1/users/{user_id}/guides/messages/{message_id}/interacted
-            positional_params: [user_id, message_id]
+            positional_params: [ user_id, message_id ]
           mark_message_as_archived:
             type: http
             endpoint: put /v1/users/{user_id}/guides/messages/{message_id}/archived
-            positional_params: [user_id, message_id]
+            positional_params: [ user_id, message_id ]
       bulk:
         methods:
           identify: post /v1/users/bulk/identify
@@ -118,63 +118,63 @@ resources:
       object: '#/components/schemas/Object'
       inline_object_request: '#/components/schemas/InlineIdentifyObjectRequest'
     methods:
-      set: 
+      set:
         type: http
         endpoint: put /v1/objects/{collection}/{id}
-        positional_params: [collection, id]
-      get: 
+        positional_params: [ collection, id ]
+      get:
         type: http
         endpoint: get /v1/objects/{collection}/{id}
-        positional_params: [collection, id]
+        positional_params: [ collection, id ]
       list: get /v1/objects/{collection}
-      delete: 
+      delete:
         type: http
         endpoint: delete /v1/objects/{collection}/{id}
-        positional_params: [collection, id]
+        positional_params: [ collection, id ]
       list_preferences:
         type: http
         endpoint: get /v1/objects/{collection}/{object_id}/preferences
-        positional_params: [collection, object_id]
-      get_preferences: 
+        positional_params: [ collection, object_id ]
+      get_preferences:
         type: http
         endpoint: get /v1/objects/{collection}/{object_id}/preferences/{id}
-        positional_params: [collection, object_id, id]
-      set_preferences: 
+        positional_params: [ collection, object_id, id ]
+      set_preferences:
         type: http
         endpoint: put /v1/objects/{collection}/{object_id}/preferences/{id}
-        positional_params: [collection, object_id, id]
-      list_schedules: 
+        positional_params: [ collection, object_id, id ]
+      list_schedules:
         type: http
         endpoint: get /v1/objects/{collection}/{id}/schedules
-        positional_params: [collection, id]
-      list_messages: 
+        positional_params: [ collection, id ]
+      list_messages:
         type: http
         endpoint: get /v1/objects/{collection}/{id}/messages
-        positional_params: [collection, id]
-      get_channel_data: 
+        positional_params: [ collection, id ]
+      get_channel_data:
         type: http
         endpoint: get /v1/objects/{collection}/{object_id}/channel_data/{channel_id}
-        positional_params: [collection, object_id, channel_id]
-      set_channel_data: 
+        positional_params: [ collection, object_id, channel_id ]
+      set_channel_data:
         type: http
         endpoint: put /v1/objects/{collection}/{object_id}/channel_data/{channel_id}
-        positional_params: [collection, object_id, channel_id]
-      unset_channel_data: 
+        positional_params: [ collection, object_id, channel_id ]
+      unset_channel_data:
         type: http
         endpoint: delete /v1/objects/{collection}/{object_id}/channel_data/{channel_id}
-        positional_params: [collection, object_id, channel_id]
-      list_subscriptions: 
+        positional_params: [ collection, object_id, channel_id ]
+      list_subscriptions:
         type: http
         endpoint: get /v1/objects/{collection}/{object_id}/subscriptions
-        positional_params: [collection, object_id]
-      add_subscriptions: 
+        positional_params: [ collection, object_id ]
+      add_subscriptions:
         type: http
         endpoint: post /v1/objects/{collection}/{object_id}/subscriptions
-        positional_params: [collection, object_id]
-      delete_subscriptions: 
+        positional_params: [ collection, object_id ]
+      delete_subscriptions:
         type: http
         endpoint: delete /v1/objects/{collection}/{object_id}/subscriptions
-        positional_params: [collection, object_id]
+        positional_params: [ collection, object_id ]
     subresources:
       bulk:
         methods:
@@ -210,13 +210,13 @@ resources:
     methods:
       get: get /v1/messages/{message_id}
       get_content: get /v1/messages/{message_id}/content
-      list: 
+      list:
         endpoint: get /v1/messages
-      list_events: 
+      list_events:
         endpoint: get /v1/messages/{message_id}/events
-      list_delivery_logs: 
+      list_delivery_logs:
         endpoint: get /v1/messages/{message_id}/delivery_logs
-      list_activities: 
+      list_activities:
         endpoint: get /v1/messages/{message_id}/activities
       mark_as_seen: put /v1/messages/{message_id}/seen
       mark_as_unseen: delete /v1/messages/{message_id}/seen
@@ -288,10 +288,10 @@ resources:
     subresources:
       bulk:
         methods:
-          update_message_status: 
+          update_message_status:
             type: http
             endpoint: post /v1/channels/{channel_id}/messages/bulk/{action}
-            positional_params: [channel_id, action]
+            positional_params: [ channel_id, action ]
   audiences:
     models:
       audience_member: '#/components/schemas/AudienceMember'
@@ -303,29 +303,29 @@ resources:
 targets:
   typescript:
     package_name: "@knocklabs/node"
-    production_repo: null
+    production_repo: knocklabs/knock-node
     publish:
       npm: false
     skip: false
   go:
     package_name: knock
-    production_repo: null
+    production_repo: knocklabs/knock-go
     skip: false
   python:
     package_name: knockapi
-    production_repo: null
+    production_repo: knocklabs/knock-python
     publish:
       pypi: false
     skip: false
   java:
     reverse_domain: app.knock.api
-    production_repo: null
+    production_repo: knocklabs/knock-java
     publish:
       maven: false
     skip: false
   ruby:
     gem_name: knockapi
-    production_repo: null
+    production_repo: knocklabs/knock-ruby
     publish:
       rubygems: false
 settings:
@@ -339,7 +339,7 @@ client_settings:
 environments:
   production: https://api.knock.app
 openapi:
-  code_samples: 
+  code_samples:
     stainless: true
 query_settings:
   nested_format: brackets


### PR DESCRIPTION
### Description
Message status responses weren't showing because they reference "allOf" the Message schema in the OpenApi spec. 

### Tasks
[KNO-8549: \[docs\] fix mark messages status schemas](https://linear.app/knock/issue/KNO-8549/[docs]-fix-mark-messages-status-schemas)