### PR TITLE
fix: stop rendering broken breadcrumbs

### DIFF
--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -21,11 +21,11 @@ const Breadcrumbs = ({ pages }: BreadcrumbsProps) => {
               {path.slug}
             </Text>
           ) : (
-            <Link href={path.slug}>
-              <Text as="span" size="2" color="gray">
-                {path.title}
-              </Text>
-            </Link>
+            // <Link href={path.slug}>
+            <Text as="span" size="2" color="gray">
+              {path.title}
+            </Text>
+            // </Link>
           )}
           {index !== pages.length - 1 && (
             <Icon


### PR DESCRIPTION
Small "fix". We'll have to revisit how we handle rendering the links here