### PR TITLE
fix: redirecting directly to SDK

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -282,6 +282,11 @@ const nextConfig = {
       },
       // Reference redirects
       {
+        source: "/sdks/:sdk",
+        destination: "/in-app-ui/:sdk/sdk/overview",
+        permanent: true,
+      },
+      {
         source: "/sdks/:sdk/reference",
         destination: "/in-app-ui/:sdk/sdk/reference",
         permanent: true,


### PR DESCRIPTION
Fixing an issue where going directly to an SDK URL would 404