### PR TITLE
chore: add info about Knock creating a user for setChannelData

### DIFF
--- a/data/specs/api/openapi.yml
+++ b/data/specs/api/openapi.yml
@@ -9598,6 +9598,7 @@ paths:
     put:
       callbacks: {}
       description: Updates or creates channel data for a specific user and channel ID.
+      operationId: setUserChannelData
       parameters:
         - description: The ID for the user that you set when identifying them in Knock.
           in: path


### PR DESCRIPTION
### Description

Adds in information that when you call `setChannelData` for a user that does not exist in the environment, Knock will create a user. 

https://docs-git-rt-add-upsert-info-setchanneldata-knocklabs.vercel.app/managing-recipients/setting-channel-data#setting-channel-data