### PR TITLE
fix: search container height too big on few results

### DIFF
--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -522,7 +522,6 @@ const Autocomplete = () => {
             style={{
               overflowY: "auto",
               maxHeight: "80vh",
-              height: "700px",
             }}
             pb="2"
             tgphRef={scrollerRef}


### PR DESCRIPTION
<img width="1177" alt="Screenshot 2025-05-16 at 2 17 18 PM" src="https://github.com/user-attachments/assets/27f7757e-fd79-4516-aab9-2941a04b6fa3" />