### PR TITLE
feat(KNO-8528): improve select and multi-select field sections of message types doc

### DIFF
--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -403,8 +403,8 @@ A plain text, single line text field.
 
 **Settings**
 
-- `required` (boolean): indicates this field is required
-- `description` (string): an optional friendly description
+- `required` (boolean): Indicates this field is required
+- `description` (string): An optional friendly description
 - `default` (string): The default value to display
 - `minLength` (integer): The minimum length to validate
 - `maxLength` (integer): The maximum length to validate against
@@ -431,8 +431,8 @@ A markdown editor for creating rich text. Will always be rendered as HTML.
 
 **Settings**
 
-- `required` (boolean): indicates this field is required
-- `description` (string): an optional friendly description
+- `required` (boolean): Indicates this field is required
+- `description` (string): An optional friendly description
 - `default` (string): The default value to display
 
 ```json
@@ -452,8 +452,8 @@ A multi-line plain text area
 
 **Settings**
 
-- `required` (boolean): indicates this field is required
-- `description` (string): an optional friendly description
+- `required` (boolean): Indicates this field is required
+- `description` (string): An optional friendly description
 - `default` (string): The default value to display
 - `minLength` (integer): The minimum length to validate
 - `maxLength` (integer): The maximum length to validate against
@@ -477,8 +477,8 @@ A multi-line plain text area
 
 **Settings**
 
-- `required` (boolean): indicates this field is required
-- `description` (string): an optional friendly description
+- `required` (boolean): Indicates this field is required
+- `description` (string): An optional friendly description
 - `default` (boolean): The default value to set
 
 **Example**
@@ -501,7 +501,7 @@ A multi-line plain text area
     **Settings**
 
     - `options` (object[]): A list of option objects that must include a `label` and a `value`
-    - `required` (boolean): indicates this field is required
+    - `required` (boolean): Indicates this field is required
     - `default` (string): The value of the default option to set
 
     **Example**
@@ -536,7 +536,7 @@ A multi-line plain text area
     **Settings**
 
     - `options` (object[]): A list of option objects that must include a `label` and a `value`
-    - `required` (boolean): indicates this field is required
+    - `required` (boolean): Indicates this field is required
     - `default` (string[]): The values of the default options to set
 
       **Example**
@@ -578,8 +578,8 @@ A multi-line plain text area
 
     **Settings**
 
-    - `required` (boolean): indicates this field is required
-    - `description` (string): an optional friendly description
+    - `required` (boolean): Indicates this field is required
+    - `description` (string): An optional friendly description
 
     **Example**
 
@@ -616,8 +616,8 @@ A multi-line plain text area
   <Accordion title="URL">
     **Settings**
 
-    - `required` (boolean): indicates this field is required
-    - `description` (string): an optional friendly description
+    - `required` (boolean): Indicates this field is required
+    - `description` (string): An optional friendly description
     - `default` (string): The default URL to display
 
     **Example**
@@ -646,8 +646,8 @@ A multi-line plain text area
 
     **Settings**
 
-    - `required` (boolean): indicates this field is required
-    - `description` (string): an optional friendly description
+    - `required` (boolean): Indicates this field is required
+    - `description` (string): An optional friendly description
 
     **Example**
 


### PR DESCRIPTION
### Description

It’s not immediately clear how to access selected values in a template preview when using select and multi-select fields, so this PR updates the message types doc to improve the descriptions and examples.

I also updated the **Variants** section to mention that a variant schema with the key `"default"` is required.

### Tasks

[KNO-8528](https://linear.app/knock/issue/KNO-8528/docs-update-message-type-schema-docs-to-better-describe-how-to-use)
