### PR TITLE
fix(kno-8744): more consistent API linking

### DIFF
--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -119,8 +119,8 @@ const StaticSearch = () => {
 const handleSearchNavigation = (
   e: React.MouseEvent<HTMLAnchorElement>,
   router,
-  itemUrl: string,
-  clearSearch: () => void,
+  itemUrl,
+  onSearch: () => void,
 ) => {
   e.preventDefault();
   const pathname = router.asPath;
@@ -139,21 +139,21 @@ const handleSearchNavigation = (
     // Handle regular navigation
     router.push(`/${itemUrl}`);
   }
-  clearSearch();
+  onSearch();
 };
 
 const DocsSearchResult = ({
   item,
-  clearSearch,
+  onClick,
 }: {
   item: ResultItem;
-  clearSearch: () => void;
+  onClick: () => void;
 }) => {
   const router = useRouter();
   return (
     <Link
       href={`/${item.path}`}
-      onClick={(e) => handleSearchNavigation(e, router, item.path, clearSearch)}
+      onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
     >
       <Box w="full" h="full" px="2" py="2">
         <Text as="p" size="2" color="black" weight="regular">
@@ -181,10 +181,10 @@ const DocsSearchResult = ({
 
 const EndpointSearchResult = ({
   item,
-  clearSearch,
+  onClick,
 }: {
   item: EndpointSearchItem;
-  clearSearch: () => void;
+  onClick: () => void;
 }) => {
   const router = useRouter();
   const colors = {
@@ -197,7 +197,7 @@ const EndpointSearchResult = ({
   return (
     <Link
       href={`/${item.path}`}
-      onClick={(e) => handleSearchNavigation(e, router, item.path, clearSearch)}
+      onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
     >
       <Stack w="full" h="full" px="1" py="2" gap="2" alignItems="center">
         <Tag size="0" color={colors[item.method as keyof typeof colors]}>
@@ -734,16 +734,12 @@ const Autocomplete = () => {
                                 {isEndpoint ? (
                                   <EndpointSearchResult
                                     item={item as EndpointSearchItem}
-                                    clearSearch={() =>
-                                      autocomplete.setQuery("")
-                                    }
+                                    onClick={() => autocomplete.setQuery("")}
                                   />
                                 ) : (
                                   <DocsSearchResult
                                     item={item as DocsSearchItem}
-                                    clearSearch={() =>
-                                      autocomplete.setQuery("")
-                                    }
+                                    onClick={() => autocomplete.setQuery("")}
                                   />
                                 )}
                               </MenuItem>

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -44,6 +44,7 @@ import { MenuItem } from "@telegraph/menu";
 import { usePageContext } from "./Page";
 import { DocsSearchItem, EndpointSearchItem } from "@/types";
 import { Button } from "@telegraph/button";
+import { highlightResource } from "./Page/helpers";
 
 // This Autocomplete component was created following:
 // https://www.algolia.com/doc/ui-libraries/autocomplete/api-reference/autocomplete-core/createAutocomplete/
@@ -365,8 +366,23 @@ const Autocomplete = () => {
               handleOpenAiChat(state.query);
               return;
             }
-            // Handle regular navigation
-            router.push(`/${itemUrl}`);
+
+            const pathname = router.asPath;
+            const isMapiReference =
+              itemUrl.startsWith("mapi-reference") &&
+              pathname.startsWith("/mapi-reference");
+            const isApiReference =
+              itemUrl.startsWith("api-reference") &&
+              pathname.startsWith("/api-reference");
+            const isSamePageReferenceResult = isMapiReference || isApiReference;
+
+            // If the item is in the same reference, highlight the item, don't navigate
+            if (isSamePageReferenceResult) {
+              highlightResource(`/${itemUrl}`, { moveToItem: true });
+            } else {
+              // Handle regular navigation
+              router.push(`/${itemUrl}`);
+            }
 
             // Clear the query when navigating
             if (state.query) {

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -99,26 +99,21 @@ const ItemWithSubpages = ({
 
   // Create the debounced function once when component mounts
   // This helps produce a smoother experience when scrolling fast
-  const debouncedHighlight = useMemo(
-    () =>
-      debounce((path: string) => {
-        setIsOpen(true);
-        // This can get triggered when the page moves, but moving the page can highlight a new
-        // item and focus it, which breaks keyboard navigation of search.
-        // So when the search is open, we skip the focus.
-        if (!isSearchOpen) {
-          highlightResource(path);
-        }
-      }, 300), // The lower the number here, the quicker the highlight, but can get laggy if too low
-    [isSearchOpen], // Empty dependency array means this is only created once
-  );
+  const debouncedHighlight = debounce((path: string) => {
+    // Open the collapsible nav item
+    setIsOpen(true);
+    // This can get triggered when the page moves, but moving the page can highlight a new
+    // item and focus it, which breaks keyboard navigation of search.
+    // So when the search is open, we skip the focus.
+    if (!isSearchOpen) {
+      highlightResource(path);
+    }
+  }, 300); // The lower the number here, the quicker the highlight, but can get laggy if too low
 
   useEffect(() => {
     // Don't need all the logic if its not a same page routing
     if (!samePageRouting) return;
     if (!isPageReady) return;
-
-    let observer: IntersectionObserver | null = null;
 
     function getObserver() {
       return new IntersectionObserver(
@@ -132,47 +127,22 @@ const ItemWithSubpages = ({
           });
         },
         {
-          threshold: 0.3,
-          rootMargin: "0px 0px 0px 0px",
+          threshold: 0.5,
+          rootMargin: "100px 0px 100px 0px",
         },
       );
     }
 
-    const addListeners = () => {
-      observer = getObserver();
-
-      // Wait for initial scroll before observing
-      let initialScrollY: number | null = null;
-
-      // Add a scroll buffer to only start observing after the user scrolls through the page a bit
-      const scrollBuffer = () => {
-        if (initialScrollY === null) {
-          initialScrollY = window.scrollY;
-        }
-        const scrollDelta = Math.abs(window.scrollY - initialScrollY);
-        // Only start observing after a certain scroll delta
-        if (scrollDelta < 500) return;
-
-        observer = getObserver();
-
-        document
-          .querySelectorAll(`[data-resource-path^="${resourceSection}"]`)
-          .forEach((element) => {
-            observer?.observe(element);
-          });
-        window.removeEventListener("scroll", scrollBuffer);
-      };
-      window.addEventListener("scroll", scrollBuffer);
-    };
-
-    // Begin observing after a short delay to allow the page to arrive at its initial state
-    // This is to prevent the sidebar from being too eager to scroll to the active item
-    const readyTimeout = setTimeout(addListeners, 1500);
+    const observer: IntersectionObserver | null = getObserver();
+    document
+      .querySelectorAll(`section[data-resource-path^="${resourceSection}"]`)
+      .forEach((element) => {
+        observer?.observe(element);
+      });
 
     // Cleanup observer on unmount
     return () => {
       observer?.disconnect();
-      clearTimeout(readyTimeout);
     };
   }, [
     basePath,

--- a/components/ui/Page/Sidebar.tsx
+++ b/components/ui/Page/Sidebar.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleNavItem,
   type CollapsibleNavItemProps,
 } from "../CollapsibleNavItem";
-import { useState, useMemo, useEffect, createContext, useContext } from "react";
+import { useState, useEffect, createContext, useContext } from "react";
 import {
   isPathTheSame,
   highlightResource,

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -133,8 +133,6 @@ const scrollToElementWithPadding = (
   // Prevents any interruption with the Sidebar scroll events
   window.scrollTo({ top: targetScrollY, behavior: "instant" });
 
-  console.log("jiggle", jiggle);
-
   // Hack to jiggle the scroll a little with smooth scroll to trigger the sidebar to open
   if (jiggle) {
     setTimeout(() => {

--- a/components/ui/Page/helpers.ts
+++ b/components/ui/Page/helpers.ts
@@ -156,8 +156,7 @@ export const useIsPageReady = () => {
     let prevHeight = document.body.scrollHeight;
     let stableCount = 0;
     const maxStableChecks = 3; // Require 3 consecutive stable measurements
-    let interval: NodeJS.Timeout;
-    interval = setInterval(() => {
+    const interval = setInterval(() => {
       const currentHeight = document.body.scrollHeight;
       if (currentHeight === prevHeight) {
         stableCount += 1;

--- a/content/__api-reference/content.mdx
+++ b/content/__api-reference/content.mdx
@@ -1,4 +1,4 @@
-<Section slug="overview">
+<Section slug="overview" path="/overview">
 <ContentColumn>
 The Knock API enables you to add a complete notification engine to your product. This API provides
 programmatic access to integrating Knock via a REST-ful API.

--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -12,7 +12,7 @@ tags: ["api", "sdks", "api key", "keys", "errors"]
   data-resource-path="/overview"
 />
 
-<Section slug="overview">
+<Section slug="overview" path="/overview">
 <ContentColumn>
 
 <Callout


### PR DESCRIPTION
[[Docs] Bug in redirect from search to API Reference](https://linear.app/knock/issue/KNO-8744/docs-bug-in-redirect-from-search-to-api-reference)

This PR makes navigating to API reference pages more consistent.

The problem was that we'd try to navigate to the section prematurely, as the page was still rendering (API references are big pages, so this takes time). I added a check to make sure the page was at its final height before navigating.

Also, the sidebar wouldn't open in Scoti's video because SlackChannelData is a deeply nested page. Sidebar open state code didn't account for pages that were nested this deeply, so I made the function recursive to handle infinitely nested pages.