### PR TITLE
chore: update signUserToken example

### DIFF
--- a/content/in-app-ui/security-and-authentication.mdx
+++ b/content/in-app-ui/security-and-authentication.mdx
@@ -123,7 +123,7 @@ Your JWT will need to be signed against your **private signing key** using an **
 To sign your JWT as middleware in a NodeJS express like app:
 
 ```js
-import Knock from "@knocklabs/node";
+import { signUserToken } from "@knocklabs/node/lib/tokenSigner";
 
 app.use(async (req, res, next) => {
   if (!req.user) {
@@ -132,7 +132,7 @@ app.use(async (req, res, next) => {
 
   res.locals({
     // `signUserToken` can take an options object as the second parameter
-    knockToken: await Knock.signUserToken(req.user.id, {
+    knockToken: await signUserToken(req.user.id, {
       // Optionally override the signing key (defaults to KNOCK_SIGNING_KEY env var)
       signingKey: knockSigningKey,
       // Optionally set custom expiration (defaults to 3600 seconds)


### PR DESCRIPTION
### Description

Updates a final `signUserToken` example for node SDK versions 1.x that wasn't updated in previous PR.