### PR TITLE
feat: collapsible menus can have beta tag

### DIFF
--- a/components/ui/CollapsibleNavItem.tsx
+++ b/components/ui/CollapsibleNavItem.tsx
@@ -4,6 +4,7 @@ import { Box, Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
 import { type TgphComponentProps } from "@telegraph/helpers";
 import { Icon, Lucide } from "@telegraph/icon";
+import { Tag } from "@telegraph/tag";
 
 export type CollapsibleNavItemProps = TgphComponentProps<typeof MenuItem> & {
   label: string;
@@ -12,6 +13,7 @@ export type CollapsibleNavItemProps = TgphComponentProps<typeof MenuItem> & {
   setIsOpen?: (isOpen: boolean) => void;
   className?: string;
   color?: "default" | "gray";
+  isBeta?: boolean;
 };
 
 export const CollapsibleNavItem = ({
@@ -21,6 +23,7 @@ export const CollapsibleNavItem = ({
   setIsOpen = () => {},
   color = "default",
   className = "",
+  isBeta = false,
   ...props
 }: CollapsibleNavItemProps) => {
   return (
@@ -43,6 +46,11 @@ export const CollapsibleNavItem = ({
           >
             {label}
           </Text>
+          {isBeta && (
+            <Tag size="0" color="blue" ml="2">
+              Beta
+            </Tag>
+          )}
           <Icon
             icon={Lucide.ChevronRight}
             size="1"

--- a/components/ui/Feedback.tsx
+++ b/components/ui/Feedback.tsx
@@ -98,7 +98,7 @@ export const Feedback = ({ currentUser, currentAccount }: Props) => {
           </Button>
         </Popover.Trigger>
         <Popover.Content style={{ padding: "0" }}>
-          <Box style={{ width: "500px" }}>
+          <Box style={{ width: "500px", maxWidth: "95vw" }}>
             <Box p="4" position="relative">
               <Button
                 position="absolute"

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -178,7 +178,7 @@ const Item = ({
     <CollapsibleNavItem
       {...depthAdjustedCollapsibleNavItemProps}
       label={section.title ?? section.slug}
-      isBeta={section.isBeta}
+      isBeta={section?.isBeta}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
     >

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -178,6 +178,7 @@ const Item = ({
     <CollapsibleNavItem
       {...depthAdjustedCollapsibleNavItemProps}
       label={section.title ?? section.slug}
+      isBeta={section.isBeta}
       isOpen={isOpen}
       setIsOpen={setIsOpen}
     >

--- a/content/in-app-ui/guides/overview.mdx
+++ b/content/in-app-ui/guides/overview.mdx
@@ -7,6 +7,7 @@ section: Building in-app UI
 
 <Callout
   emoji="🚧"
+  bgColor="blue"
   text={
     <>
       Guides are currently in beta. If you'd like early access, or this is

--- a/data/sidebars/inAppSidebar.ts
+++ b/data/sidebars/inAppSidebar.ts
@@ -34,6 +34,7 @@ export const IN_APP_UI_SIDEBAR: SidebarSection[] = [
       {
         title: "Guides",
         slug: "/guides",
+        isBeta: true,
         pages: [
           { slug: "/overview", title: "Overview" },
           {


### PR DESCRIPTION
Guides needs a beta indicator. Instead of putting it on the Overview page, let's enable CollapsibleNavItems to accept an `isBeta` prop and render it at the top level
<img width="317" alt="Screenshot 2025-05-21 at 11 50 59 PM" src="https://github.com/user-attachments/assets/5c487e13-12ef-417a-801c-14c5aff0e52f" />