### PR TITLE
fix(kno-8569): stop scrolling when typing in search bar

### DIFF
--- a/components/ui/ApiReference/ApiReference.tsx
+++ b/components/ui/ApiReference/ApiReference.tsx
@@ -3,7 +3,6 @@
 import { ApiReferenceProvider } from "./ApiReferenceContext";
 import { ApiReferenceSection } from ".";
 import { Page as TelegraphPage } from "../Page";
-import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { StainlessConfig } from "../../../lib/openApiSpec";
 import { OpenAPIV3 } from "@scalar/openapi-types";

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -41,9 +41,15 @@ export const highlightResource = (
 
     // Scroll to the content on the page
     if (newActiveItem) {
-      newActiveItem.scrollIntoView({
-        behavior: "instant",
-        block: "start",
+      // Get the desired padding from the CSS variable
+      const topPadding = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--top-padding'), 10) || 0;
+      const elementRect = newActiveItem.getBoundingClientRect();
+      const targetScrollY = window.scrollY + elementRect.top - topPadding;
+
+      window.scrollTo({
+        top: targetScrollY,
+        // Use 'instant' matching the original scrollIntoView behavior here
+        behavior: "instant", 
       });
 
       newActiveItem.focus();
@@ -118,7 +124,20 @@ export const useInitialScrollState = () => {
         `[data-resource-path="${resourcePath}"]`,
       );
 
-      element?.scrollIntoView();
+      if (element) {
+        // Get the desired padding from the CSS variable
+        const topPadding = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--top-padding'), 10) || 0;
+        const elementRect = element.getBoundingClientRect();
+        // Calculate scroll position relative to the current scroll, adjusted for padding.
+        // No need for window.scrollY here as we are setting the absolute scroll position on load (within timeout).
+        const targetScrollY = window.pageYOffset + elementRect.top - topPadding;
+        
+        // Use 'auto' for immediate jump on load, respecting user agent settings for motion if any.
+        window.scrollTo({ top: targetScrollY, behavior: 'auto' }); 
+      } else {
+        // Fallback or default scroll behavior if element not found initially
+        window.scrollTo(0, 0);
+      }
     }, 250);
 
     return () => clearTimeout(timeout);

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -48,7 +48,6 @@ export const highlightResource = (
 
       window.scrollTo({
         top: targetScrollY,
-        // Use 'instant' matching the original scrollIntoView behavior here
         behavior: "instant", 
       });
 

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -42,13 +42,19 @@ export const highlightResource = (
     // Scroll to the content on the page
     if (newActiveItem) {
       // Get the desired padding from the CSS variable
-      const topPadding = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--top-padding'), 10) || 0;
+      const topPadding =
+        parseInt(
+          getComputedStyle(document.documentElement).getPropertyValue(
+            "--top-padding",
+          ),
+          10,
+        ) || 0;
       const elementRect = newActiveItem.getBoundingClientRect();
       const targetScrollY = window.scrollY + elementRect.top - topPadding;
 
       window.scrollTo({
         top: targetScrollY,
-        behavior: "instant", 
+        behavior: "instant",
       });
 
       newActiveItem.focus();
@@ -125,14 +131,20 @@ export const useInitialScrollState = () => {
 
       if (element) {
         // Get the desired padding from the CSS variable
-        const topPadding = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--top-padding'), 10) || 0;
+        const topPadding =
+          parseInt(
+            getComputedStyle(document.documentElement).getPropertyValue(
+              "--top-padding",
+            ),
+            10,
+          ) || 0;
         const elementRect = element.getBoundingClientRect();
         // Calculate scroll position relative to the current scroll, adjusted for padding.
         // No need for window.scrollY here as we are setting the absolute scroll position on load (within timeout).
         const targetScrollY = window.pageYOffset + elementRect.top - topPadding;
-        
+
         // Use 'auto' for immediate jump on load, respecting user agent settings for motion if any.
-        window.scrollTo({ top: targetScrollY, behavior: 'auto' }); 
+        window.scrollTo({ top: targetScrollY, behavior: "auto" });
       } else {
         // Fallback or default scroll behavior if element not found initially
         window.scrollTo(0, 0);

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -115,6 +115,22 @@ export const updateNavStyles = (resourceUrl: string) => {
   });
 };
 
+const scrollToElementWithPadding = (document: Document, element: Element) => {
+  const topPadding =
+    parseInt(
+      getComputedStyle(document.documentElement).getPropertyValue(
+        "--top-padding",
+      ),
+      10,
+    ) || 0;
+  const elementRect = element.getBoundingClientRect();
+  // Calculate scroll position relative to the current scroll, adjusted for padding.
+  const targetScrollY = window.pageYOffset + elementRect.top - topPadding;
+
+  // Use 'auto' for immediate jump on load, respecting user agent settings for motion if any.
+  window.scrollTo({ top: targetScrollY, behavior: "auto" });
+};
+
 export const useInitialScrollState = () => {
   const router = useRouter();
   const basePath = router.pathname.split("/")[1];
@@ -130,21 +146,7 @@ export const useInitialScrollState = () => {
       );
 
       if (element) {
-        // Get the desired padding from the CSS variable
-        const topPadding =
-          parseInt(
-            getComputedStyle(document.documentElement).getPropertyValue(
-              "--top-padding",
-            ),
-            10,
-          ) || 0;
-        const elementRect = element.getBoundingClientRect();
-        // Calculate scroll position relative to the current scroll, adjusted for padding.
-        // No need for window.scrollY here as we are setting the absolute scroll position on load (within timeout).
-        const targetScrollY = window.pageYOffset + elementRect.top - topPadding;
-
-        // Use 'auto' for immediate jump on load, respecting user agent settings for motion if any.
-        window.scrollTo({ top: targetScrollY, behavior: "auto" });
+        scrollToElementWithPadding(document, element);
       } else {
         // Fallback or default scroll behavior if element not found initially
         window.scrollTo(0, 0);

--- a/styles/index.css
+++ b/styles/index.css
@@ -52,7 +52,6 @@ body {
   min-height: 100vh;
   margin: 0;
   line-height: 1.5;
-  scroll-padding-top: var(--top-padding);
 }
 
 /* Set shorter line heights on headings and interactive elements */

--- a/styles/index.css
+++ b/styles/index.css
@@ -24,7 +24,6 @@ html {
   scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  scroll-padding-top: var(--top-padding);
 }
 
 /* Remove default margin in favour of better control in authored CSS */
@@ -53,6 +52,7 @@ body {
   min-height: 100vh;
   margin: 0;
   line-height: 1.5;
+  scroll-padding-top: var(--top-padding);
 }
 
 /* Set shorter line heights on headings and interactive elements */


### PR DESCRIPTION
### Description

**Problem:**
When the page is scrolled down from the top, typing into the global search input located in the PageHeader causes the page viewport to incrementally scroll upwards with each keystroke. This behavior was observed across multiple browsers (Chrome, Safari).

**Root Cause:**
The root cause was identified as the global CSS rule `scroll-padding-top: var(--top-padding);` applied to the html element in styles/index.css. This property, intended to add padding above targets of fragment identifier navigation (# links) to prevent them from being obscured by sticky headers, was being incorrectly applied by browsers during input focus events. When typing into the search input while the page was scrolled, the browser attempted to ensure the focused input respected this top padding, resulting in the incremental upward scroll on each keystroke.

**Solution:**
The scroll-padding-top: var(--top-padding); rule was moved from the html selector to the body selector in styles/index.css.
Result:

The intended behavior of scroll-padding-top for fragment identifier navigation (clicking # links) is preserved, as the body element typically acts as the main scroll container for page content containing such anchor targets. This ensures headings or sections linked via # are still correctly positioned below the sticky header.

### Tasks

[KNO-8569: \[docs\] fix scrolling when typing in search box](https://linear.app/knock/issue/KNO-8569/[docs]-fix-scrolling-when-typing-in-search-box)
