### PR TITLE
chore: clarify message type template previews

### DIFF
--- a/content/in-app-ui/message-types.mdx
+++ b/content/in-app-ui/message-types.mdx
@@ -313,9 +313,9 @@ If the editor creates an in-app message template using the “default” variant
 
 ### Template previews
 
-A template preview is a visual representation of what the message type will look like in the template editor.
+A template preview is a visual representation of what the message type will look like in the template editor. This provides a way for your content editors to understand what your front-end component will look like when a guide is rendered in your application.
 
-You draft template previews using HTML, CSS, and Liquid.
+You can draft template previews using HTML, CSS, and Liquid. This content will not be included in the generated message, and is only for preview purposes.
 
 You can reference variables from your schema to customize the preview, like this:
 


### PR DESCRIPTION
### Description

This PR clarifies that template previews for message types are not part of the message generated by a guide.

https://docs-git-mk-kno-8725-knocklabs.vercel.app/in-app-ui/message-types#template-previews