### PR TITLE
chore: tweak claude desktop mcp instructions

### DIFF
--- a/content/developer-tools/mcp-server.mdx
+++ b/content/developer-tools/mcp-server.mdx
@@ -30,8 +30,21 @@ To get started with the MCP server, you'll need to create a [service token](/dev
 
 Once you have your service, you can then setup the MCP Server in any MCP Client-compatible AI application. We've added the setup instructions below for both Cursor and Claude Desktop, but the same instructions apply to any other MCP Client-compatible application.
 
-**Note**: To run the local MCP server you must have Node 20 or higher installed and accessible globally on your system. You can test this by running `node --version` in your terminal.
-
+<Callout
+  emoji="⚠️"
+  text={
+    <>
+      <strong>Note</strong>: To run the local MCP server you must have Node 20
+      or higher installed and accessible globally on your system. You can test
+      this by running `node --version` in your terminal. You can download Node
+      from{" "}
+      <a href="https://nodejs.org/en/download" target="_blank">
+        the official site
+      </a>
+      .
+    </>
+  }
+/>
 ### Cursor
 
 1. Go to your Cursor settings and find the "MCP" section
@@ -60,20 +73,22 @@ Once you have your service, you can then setup the MCP Server in any MCP Client-
 1. Open the Claude Desktop settings and find the "Developer" section
 2. Click to "Edit Config"
 3. Open your `claude_desktop_config.json` file in your preferred text editor
-4. Add the following to the `mcpServers` section (or add the key if it doesn't exist):
+4. Add the following contents to the file (or add to the `mcpServers` section if it exists):
 
 ```json
 {
-  "knock": {
-    "command": "npx",
-    "args": [
-      "-y",
-      "@knocklabs/agent-toolkit",
-      "-p",
-      "local-mcp",
-      "--service-token",
-      "YOUR-SERVICE-TOKEN"
-    ]
+  "mcpServers": {
+    "knock": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@knocklabs/agent-toolkit",
+        "-p",
+        "local-mcp",
+        "--service-token",
+        "YOUR-SERVICE-TOKEN"
+      ]
+    }
   }
 }
 ```


### PR DESCRIPTION
### Description

Makes it more clear that node is required for local MCP by turning note into callout.

Adjusts claude desktop config snippet to be more friendly for non-technical ppl by including `mcpServers` key. I think this actually makes us more aligned with this [MCP quickstart here](https://modelcontextprotocol.io/quickstart/user).
