### PR TITLE
chore: add trigger data size limits

### DIFF
--- a/content/send-notifications/triggering-workflows/api.mdx
+++ b/content/send-notifications/triggering-workflows/api.mdx
@@ -61,7 +61,7 @@ Triggering a workflow will always return a unique UUID v4 representing the workf
 
 ## Passing data to your trigger
 
-Pass schema data required by the workflow in your `trigger` call. The payload must be a valid JSON object.
+Pass schema data required by the workflow in your `trigger` call. The payload must be a valid JSON object. There is a 1024 byte limit on the size of any single string value (with the exception of [email attachments](/integrations/email/attachments)), and a 10MB limit on the size of the full `data` payload.
 
 The workflow builder determines which data keys are required.
 


### PR DESCRIPTION
### Description

Documents limits on `data` payload size, for the full payload and individual string values.