### PR TITLE
feat: add guides analytics info

### DIFF
--- a/content/concepts/guides.mdx
+++ b/content/concepts/guides.mdx
@@ -41,6 +41,17 @@ Guides enable you to power in-product messaging, everything from paywalls and ba
 
 Guides are reactive and data-driven. At runtime, you can pass data from your app into a guide to influence both its content and targeting. For example, you might show a guide only when `currentProject.assetCount` exceeds 25. The API evaluates the current user and returns any eligible guides, enabling personalized, real-time experiences for your users.
 
+## Guides analytics
+
+Guides include an analytics summary that highlights key metrics over the last N days, based on your account's [retention period](/manage-your-account/data-retention). These metrics include:
+
+- **Audience**: The total number of users in the target audience.
+- **Seen**: The number of users who saw this guide.
+- **Interacted**: The number of users who interacted with this guide.
+- **Archived**: The number of users who archived this guide.
+
+To learn more, see our [message statuses guide](/send-notifications/message-statuses).
+
 ## Learn more
 
 To learn more about Knock guides and how you can use them to power activate, engage, and retain users, go to our [Guides overview](/in-app-ui/guides/overview).


### PR DESCRIPTION
### Description
Small description of guides analytics that we can link to from the dashboard.
