### PR TITLE
fix: 404s for markdown and in-app feeds

### DIFF
--- a/data/sidebars/inAppSidebar.ts
+++ b/data/sidebars/inAppSidebar.ts
@@ -122,10 +122,6 @@ export const REACT_SIDEBAR: SidebarSection[] = [
       { slug: "/slack-kit", title: "SlackKit" },
       { slug: "/teams-kit", title: "TeamsKit" },
       {
-        slug: "/filtering-in-app-feeds",
-        title: "Filtering feeds",
-      },
-      {
         slug: "/customizing-feed-components",
         title: "Customizing feed components",
       },

--- a/next.config.js
+++ b/next.config.js
@@ -455,6 +455,11 @@ const nextConfig = {
         destination: "/in-app-ui/feeds/filtering-in-app-feeds",
         permanent: true,
       },
+      {
+        source: "/in-app-ui/react/filtering-in-app-feeds",
+        destination: "/in-app-ui/react/feed",
+        permanent: true,
+      },
     ];
   },
 };

--- a/next.config.js
+++ b/next.config.js
@@ -457,7 +457,7 @@ const nextConfig = {
       },
       {
         source: "/in-app-ui/react/filtering-in-app-feeds",
-        destination: "/in-app-ui/react/feed",
+        destination: "/in-app-ui/feeds/filtering-in-app-feeds",
         permanent: true,
       },
     ];


### PR DESCRIPTION
I had a file locally that was not being generated -- added better error handling so we can more easily detect when a page isn't being generated. That also helped pick up that .md files weren't being picked up either