### PR TITLE
feat: allow sidebar to not be nested

### DIFF
--- a/components/ui/NavItem.tsx
+++ b/components/ui/NavItem.tsx
@@ -18,6 +18,7 @@ type NavItemProps = {
   children: React.ReactNode;
   samePageRouting?: boolean;
   containerProps?: TgphComponentProps<typeof Stack>;
+  className?: string;
 } & Omit<TgphComponentProps<typeof Text<"span">>, "as">;
 
 const NavItem = ({
@@ -26,6 +27,7 @@ const NavItem = ({
   icon,
   children,
   containerProps = {},
+  className,
   ...textProps
 }: NavItemProps) => {
   const { samePageRouting } = useSidebar();
@@ -63,7 +65,7 @@ const NavItem = ({
       gap="2"
       px="1"
       py="1"
-      className="nav-item"
+      className={`nav-item ${className ?? ""}`}
       style={{
         textDecoration: "none",
         display: "block",

--- a/components/ui/NavItem.tsx
+++ b/components/ui/NavItem.tsx
@@ -9,6 +9,7 @@ import {
 import { Stack } from "@telegraph/layout";
 import { useSidebar } from "./Page/Sidebar";
 import { useMobileSidebar } from "./Page/MobileSidebar";
+import { TgphComponentProps } from "@telegraph/helpers";
 
 type NavItemProps = {
   href: string;
@@ -16,9 +17,17 @@ type NavItemProps = {
   icon?: LucideIcon;
   children: React.ReactNode;
   samePageRouting?: boolean;
-};
+  containerProps?: TgphComponentProps<typeof Stack>;
+} & Omit<TgphComponentProps<typeof Text<"span">>, "as">;
 
-const NavItem = ({ href, isActive, icon, children }: NavItemProps) => {
+const NavItem = ({
+  href,
+  isActive,
+  icon,
+  children,
+  containerProps = {},
+  ...textProps
+}: NavItemProps) => {
   const { samePageRouting } = useSidebar();
   const { isOpen: isMobileSidebarOpen, closeSidebar: closeMobileSidebar } =
     useMobileSidebar();
@@ -38,6 +47,9 @@ const NavItem = ({ href, isActive, icon, children }: NavItemProps) => {
   // Next.js is really annoying if you have prefetch={true} so let's just NOT
   const prefetchProps = samePageRouting ? { prefetch: false } : {};
 
+  const textPropsWithoutStyle = { ...textProps };
+  delete textPropsWithoutStyle.style;
+
   return (
     <Stack
       as={Link}
@@ -52,7 +64,6 @@ const NavItem = ({ href, isActive, icon, children }: NavItemProps) => {
       px="1"
       py="1"
       className="nav-item"
-      color={isActive ? "default" : "gray"}
       style={{
         textDecoration: "none",
         display: "block",
@@ -63,6 +74,7 @@ const NavItem = ({ href, isActive, icon, children }: NavItemProps) => {
       data-active={isActive}
       data-resource-path={stripTrailingSlash(href)}
       icon={icon ? { icon: icon, "aria-hidden": true } : undefined}
+      {...containerProps}
     >
       <Text
         as="span"
@@ -74,7 +86,10 @@ const NavItem = ({ href, isActive, icon, children }: NavItemProps) => {
           textWrap: "nowrap",
           // Easy way to vertically align the text
           verticalAlign: "text-bottom",
+          color: isActive ? "var(--tgph-gray-12)" : "var(--tgph-gray-11)",
+          ...(textProps.style || {}),
         }}
+        {...textPropsWithoutStyle}
       >
         {children}
       </Text>

--- a/components/ui/NavItem.tsx
+++ b/components/ui/NavItem.tsx
@@ -81,14 +81,13 @@ const NavItem = ({
       <Text
         as="span"
         weight="medium"
-        color={isActive ? "default" : "gray"}
         style={{
           fontSize: "13px",
           // @ts-expect-error textWrap is fine
           textWrap: "nowrap",
           // Easy way to vertically align the text
           verticalAlign: "text-bottom",
-          color: isActive ? "var(--tgph-gray-12)" : "var(--tgph-gray-11)",
+          "--color": isActive ? "var(--tgph-gray-12)" : "var(--tgph-gray-11)",
           ...(textProps.style || {}),
         }}
         {...textPropsWithoutStyle}

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -240,7 +240,8 @@ const Item = ({ section, preSlug = "", depth = 0, defaultOpen }: ItemProps) => {
       href={slug}
       isActive={isPathTheSame(slug, router.asPath)}
       containerProps={{ px: "3" }}
-      style={{ color: "var(--tgph-gray-12)" }}
+      // @ts-expect-error --color is a valid CSS variable
+      style={{ "--color": "var(--tgph-gray-12)" }}
       className="nav-item--top-level"
     >
       {section.title}

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -241,6 +241,7 @@ const Item = ({ section, preSlug = "", depth = 0, defaultOpen }: ItemProps) => {
       isActive={isPathTheSame(slug, router.asPath)}
       containerProps={{ px: "3" }}
       style={{ color: "var(--tgph-gray-12)" }}
+      className="nav-item--top-level"
     >
       {section.title}
       {section.isBeta && (

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -129,10 +129,6 @@ export const updateNavStyles = (resourceUrl: string) => {
   activeElements.forEach((element) => {
     if (element.dataset.resourcePath !== resourceUrl) {
       element.setAttribute("data-active", "false");
-      // For some reason, the color persists and we have to set it back to default by hand
-      if (element.firstChild) {
-        (element.firstChild as HTMLElement).style.color = "var(--tgph-gray-11)";
-      }
     }
   });
 };

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -130,6 +130,14 @@ export const updateNavStyles = (resourceUrl: string) => {
     if (element.dataset.resourcePath !== resourceUrl) {
       element.setAttribute("data-active", "false");
     }
+
+    // For some reason, the color persists and we have to set it back to default by hand
+    if (
+      element.firstChild &&
+      !element.classList.contains("nav-item--top-level")
+    ) {
+      (element.firstChild as HTMLElement).style.color = "var(--tgph-gray-11)";
+    }
   });
 };
 

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -112,11 +112,6 @@ export const updateNavStyles = (resourceUrl: string) => {
 
       // Use the debounced function
       debouncedScrollIntoView(element);
-
-      // Annoying we have to do this by hand, but have to do it
-      if (element.firstChild) {
-        (element.firstChild as HTMLElement).style.color = "var(--tgph-gray-12)";
-      }
     });
   }
 
@@ -128,15 +123,7 @@ export const updateNavStyles = (resourceUrl: string) => {
   // Remove the styling from any previous active nav items
   activeElements.forEach((element) => {
     if (element.dataset.resourcePath !== resourceUrl) {
-      element.setAttribute("data-active", "false");
-    }
-
-    // For some reason, the color persists and we have to set it back to default by hand
-    if (
-      element.firstChild &&
-      !element.classList.contains("nav-item--top-level")
-    ) {
-      (element.firstChild as HTMLElement).style.color = "var(--tgph-gray-11)";
+      element.dataset.active = "false";
     }
   });
 };

--- a/data/sidebars/developerToolsSidebar.ts
+++ b/data/sidebars/developerToolsSidebar.ts
@@ -1,79 +1,81 @@
-import { SidebarSection } from "../types";
+import { SidebarContent } from "../types";
 
-export const DEVELOPER_TOOLS_SIDEBAR: SidebarSection[] = [
+const baseSlug = "/developer-tools";
+
+export const parentSection = {
+  slug: baseSlug,
+  title: "Developer tools",
+};
+
+export const DEVELOPER_TOOLS_SIDEBAR_CONTENT: SidebarContent[] = [
+  { slug: `${baseSlug}/overview`, title: "Overview" },
+  { slug: `${baseSlug}/api-keys`, title: "API keys" },
+  { slug: `${baseSlug}/service-tokens`, title: "Service tokens" },
+  { slug: `${baseSlug}/knock-cli`, title: "Knock CLI" },
+  { slug: `${baseSlug}/sdks`, title: "SDKs" },
+  { slug: `${baseSlug}/management-api`, title: "Management API" },
+  { slug: `${baseSlug}/api-logs`, title: "API logs" },
+  { slug: `${baseSlug}/knock-and-postman`, title: "Knock and Postman" },
+  { slug: `${baseSlug}/security`, title: "Security" },
   {
-    title: "Developer tools",
-    slug: "/developer-tools",
-    desc: "Use our powerful developer tools in order to integrate Knock seamlessly into your development workflow.",
-    sidebarMenuDefaultOpen: true,
+    slug: `${baseSlug}/integrating-into-cicd`,
+    title: "Integrating into CI/CD",
+  },
+  {
+    slug: `${baseSlug}/outbound-webhooks`,
+    title: "Outbound webhooks",
     pages: [
       { slug: "/overview", title: "Overview" },
-      { slug: "/api-keys", title: "API keys" },
-      { slug: "/service-tokens", title: "Service tokens" },
-      { slug: "/knock-cli", title: "Knock CLI" },
-      { slug: "/sdks", title: "SDKs" },
-      { slug: "/management-api", title: "Management API" },
-      { slug: "/api-logs", title: "API logs" },
-      { slug: "/knock-and-postman", title: "Knock and Postman" },
-      { slug: "/security", title: "Security" },
-      { slug: "/integrating-into-cicd", title: "Integrating into CI/CD" },
+      { slug: "/event-types", title: "Event types" },
+    ],
+  },
+  {
+    slug: `${baseSlug}/migration-guides`,
+    title: "Migration guides",
+    pages: [
+      { slug: "/node", title: "Node.js 1.0" },
+      { slug: "/python", title: "Python 1.0" },
+      { slug: "/java", title: "Java 1.0" },
+      { slug: "/ruby", title: "Ruby 1.0" },
+      { slug: "/go", title: "Go 1.0" },
+    ],
+  },
+  {
+    slug: `${baseSlug}/agent-toolkit`,
+    title: "Agent Toolkit",
+    isBeta: true,
+    pages: [
+      { slug: "/overview", title: "Overview" },
+      { slug: "/getting-started", title: "Getting started" },
       {
-        slug: "/outbound-webhooks",
-        title: "Outbound webhooks",
-        pages: [
-          { slug: "/overview", title: "Overview" },
-          { slug: "/event-types", title: "Event types" },
-        ],
+        slug: "/workflows-as-tools",
+        title: "Workflows-as-tools",
       },
       {
-        slug: "/migration-guides",
-        title: "Migration guides",
-        pages: [
-          { slug: "/node", title: "Node.js 1.0" },
-          { slug: "/python", title: "Python 1.0" },
-          { slug: "/java", title: "Java 1.0" },
-          { slug: "/ruby", title: "Ruby 1.0" },
-          { slug: "/go", title: "Go 1.0" },
-        ],
+        slug: "/human-in-the-loop-flows",
+        title: "Human-in-the-loop flows",
       },
       {
-        slug: "/agent-toolkit",
-        title: "Agent Toolkit",
-        isBeta: true,
-        pages: [
-          { slug: "/overview", title: "Overview" },
-          { slug: "/getting-started", title: "Getting started" },
-          {
-            slug: "/workflows-as-tools",
-            title: "Workflows-as-tools",
-          },
-          {
-            slug: "/human-in-the-loop-flows",
-            title: "Human-in-the-loop flows",
-          },
-          {
-            slug: "/providing-context",
-            title: "Providing context",
-          },
-          {
-            slug: "/working-with-environments",
-            title: "Working with environments",
-          },
-          {
-            slug: "/tools-reference",
-            title: "Tools reference",
-          },
-        ],
+        slug: "/providing-context",
+        title: "Providing context",
       },
       {
-        slug: "/mcp-server",
-        title: "MCP server",
-        isBeta: true,
+        slug: "/working-with-environments",
+        title: "Working with environments",
       },
       {
-        slug: "/building-with-llms",
-        title: "Building with LLMs",
+        slug: "/tools-reference",
+        title: "Tools reference",
       },
     ],
+  },
+  {
+    slug: `${baseSlug}/mcp-server`,
+    title: "MCP server",
+    isBeta: true,
+  },
+  {
+    slug: `${baseSlug}/building-with-llms`,
+    title: "Building with LLMs",
   },
 ];

--- a/data/sidebars/integrationsSidebar.ts
+++ b/data/sidebars/integrationsSidebar.ts
@@ -1,10 +1,14 @@
-import { SidebarSection } from "../types";
+import { SidebarContent } from "../types";
 
-export const INTEGRATIONS_SIDEBAR: SidebarSection[] = [
+export const parentSection = {
+  slug: "/integrations",
+  title: "Integrations",
+};
+
+export const INTEGRATIONS_SIDEBAR: SidebarContent[] = [
   {
-    title: "Integrations",
-    slug: "/integrations",
-    pages: [{ slug: "/overview", title: "Overview" }],
+    title: "Overview",
+    slug: "/integrations/overview",
   },
   {
     title: "Sources",

--- a/data/sidebars/tutorialsSidebar.ts
+++ b/data/sidebars/tutorialsSidebar.ts
@@ -1,36 +1,36 @@
-import { SidebarSection } from "../types";
+import { SidebarContent } from "../types";
 
-export const TUTORIALS_SIDEBAR: SidebarSection[] = [
+const baseSlug = "/tutorials";
+
+export const parentSection = {
+  slug: baseSlug,
+  title: "Tutorials",
+};
+
+export const TUTORIALS_SIDEBAR: SidebarContent[] = [
   {
-    title: "Tutorials",
-    slug: "/tutorials",
-    sidebarMenuDefaultOpen: true,
-    pages: [
-      {
-        slug: "/overview",
-        title: "Overview",
-      },
-      {
-        slug: "/implementation-guide",
-        title: "Knock implementation guide",
-      },
-      {
-        slug: "/alerting",
-        title: "Alerting",
-      },
-      {
-        slug: "/customer-webhooks",
-        title: "Customer-facing webhooks",
-      },
-      {
-        slug: "/building-recurring-digests",
-        title: "Recurring digests",
-      },
-      { slug: "/migrate-from-courier", title: "Migrate from Courier" },
-      {
-        slug: "/modeling-users-objects-and-tenants",
-        title: "Modeling Users, Objects, and Tenants",
-      },
-    ],
+    slug: `${baseSlug}/overview`,
+    title: "Overview",
+  },
+  {
+    slug: `${baseSlug}/implementation-guide`,
+    title: "Knock implementation guide",
+  },
+  {
+    slug: `${baseSlug}/alerting`,
+    title: "Alerting",
+  },
+  {
+    slug: `${baseSlug}/customer-webhooks`,
+    title: "Customer-facing webhooks",
+  },
+  {
+    slug: `${baseSlug}/building-recurring-digests`,
+    title: "Recurring digests",
+  },
+  { slug: `${baseSlug}/migrate-from-courier`, title: "Migrate from Courier" },
+  {
+    slug: `${baseSlug}/modeling-users-objects-and-tenants`,
+    title: "Modeling Users, Objects, and Tenants",
   },
 ];

--- a/data/types.ts
+++ b/data/types.ts
@@ -1,3 +1,4 @@
+// TODO: Remove these types and just use the `SidebarContent` instead as it's recursive
 export type SidebarPage = {
   slug: string;
   title: string;
@@ -21,4 +22,13 @@ export type SidebarSection = {
     | SidebarSubsection[]
     | Array<SidebarPage | SidebarSubsection>;
   sidebarMenuDefaultOpen?: boolean;
+};
+
+export type SidebarContent = {
+  title: string;
+  slug: string;
+  isBeta?: boolean;
+  pages?: SidebarContent[];
+  sidebarMenuDefaultOpen?: boolean;
+  parentSection?: SidebarContent;
 };

--- a/hooks/useSidebarContent.ts
+++ b/hooks/useSidebarContent.ts
@@ -1,15 +1,37 @@
 import { useRouter } from "next/router";
 import { PLATFORM_SIDEBAR } from "@/data/sidebars/platformSidebar";
-import { TUTORIALS_SIDEBAR } from "@/data/sidebars/tutorialsSidebar";
-import { DEVELOPER_TOOLS_SIDEBAR } from "@/data/sidebars/developerToolsSidebar";
+import {
+  TUTORIALS_SIDEBAR,
+  parentSection as TUTORIALS_SECTION,
+} from "@/data/sidebars/tutorialsSidebar";
+import {
+  DEVELOPER_TOOLS_SIDEBAR_CONTENT,
+  parentSection as DEVELOPER_TOOLS_SECTION,
+} from "@/data/sidebars/developerToolsSidebar";
+import { SidebarContent, SidebarSection } from "@/data/types";
 
-export function useSidebarContent() {
+export function useSidebarContent(): {
+  content: SidebarSection[] | SidebarContent[];
+  parentSection: SidebarContent | undefined;
+} {
   const { asPath } = useRouter();
+
   if (asPath.startsWith("/tutorials")) {
-    return TUTORIALS_SIDEBAR;
+    return { content: TUTORIALS_SIDEBAR, parentSection: TUTORIALS_SECTION };
   }
+
   if (asPath.startsWith("/developer-tools")) {
-    return DEVELOPER_TOOLS_SIDEBAR;
+    return {
+      content: DEVELOPER_TOOLS_SIDEBAR_CONTENT,
+      parentSection: DEVELOPER_TOOLS_SECTION,
+    };
   }
-  return PLATFORM_SIDEBAR;
+
+  return {
+    content: PLATFORM_SIDEBAR,
+    parentSection: {
+      slug: "/platform",
+      title: "Platform",
+    },
+  };
 }

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -11,10 +11,10 @@ const DocsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
   const paths = slugToPaths(router.query.slug);
 
-  const sidebarContent = useSidebarContent();
+  const { content: sidebarContent, parentSection } = useSidebarContent();
 
   const { breadcrumbs, nextPage, prevPage } = useMemo(
-    () => getSidebarInfo(paths, sidebarContent),
+    () => getSidebarInfo(paths, sidebarContent, parentSection),
     [paths, sidebarContent],
   );
 

--- a/layouts/IntegrationsLayout.tsx
+++ b/layouts/IntegrationsLayout.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo } from "react";
 import { useRouter } from "next/router";
-import { INTEGRATIONS_SIDEBAR } from "../data/sidebars/integrationsSidebar";
+import {
+  INTEGRATIONS_SIDEBAR,
+  parentSection,
+} from "../data/sidebars/integrationsSidebar";
 import Meta from "../components/Meta";
 import { getSidebarInfo, slugToPaths } from "../lib/content";
 import { Page } from "@/components/ui/Page";
@@ -31,7 +34,7 @@ const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
       sidebarPaths = [`${paths[0]}/${paths[1]}`, ...paths.slice(2)];
     }
 
-    return getSidebarInfo(sidebarPaths, INTEGRATIONS_SIDEBAR);
+    return getSidebarInfo(sidebarPaths, INTEGRATIONS_SIDEBAR, parentSection);
   }, [paths]);
 
   return (

--- a/scripts/generateLlmsTxt.ts
+++ b/scripts/generateLlmsTxt.ts
@@ -4,10 +4,10 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkFrontmatter from "remark-frontmatter";
 import yaml from "yaml";
-import { type SidebarSection } from "../data/types";
+import { SidebarContent, type SidebarSection } from "../data/types";
 
 import { TUTORIALS_SIDEBAR } from "../data/sidebars/tutorialsSidebar";
-import { DEVELOPER_TOOLS_SIDEBAR } from "../data/sidebars/developerToolsSidebar";
+import { DEVELOPER_TOOLS_SIDEBAR_CONTENT } from "../data/sidebars/developerToolsSidebar";
 import { CLI_SIDEBAR } from "../data/sidebars/cliSidebar";
 import { PLATFORM_SIDEBAR } from "../data/sidebars/platformSidebar";
 import { INTEGRATIONS_SIDEBAR } from "../data/sidebars/integrationsSidebar";
@@ -211,8 +211,10 @@ async function processPages(
   }
 }
 
+type SidebarSectionOrContent = SidebarSection | SidebarContent;
+
 async function processSections(
-  sections: SidebarSection[],
+  sections: SidebarSectionOrContent[],
   indexContent,
   fullContent,
   hrefOverride?: string | null,
@@ -221,14 +223,14 @@ async function processSections(
     totalSections += 1;
     // Add section to index
     indexContent.push(`## ${section.title}`);
-    if (section.desc) {
+    if ("desc" in section && section.desc) {
       indexContent.push(section.desc);
     }
     indexContent.push("");
 
     // Add section to full content
     fullContent.push(`# ${section.title}`);
-    if (section.desc) {
+    if ("desc" in section && section.desc) {
       fullContent.push(section.desc);
     }
     fullContent.push("");
@@ -354,7 +356,11 @@ async function generateAllLlmsFiles() {
     fullContent.push("---\n");
 
     // DEVELOPER TOOLS
-    await processSections(DEVELOPER_TOOLS_SIDEBAR, indexContent, fullContent);
+    await processSections(
+      DEVELOPER_TOOLS_SIDEBAR_CONTENT,
+      indexContent,
+      fullContent,
+    );
 
     // DIVIDER
     indexContent.push("---\n");

--- a/scripts/generateLlmsTxt.ts
+++ b/scripts/generateLlmsTxt.ts
@@ -164,6 +164,10 @@ async function processPages(
   indentLevel = 0,
   hrefOverride: string | null = null,
 ) {
+  if (!pages) {
+    return;
+  }
+
   for (const page of pages) {
     totalPages += 1;
     let fullHref = `${parentSlug}${page.slug}`;

--- a/styles/global.css
+++ b/styles/global.css
@@ -16,8 +16,8 @@
   margin-top: 0;
 }
 
-.tgraph-content p, 
-.tgraph-content ul, 
+.tgraph-content p,
+.tgraph-content ul,
 .tgraph-content ol {
   margin-bottom: var(--tgph-spacing-4);
 }
@@ -28,7 +28,8 @@
   margin-bottom: var(--tgph-spacing-4);
 }
 
-.tgraph-content p, li {
+.tgraph-content p,
+li {
   font-size: var(--tgph-text-2);
   line-height: var(--tgph-leading-3);
 }
@@ -44,7 +45,7 @@
 .tgraph-content p a:active,
 .tgraph-content li a:hover,
 .tgraph-content li a:focus,
-.tgraph-content li a:active { 
+.tgraph-content li a:active {
   color: var(--tgph-accent-11);
 }
 
@@ -59,7 +60,10 @@
 
 .nav-item[data-active="true"] {
   background-color: var(--tgph-gray-3);
-  color: var(--tgph-gray-12);
+}
+
+.nav-item[data-active="true"] span {
+  --color: var(--tgph-gray-12) !important;
 }
 
 /* Data properties are new */


### PR DESCRIPTION
### Description

This PR allows us to have non-nested sidebar items, so that we don't need to wrap "Developer tools" under a developer tools section in the sidebar. It does this by introducing a new recursive `SidebarContent` type, which can then have subpages (or subpages of subpages).

Most of the changes here are reworking the breadcrumbs as those were most borked because of this. It could definitely do with another pass later, but I think this should suffice for now. 

I implemented the changes in the following places:

- Integrations > Overview
- Developer tools
- Tutorials

### Screenshots

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/7963635c-e121-4772-ae06-32cd295433f3" />
