### PR TITLE
chore(KNO-8820): Add format_date_in_locale to Knock-specific Liquid helpers

### DIFF
--- a/content/designing-workflows/template-editor/reference-liquid-helpers.mdx
+++ b/content/designing-workflows/template-editor/reference-liquid-helpers.mdx
@@ -40,6 +40,6 @@ The Knock template editor uses Liquid syntax for control flow and variable decla
 
 ### Localization parameters
 
-A few of Knock's Liquid helpers (such as `format_date_in_locale`, `currency`, and `format_number`) take an optional locale parameter to format the output of the helper into a localized format. You can find a list of supported locales below. If we're missing a locale that you'd like us to support, please [reach out](mailto:support@knock.app).
+A few of Knock's Liquid helpers (such as `format_date_in_locale`, `format_number`, `currency`, and `rounded_currency`) take an optional locale parameter to format the output of the helper into a localized format. You can find a list of supported locales below. If we're missing a locale that you'd like us to support, please [reach out](mailto:support@knock.app).
 
 **Supported locales:** `af`, `ar`, `az`, `be`, `bg`, `bn`, `bs`, `ca`, `cs`, `cy`, `da`, `de`, `el`, `en`, `en-GB`, `eo`, `es`, `es-419`, `et`, `eu`, `fa`, `fi`, `fr`, `fr-CA`, `fr-FR`, `gl`, `he`, `hi`, `hr`, `hu`, `id`, `is`, `it`, `ja`, `ka`, `km`, `kn`, `ko`, `lb`, `lo`, `lt`, `lv`, `mk`, `ml`, `mn`, `mr`, `ms`, `nb`, `ne`, `nl`, `nn`, `no`, `or`, `pa`, `pl`, `pl-PL`, `pt`, `pt-BR`, `rm`, `ro`, `ru`, `sk`, `sl`, `sq`, `sr`, `sv`, `sw`, `ta`, `te`, `th`, `tr`, `tt`, `ug`, `uk`, `ur`, `uz`, `vi`, `wo`, `zh`, `zh-Hans`, `zh-Hant`


### PR DESCRIPTION
### Description

Adds the new `format_date_in_locale` Liquid helper to the docs. https://docs-git-rt-kno-8820-knocklabs.vercel.app/designing-workflows/template-editor/reference-liquid-helpers#knock-specific-liquid-helpers

### Tasks

[KNO-8820](https://linear.app/knock/issue/KNO-8820/docs-add-format-date-in-locale-to-liquid-helpers)

### Screenshots

![Screenshot 2025-06-09 at 11 37 04 AM](https://github.com/user-attachments/assets/1c7892e6-b020-488f-ae1f-173dd8e81a67)
