### PR TITLE
feat: update /concepts/guides to dedupe content

### DIFF
--- a/content/concepts/guides.mdx
+++ b/content/concepts/guides.mdx
@@ -19,38 +19,25 @@ section: Concepts
   }
 />
 
-A guide represents a piece of UI that you want to be **powered by Knock within your application**.
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0 }}>
+  <iframe
+    src="https://www.youtube.com/embed/k0pfnmqTzRA?si=mTLsLnRmxF9Xpirc"
+    frameBorder="0"
+    allowFullScreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  />
+</div>
 
-<Image
-  src="/images/concepts/guides/WhatIsAGuide.png"
-  alt="Whatisaguide"
-  width={1356}
-  height={1452}
-  className="rounded-md mx-auto border border-gray-200"
-/>
+## An overview
+Guides enable you to power in-product messaging, everything from paywalls and badges, to one-time announcements and banners, using your own components. Your engineering team controls the UI via a new API, while your content team manages content, targeting, and activation rules in the Knock dashboard.
 
-You configure your guide in the Knock dashboard, including its **content**, its **targeting** rules (who can see it), and its **activation** rules (where in your product they can see it.)
-
-You then use our API and client SDKs to render the **data** of a guide within your application.
-
-Your engineering team owns the UI layer, and your content team owns the contents of the UI shown to users. Knock seamlessly powers this on your behalf, making it effortless to build powerful, managed UI components that any one in your team can maintain.
-
-## Use cases
-
-- **Upgrade flows.** Show a guide to users on a `free` plan to display an upgrade button.
-- **Outage banners.** Show a guides to all customers when there's upcoming maintenance for your product.
-- **In-place feature announcements.** Ship static pieces of UI that prompt a user to learn more about new features.
-- **Welcome modals.** Display a welcome modal to new users to help them get started with your product.
-
-## Benefits
-
-Using Knock guides to power your application UI gives you:
-
-- **Native performance.** Guides render as first-class React, Vue, or Angular components instead of injected scripts. They add no runtime overhead and stay aligned with your design system.
-- **Composable primitives for engineers.** The package ships components, hooks, low-level APIs, and socket infrastructure you can assemble into any in-product announcement, UI, or tour.
-- **Self-service for product and marketing.** Content, targeting, and activation rules are edited entirely in the dashboard; no code or deploys required.
-- **Built-in analytics and observability.** Delivery and engagement events are tracked automatically and can be forwarded to the analytics destinations you already use, whether that's a data warehouse, a third-party analytics service, or your own custom analytics platform.
+Guides are reactive and data-driven. At runtime, you can pass data from your app into a guide to influence both its content and targeting. For example, you might show a guide only when `currentProject.assetCount` exceeds 25. The API evaluates the current user and returns any eligible guides, enabling personalized, real-time experiences for your users.
 
 ## Learn more
-
-To learn more about Knock guides and how you can use them to power activate, engage, and retain users, go to our [guides overview](/in-app-ui/guides/overview).
+To learn more about Knock guides and how you can use them to power activate, engage, and retain users, go to our [Guides overview](/in-app-ui/guides/overview).


### PR DESCRIPTION
### Description

The content of [/concepts/guides](https://docs.knock.app/concepts/guides) and [/in-app-ui/guides/overview](https://docs.knock.app/in-app-ui/guides/overview) was duplicative. To dedupe, the content of /concepts/guides has been updated to include Thomas's walkthrough video and new copy explaining guides at a high-level.
