### PR TITLE
fix: scroll jumps on navigation

### DIFF
--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -230,7 +230,7 @@ const FullLayout = ({ children, scrollerRef }: SidebarProps) => {
         data-sidebar-wrapper
         as="aside"
         width="64"
-        position="sticky"
+        position="fixed"
         bottom="0"
         pr="4"
         pl="3"


### PR DESCRIPTION
To trigger currently, expand the sidebar menus until it can scroll. Then changing pages will cause a small jump in the scroll of the main content. Not sure why exactly. But this fixes it!

Originally changed to sticky in anticipation of a footer but we'll come back to that if we do