### PR TITLE
feat(pla-1336): document new custom properties size limit for recipients

### DIFF
--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -96,6 +96,17 @@ There are some reserved property names for recipients that have special meaning:
 
 A recipient also accepts any number of custom properties, which are key-value pairs that you define. It's useful to store custom properties on your recipients so that you can reference these attributes when sending notifications, or for use in message templates.
 
+<Callout
+  emoji="⚠️"
+  title="Recipient custom properties cannot exceed 256 kB in size."
+  bgColor="yellow"
+  text={
+    <>
+      When directly identifying your recipients, an update that would result in a total custom properties size exceeding this limit will result in a <code>422</code> response.
+    </>
+  }
+/>
+
 ### Setting preferences and channel data
 
 It's also possible to set preferences and channel data for a recipient during the identification process.

--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -102,7 +102,9 @@ A recipient also accepts any number of custom properties, which are key-value pa
   bgColor="yellow"
   text={
     <>
-      When directly identifying your recipients, an update that would result in a total custom properties size exceeding this limit will result in a <code>422</code> response.
+      When directly identifying your recipients, an update that would result in
+      a total custom properties size exceeding this limit will result in a{" "}
+      <code>422</code> response.
     </>
   }
 />


### PR DESCRIPTION
### Description

A simple warning callout on the existing recipient identification docs page.
