### PR TITLE
chore: update prequel setup docs

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -22,15 +22,15 @@ You can bring your notification analytics from Knock into your own data warehous
 
 ## How it works
 
-Knock leverages [Prequel](https://www.prequel.co/) to integrate with your data warehouse. There is no self-service UI to connect your account to start receiving data; instead when you contact us to set up a sync we'll send you a secure link to fill in the information about your data warehouse. Once it's connected, you'll begin receiving a [backfill of historical data](https://docs.prequel.co/docs/transfer-logic#backfills--full-refreshes), and then going forward you will receive the most up to date data on an ongoing basis.
+Knock leverages [Prequel](https://www.prequel.co/) to integrate with your data warehouse. There is no self-service UI to connect your account to start receiving data; instead when you contact us to set up a sync we'll send you a secure link to fill in the information about your data warehouse. Once it's connected, you'll begin receiving a [backfill of historical data](https://docs.prequel.co/docs/transfer-logic#backfills--full-refreshes), and will continue to receive the most up-to-date data every 24 hours.
 
 ## Setup
 
-First, you'll have to give Knock your database type and host destination address for your data warehouse. The databases supported as destinations for Knock are [those listed on Prequel](https://docs.prequel.co/docs/destinations-overview).
+You'll need to work with our [support team](mailto:support@knock.app) to connect your data warehouse. We'll need to know the destination type of your data warehouse, and will ask you for some additional information based on which destination type you're configuring. The databases supported as destinations for Knock are listed <a href="https://docs.prequel.co/docs/destinations-overview" target="_blank" rel="noreferrer">here</a>.
 
-Next, Knock generates a magic link you'll fill out. See what information you'll need for your particular database [here](https://docs.prequel.co/v2022-01-01/reference/post_import-magic-links).
+Once we have the information we need, Knock generates a magic link that you'll use to complete the setup process. The link will take you through a setup wizard that is specific to your destination.
 
-Once the information is filled out, Prequel will provide you with a table definition. Additionally, you can run a test connection to make sure it's wired up. If it's successful, you can save it and it will proceed with the backfill transfer.
+If the connection is successful, you can save it and it will proceed with the backfill transfer.
 
 ## Available data
 


### PR DESCRIPTION
### Description

Made some updates to the Prequel docs to remove some unhelpful links and better clarify the process.

### Questions

I feel like this whole page is a bit redundant, when you look at what we list at the top, under "How it works," and then again under "Setup." What I've done here is mostly just to make things a bit clearer and more accurate, but I would also be in favor of just condensing the information under a single "How it works" or "Setup" section if other folks think that would be better

https://docs-git-mk-update-prequel-docs-knocklabs.vercel.app/integrations/extensions/data-sync
