### PR TITLE
fix(KNO-8617): fix feeds v. guides callout in message types doc

### DIFF
--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -31,11 +31,16 @@ Once a message type exists, you can use it to create [guides](/concepts/guides) 
   height={457}
 />
 
-<Callout emoji="🌠">
-  <span className="font-bold">Feeds v. guides.</span> To learn more about the
-  difference between feeds and guides, see our
-  <a href="/in-app-ui/feeds-v-guides">feeds v. guides doc</a>.
-</Callout>
+<Callout
+  emoji="🌠"
+  text={
+    <>
+      <span className="font-bold">Feeds v. guides.</span> To learn more about
+      the difference between feeds and guides, see our{" "}
+      <a href="/in-app-ui/feeds-vs-guides">feeds v. guides doc</a>.
+    </>
+  }
+/>
 
 ## Overview
 


### PR DESCRIPTION
Found a broken `<Callout>` so I fixed it. 😎   

### Tasks

[KNO-8617](https://linear.app/knock/issue/KNO-8617/docs-fix-callout-in-message-types-doc)

### Screenshots

#### Before

<img width="1124" alt="Screenshot 2025-05-12 at 3 20 34 PM" src="https://github.com/user-attachments/assets/e23cb597-a44e-40b5-9f32-b1c74ec6154d" />

#### After

<img width="1125" alt="Screenshot 2025-05-12 at 3 20 16 PM" src="https://github.com/user-attachments/assets/704e6b25-a6a8-4431-bcd5-b199173d435e" />
