### PR TITLE
chore(kno-8732): clarify inline preferences merge behavior

### DIFF
--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -174,10 +174,11 @@ Another option is to offload these updates to your workflow trigger calls via in
       title="Please note:"
       text={
         <>
-          setting preferences inline will always
-          upsert the preference set, meaning that changes will override any existing
-          preferences. We generally recommend against using inline preferences to
-          ensure the integrity of your data.
+          unlike our preferences endpoints, which will overwrite any existing preferences with the preferences provided,
+          setting preferences inline will perform a deep merge of the provided preferences into any existing preferences
+          (just like any other <a href="/concepts/users#storing-user-properties">properties stored on the recipient</a>).
+          Unless you intend to leverage this behavior for a specific use case, we generally recommend against using
+          inline preferences to ensure the integrity of your data.
         </>
       }
     />

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -257,3 +257,73 @@ You can update the preferences of up to 1000 users in a single batch by using th
 - [Preference conditions](/preferences/preference-conditions). You can build advanced conditions and store them on Knock’s preference model to power use cases such as per-resource muting (example: mute notifications about this task) or threshold alerts (example: only notify me if my account balance is below $5).
 - Workflow overrides. If you need to override a recipient's notification preferences to send notifications like a password reset email, you can override the preferences model. To do this, go to your workflow, click "Manage workflow," and enable "Override recipient preferences." You will need to commit this change for it to take effect. When enabled, the workflow will send to all of its channels, regardless of the recipient's preferences.
 - [Commercial unsubscribe](/preferences/commercial-unsubscribe). You can configure 1-click unsubscribe links to help users opt-out of commercial or promotional notifications and comply with CAN-SPAM requirements.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Can I update a single preference rather than replacing a recipient's entire preference set?">
+    While our preferences API endpoints will always overwrite the
+    existing `PreferenceSet` with the new preferences provided, it's possible to
+    update a single preference by using any of our [recipient identification
+    methods](/managing-recipients/identifying-recipients), including while triggering a workflow (as seen in the example below). 
+    This will perform a deep merge of the provided preferences into any
+    existing preferences, just like any other [properties stored on the
+    recipient](/concepts/users#storing-user-properties). 
+    
+    Note that the syntax for providing the `id` of the preference set on an [`InlinePreferenceSetRequest`](/api-reference/recipients/preferences/schemas/inline_preference_set_request)
+    is slightly different than the way that our preferences endpoints handles them; you'll simply provide a key-value pair where the key is the `id` of the preference set and the value is the `PreferenceSet` you'd like to merge.
+   
+    Here's what this looks like in practice. If a user has these existing `default` preferences:
+    ```json title="An existing default preference set"
+    {
+      "categories": {
+        "collaboration": {
+          "channel_types": {
+            "email": true,
+            "in_app_feed": true
+          }
+        }
+      }
+    }
+    ```
+    and they would like to update their email preference for the `collaboration` category to `false`, you can do so by providing the following `InlinePreferenceSetRequest` while triggering a workflow:
+    ```javascript title="Triggering a workflow with inline preferences using the Node SDK"
+    import Knock from "@knocklabs/node";
+    const knock = new Knock({ apiKey: process.env.KNOCK_API_KEY });
+
+    await knock.workflows.trigger("new-comment", {
+      data: { project_name: "My Project" },
+      recipients: [
+        {
+          id: "1",
+          preferences: {
+            default: {
+              categories: {
+                collaboration: {
+                  channel_types: {
+                    email: false
+                  }
+                }
+              }
+            }
+          }
+        },
+      ],
+    });
+    ```
+    This will result in the following `PreferenceSet` being set on the recipient prior to the workflow being triggered:
+    ```json title="The resulting default preference set"
+    {
+      "categories": {
+        "collaboration": {
+          "channel_types": {
+            "email": false,
+            "in_app_feed": true
+          }
+        }
+      }
+    }
+    ```
+
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

This PR clarifies the behavior that will occur when `preferences` are provided on an identify request: rather than replacing the existing `PreferenceSet`, these preferences will be merged in the same way that other recipient properties are merged.

- Updates existing FAQ on "Identifying recipients" page (currently-documented behavior is incorrect)
- Adds FAQ to Preferences overview page

I'll open a separate PR to clarify this on the `InlinePreferenceSetRequest` description in the OpenAPI spec as well.