### PR TITLE
fix: change template level settings from modal to editor

### DIFF
--- a/content/integrations/email/settings.mdx
+++ b/content/integrations/email/settings.mdx
@@ -15,7 +15,7 @@ When you configure a setting in a channel's configuration, it will be used on al
 You can override email settings on a per-channel basis, or on a per-template basis.
 
 - **At the channel level**. The `to`, `cc`, `bcc`, and `reply-to` fields can be found in the "Overrides" section of the channel's "Settings" tab.
-- **At the template level**. You'll find the email settings under the "Template settings" button.
+- **At the template level**. The email settings fields can be found at the top of the email template editor.
 
 All email configuration fields support Liquid usage. You will be able to use any variables available in your workflow trigger payloads, as well as system variables such as the current workflow, activities, and any other variables you have access to when building templates.
 


### PR DESCRIPTION
### Description
Settings like from, to, reply to, etc. will be moved from the template settings modal to the editor itself, so this reflects that change. 