### PR TITLE
fix: adds API Keys section to mAPI

### DIFF
--- a/data/sidebars/mapiOverviewSidebar.ts
+++ b/data/sidebars/mapiOverviewSidebar.ts
@@ -11,6 +11,7 @@ export const RESOURCE_ORDER = [
   "variables",
   "templates",
   "message_types",
+  "api_keys"
 ];
 
 export const MAPI_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [

--- a/data/sidebars/mapiOverviewSidebar.ts
+++ b/data/sidebars/mapiOverviewSidebar.ts
@@ -11,7 +11,7 @@ export const RESOURCE_ORDER = [
   "variables",
   "templates",
   "message_types",
-  "api_keys"
+  "api_keys",
 ];
 
 export const MAPI_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [

--- a/data/specs/mapi/customizations.yml
+++ b/data/specs/mapi/customizations.yml
@@ -56,3 +56,7 @@ resources:
     name: Variables
     description: |-
       Variables are used to store shared attributes for your workflows and templates at the environment level.
+  api_keys:
+    name: API keys
+    description: |-
+      API keys are used to authenticate requests to the Knock API.


### PR DESCRIPTION
We had missed adding this to the sidebar, so this content wasn't getting rendered.

[https://linear.app/knock/issue/KNO-8785/docs-api-keysexchange-endpoint-not-present-in-mapi-docs](https://linear.app/knock/issue/KNO-8785/docs-api-keysexchange-endpoint-not-present-in-mapi-docs)

<img width="1289" alt="Screenshot 2025-06-02 at 4 09 33 PM" src="https://github.com/user-attachments/assets/d0d434b7-c43b-4b35-bd2e-019c2a18a77b" />

---

In search too:
<img width="684" alt="Screenshot 2025-06-02 at 4 21 22 PM" src="https://github.com/user-attachments/assets/05c08c1d-a9b8-4acc-89b7-773ac9cef307" />

