### PR TITLE
chore: update endpoints in tutorials with new placeholder syntax

### DIFF
--- a/content/tutorials/implementation-guide.mdx
+++ b/content/tutorials/implementation-guide.mdx
@@ -103,7 +103,7 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
         <a href="https://docs.knock.app/api-reference/users/update" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="PUT" path="https://api.knock.app/v1/users/:user_id" />
+          <Endpoint method="PUT" path="https://api.knock.app/v1/users/{user_id}" />
         </a>
         <a href="https://docs.knock.app/api-reference/users/bulk/identify" target="_blank" style={{textDecoration: 'none'}}>
           <Endpoint method="POST" path="https://api.knock.app/v1/users/bulk/identify" />
@@ -120,16 +120,16 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
         <a href="https://docs.knock.app/api-reference/objects/set" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="PUT" path="https://api.knock.app/v1/objects/:collection/:id" />
+          <Endpoint method="PUT" path="https://api.knock.app/v1/objects/{collection}/{id}" />
         </a>
         <a href="https://docs.knock.app/api-reference/objects/bulk/set" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/bulk/set" />
+          <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/bulk/set" />
         </a>
         <a href="https://docs.knock.app/api-reference/objects/add_subscriptions" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/:id/subscriptions" />
+          <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/{object_id}/subscriptions" />
         </a>
         <a href="https://docs.knock.app/api-reference/objects/bulk/add_subscriptions" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/bulk/subscriptions/add" />
+          <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/bulk/subscriptions/add" />
         </a>
       </Accordion>
     </AccordionGroup>
@@ -160,7 +160,7 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
         <a href="https://docs.knock.app/api-reference/tenants/set" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="PUT" path="https://api.knock.app/v1/tenants/:id" />
+          <Endpoint method="PUT" path="https://api.knock.app/v1/tenants/{id}" />
         </a>
       </Accordion>
     </AccordionGroup>
@@ -176,13 +176,13 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
         <a href="https://docs.knock.app/api-reference/users/set_preferences" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="PUT" path="https://api.knock.app/v1/users/:user_id/preferences/:id" />
+          <Endpoint method="PUT" path="https://api.knock.app/v1/users/{user_id}/preferences/{id}" />
         </a>
         <a href="https://docs.knock.app/api-reference/users/bulk/set_preferences" target="_blank" style={{textDecoration: 'none'}}>
           <Endpoint method="POST" path="https://api.knock.app/v1/users/bulk/preferences" />
         </a>
         <a href="https://docs.knock.app/api-reference/objects/set_preferences" target="_blank" style={{textDecoration: 'none'}}>
-          <Endpoint method="PUT" path="https://api.knock.app/v1/objects/:collection/:object_id/preferences/:id" />
+          <Endpoint method="PUT" path="https://api.knock.app/v1/objects/{collection}/{object_id}/preferences/{id}" />
         </a>
       </Accordion>
     </AccordionGroup>
@@ -191,12 +191,15 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
   <Step title="Schedules">
     Finally, for any notifications that you’ll send on a recurring basis or reminders that should be sent at a specific future date, our [Schedules](/concepts/schedules) feature should be considered before you’re ready to finalize your integration.
 
-    Schedules can be set, updated, and deleted via API. Although they are recipient-specific, you can create a schedule for up to 100 recipients at a time.
+    Schedules can be set, updated, and deleted via API. Although they are recipient-specific, you can set the same schedule for up to 100 recipients at a time by providing a list of recipients. To set unique schedules for multiple recipients, you can create up to 1,000 schedules at a time with the bulk endpoint.
 
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
         <a href="https://docs.knock.app/api-reference/schedules/create" target="_blank" style={{textDecoration: 'none'}}>
           <Endpoint method="POST" path="https://api.knock.app/v1/schedules" />
+        </a>
+        <a href="https://docs.knock.app/api-reference/schedules/bulk/create" target="_blank" style={{textDecoration: 'none'}}>
+          <Endpoint method="POST" path="https://api.knock.app/v1/schedules/bulk/create" />
         </a>
         <a href="https://docs.knock.app/api-reference/schedules/update" target="_blank" style={{textDecoration: 'none'}}>
           <Endpoint method="PUT" path="https://api.knock.app/v1/schedules" />

--- a/content/tutorials/migrate-from-courier.mdx
+++ b/content/tutorials/migrate-from-courier.mdx
@@ -151,7 +151,7 @@ We recommend migrating data into Knock in the following order to ensure that cer
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
           <a href="https://www.courier.com/docs/reference/translations/get_translation/" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="GET" path="https://api.courier.com/translations/:domain/:locale" />
+            <Endpoint method="GET" path="https://api.courier.com/translations/{domain}/{locale}" />
           </a>
           <a href="https://docs.knock.app/mapi-reference/translations/upsert" target="_blank" style={{textDecoration: 'none'}}>
             <Endpoint method="PUT" path="https://control.knock.app/v1/translations/{locale_code}" />
@@ -172,7 +172,7 @@ We recommend migrating data into Knock in the following order to ensure that cer
             <Endpoint method="GET" path="https://api.courier.com/brands" />
           </a>
           <a href="https://docs.knock.app/api-reference/tenants/set" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="PUT" path="https://api.knock.app/v1/tenants/:id" />
+            <Endpoint method="PUT" path="https://api.knock.app/v1/tenants/{id}" />
           </a>
       </Accordion>
     </AccordionGroup>
@@ -187,10 +187,10 @@ We recommend migrating data into Knock in the following order to ensure that cer
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
           <a href="https://www.courier.com/docs/reference/profiles/by-id/" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="GET" path="https://api.courier.com/profiles/:user_id" />
+            <Endpoint method="GET" path="https://api.courier.com/profiles/{user_id}" />
           </a>
           <a href="https://docs.knock.app/api-reference/users/update" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="PUT" path="https://api.knock.app/v1/users/:user_id" />
+            <Endpoint method="PUT" path="https://api.knock.app/v1/users/{user_id}" />
           </a>
           <a href="https://docs.knock.app/api-reference/users/bulk/identify" target="_blank" style={{textDecoration: 'none'}}>
             <Endpoint method="POST" path="https://api.knock.app/v1/users/bulk/identify" />
@@ -213,19 +213,19 @@ We recommend migrating data into Knock in the following order to ensure that cer
             <Endpoint method="GET" path="https://api.courier.com/lists" />
           </a>
           <a href="https://www.courier.com/docs/reference/lists/subscriptions/" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="GET" path="https://api.courier.com/lists/:list_id/subscriptions" />
+            <Endpoint method="GET" path="https://api.courier.com/lists/{list_id}/subscriptions" />
           </a>
           <a href="https://docs.knock.app/api-reference/objects/set" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="PUT" path="https://api.knock.app/v1/objects/:collection/:id" />
+            <Endpoint method="PUT" path="https://api.knock.app/v1/objects/{collection}/{id}" />
           </a>
           <a href="https://docs.knock.app/api-reference/objects/bulk/set" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/bulk/set" />
+            <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/bulk/set" />
           </a>
           <a href="https://docs.knock.app/api-reference/objects/add_subscriptions" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/:id/subscriptions" />
+            <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/{object_id}/subscriptions" />
           </a>
           <a href="https://docs.knock.app/api-reference/objects/bulk/add_subscriptions" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="POST" path="https://api.knock.app/v1/objects/:collection/bulk/subscriptions/add" />
+            <Endpoint method="POST" path="https://api.knock.app/v1/objects/{collection}/bulk/subscriptions/add" />
           </a>
       </Accordion>
     </AccordionGroup>
@@ -237,10 +237,10 @@ We recommend migrating data into Knock in the following order to ensure that cer
     <AccordionGroup>
       <Accordion title="Relevant endpoints">
           <a href="https://www.courier.com/docs/reference/user-preferences/list-all-user-preferences/" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="GET" path="https://api.courier.com/users/:user_id/preferences" />
+            <Endpoint method="GET" path="https://api.courier.com/users/{user_id}/preferences" />
           </a>
           <a href="https://docs.knock.app/api-reference/users/set_preferences" target="_blank" style={{textDecoration: 'none'}}>
-            <Endpoint method="PUT" path="https://api.knock.app/v1/users/:user_id/preferences/:id" />
+            <Endpoint method="PUT" path="https://api.knock.app/v1/users/{user_id}/preferences/{id}" />
           </a>
           <a href="https://docs.knock.app/api-reference/users/bulk/set_preferences" target="_blank" style={{textDecoration: 'none'}}>
             <Endpoint method="POST" path="https://api.knock.app/v1/users/bulk/preferences" />


### PR DESCRIPTION
### Description

This PR updates the placeholder syntax in the listed endpoints in our integration/migration guides to reflect the new syntax:
`https://api.knock.app/v1/objects/:collection/:id/subscriptions` -> `https://api.knock.app/v1/objects/{collection}/{object_id}/subscriptions`

It also adds the new bulk schedules endpoint and clarifies the language around creating schedules for multiple recipients at a time.
