### PR TITLE
feat(KNO-8819): add push and pull commands to CLI reference

### DIFF
--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -1390,3 +1390,78 @@ knock commit promote --only=69cdde18-830a-42e0-ad4b-a230943bdc90
 
 </ExampleColumn>
 </Section>
+
+<Section title="knock pull [flags]" path="/pull">
+<ContentColumn>
+
+Pulls the contents of all Knock resources (workflows, partials, email layouts, and translations) from Knock into your local file system.
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--environment"
+    type="string"
+    description="The environment to use. Defaults to development."
+  />
+  <Attribute
+    name="--knock-dir"
+    type="directory"
+    description="The target directory path to pull all resources into."
+  />
+  <Attribute
+    name="--hide-uncommitted-changes"
+    type="boolean"
+    description="Should any uncommitted changes be hidden? Defaults to false."
+  />
+  <Attribute
+    name="--force"
+    type="boolean"
+    description="Removes the confirmation prompt. Defaults to false."
+  />
+</Attributes>
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="Pull all resources"
+knock pull --knock-dir=./knock
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="knock push [flags]" path="/push">
+<ContentColumn>
+
+Pushes all local resource files (workflows, partials, email layouts, and translations) back to Knock and upserts them.
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--knock-dir"
+    type="directory"
+    description="The target directory path to push all resources from."
+  />
+  <Attribute
+    name="--commit"
+    type="boolean"
+    description="Push and commit at the same time. Defaults to false."
+  />
+  <Attribute
+    name="-m, --commit-message"
+    type="string"
+    description="The commit message to pass when using the `--commit` flag."
+  />
+</Attributes>
+</ContentColumn>
+
+<ExampleColumn>
+
+```bash title="Push all resources"
+knock push --knock-dir=./knock
+```
+
+</ExampleColumn>
+</Section>

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -109,6 +109,92 @@ The following flags are supported for every command.
 </ContentColumn>
 </Section>
 
+<Section title="knock pull [flags]" path="/pull">
+<ContentColumn>
+
+Pulls the contents of all Knock resources (workflows, partials, email layouts, and translations) from Knock into your local file system.
+
+Resources will be grouped by resource type within subdirectories of the target directory path set by the `--knock-dir` flag. For example, invoking `knock pull --knock-dir=./knock` will create the following directory structure:
+
+{/* prettier-ignore */}
+<pre role="img" aria-label="Directory structure created by the knock pull command" style={{ marginLeft: "16px" }}>
+./knock/
+├── layouts/
+├── partials/
+├── translations/
+├── workflows/
+</pre>
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--environment"
+    type="string"
+    description="The environment to use. Defaults to development."
+  />
+  <Attribute
+    name="--knock-dir"
+    type="directory"
+    description="The target directory path to pull all resources into."
+  />
+  <Attribute
+    name="--hide-uncommitted-changes"
+    type="boolean"
+    description="Should any uncommitted changes be hidden? Defaults to false."
+  />
+  <Attribute
+    name="--force"
+    type="boolean"
+    description="Removes the confirmation prompt. Defaults to false."
+  />
+</Attributes>
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="Pull all resources"
+knock pull --knock-dir=./knock
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="knock push [flags]" path="/push">
+<ContentColumn>
+
+Pushes all local resource files (workflows, partials, email layouts, and translations) back to Knock and upserts them. This command expects the directory structure to be the same as the one created by the `knock pull` command.
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--knock-dir"
+    type="directory"
+    description="The target directory path to push all resources from."
+  />
+  <Attribute
+    name="--commit"
+    type="boolean"
+    description="Push and commit at the same time. Defaults to false."
+  />
+  <Attribute
+    name="-m, --commit-message"
+    type="string"
+    description="The commit message to pass when using the `--commit` flag."
+  />
+</Attributes>
+</ContentColumn>
+
+<ExampleColumn>
+
+```bash title="Push all resources"
+knock push --knock-dir=./knock
+```
+
+</ExampleColumn>
+</Section>
+
 <Section title="knock workflow list [flags]" path="/workflow/list">
 <ContentColumn>
 
@@ -1386,92 +1472,6 @@ knock commit promote --to=production
 
 ```bash title="Promotes one change"
 knock commit promote --only=69cdde18-830a-42e0-ad4b-a230943bdc90
-```
-
-</ExampleColumn>
-</Section>
-
-<Section title="knock pull [flags]" path="/pull">
-<ContentColumn>
-
-Pulls the contents of all Knock resources (workflows, partials, email layouts, and translations) from Knock into your local file system.
-
-Resources will be grouped by resource type within subdirectories of the target directory path set by the `--knock-dir` flag. For example, invoking `knock pull --knock-dir=./knock` will create the following directory structure:
-
-{/* prettier-ignore */}
-<pre role="img" aria-label="Directory structure created by the knock pull command" style={{ marginLeft: "16px" }}>
-./knock/
-├── layouts/
-├── partials/
-├── translations/
-├── workflows/
-</pre>
-
-### Flags
-
-<Attributes>
-  <Attribute
-    name="--environment"
-    type="string"
-    description="The environment to use. Defaults to development."
-  />
-  <Attribute
-    name="--knock-dir"
-    type="directory"
-    description="The target directory path to pull all resources into."
-  />
-  <Attribute
-    name="--hide-uncommitted-changes"
-    type="boolean"
-    description="Should any uncommitted changes be hidden? Defaults to false."
-  />
-  <Attribute
-    name="--force"
-    type="boolean"
-    description="Removes the confirmation prompt. Defaults to false."
-  />
-</Attributes>
-
-</ContentColumn>
-<ExampleColumn>
-
-```bash title="Pull all resources"
-knock pull --knock-dir=./knock
-```
-
-</ExampleColumn>
-</Section>
-
-<Section title="knock push [flags]" path="/push">
-<ContentColumn>
-
-Pushes all local resource files (workflows, partials, email layouts, and translations) back to Knock and upserts them. This command expects the directory structure to be the same as the one created by the `knock pull` command.
-
-### Flags
-
-<Attributes>
-  <Attribute
-    name="--knock-dir"
-    type="directory"
-    description="The target directory path to push all resources from."
-  />
-  <Attribute
-    name="--commit"
-    type="boolean"
-    description="Push and commit at the same time. Defaults to false."
-  />
-  <Attribute
-    name="-m, --commit-message"
-    type="string"
-    description="The commit message to pass when using the `--commit` flag."
-  />
-</Attributes>
-</ContentColumn>
-
-<ExampleColumn>
-
-```bash title="Push all resources"
-knock push --knock-dir=./knock
 ```
 
 </ExampleColumn>

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -1396,6 +1396,17 @@ knock commit promote --only=69cdde18-830a-42e0-ad4b-a230943bdc90
 
 Pulls the contents of all Knock resources (workflows, partials, email layouts, and translations) from Knock into your local file system.
 
+Resources will be grouped by resource type within subdirectories of the target directory path set by the `--knock-dir` flag. For example, invoking `knock pull --knock-dir=./knock` will create the following directory structure:
+
+{/* prettier-ignore */}
+<pre role="img" aria-label="Directory structure created by the knock pull command" style={{ marginLeft: "16px" }}>
+./knock/
+├── layouts/
+├── partials/
+├── translations/
+├── workflows/
+</pre>
+
 ### Flags
 
 <Attributes>
@@ -1434,7 +1445,7 @@ knock pull --knock-dir=./knock
 <Section title="knock push [flags]" path="/push">
 <ContentColumn>
 
-Pushes all local resource files (workflows, partials, email layouts, and translations) back to Knock and upserts them.
+Pushes all local resource files (workflows, partials, email layouts, and translations) back to Knock and upserts them. This command expects the directory structure to be the same as the one created by the `knock pull` command.
 
 ### Flags
 

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -27,9 +27,9 @@ With the CLI, you can:
 <Section title="Install the CLI" path="/overview/installation">
 <ContentColumn>
 
-### Install with homebrew
+### Install with Homebrew
 
-For macOS, you can install the Knock CLI using [homebrew](https://brew.sh/). Once the CLI is installed you can call it by using the `knock` command in your terminal.
+For macOS, you can install the Knock CLI using [Homebrew](https://brew.sh/). Once the CLI is installed you can call it by using the `knock` command in your terminal.
 
 ### Install with npm
 

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -17,7 +17,7 @@ section: Developer Tools
 
 With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, Partials, and Translations between [environments](/concepts/environments) during testing and deployment.
 
-This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli#installation) on your local machine.
+This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli/overview/installation) on your local machine.
 
 ## Local development
 
@@ -30,7 +30,7 @@ With the Knock CLI, you can pull all of your resources from the Knock dashboard 
 
 You can also work with specific resources by providing a `key` rather than using the `--all` flag.
 
-Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock push`](/cli/push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock push`](/cli/push)) and commit ([`knock commit`](/cli/commit/all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
 
 <Callout
   emoji="🛑"

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -15,15 +15,22 @@ tags:
 section: Developer Tools
 ---
 
-With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, and Translations between [environments](/concepts/environments) during testing and deployment.
+With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, Partials, and Translations between [environments](/concepts/environments) during testing and deployment.
 
 This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli#installation) on your local machine.
 
 ## Local development
 
-With the Knock CLI, you can pull resources from the Knock dashboard and develop them locally using the [`knock workflow pull --all`](/cli#workflow-pull), [`knock layout pull --all`](/cli#email-layout-pull), and [`knock translation pull --all`](/cli#translation-pull) commands. You can also work with specific resources by providing a `key` rather than using the `--all` flag.
+With the Knock CLI, you can pull all of your resources from the Knock dashboard and develop them locally using the [`knock pull`](/cli/pull) command. If you’d prefer to pull each type of resource individually, you can use one of the following commands:
 
-Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock workflow push --all`](/cli#workflow-push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
+- [`knock workflow pull --all`](/cli/workflow/pull)
+- [`knock layout pull --all`](/cli/email-layout/pull)
+- [`knock partial pull --all`](/cli/partial/pull)
+- [`knock translation pull --all`](/cli/translation/pull)
+
+You can also work with specific resources by providing a `key` rather than using the `--all` flag.
+
+Once you’re ready to send your updates back to Knock’s Development environment, you can push ([`knock push`](/cli/push)) and commit ([`knock commit`](/cli#commit-all)) changes directly from the command line in the same way that you would save and commit them in your dashboard. You can also perform both of these actions at once by using the `--commit` flag on any `push` command.
 
 <Callout
   emoji="🛑"

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -18,7 +18,7 @@ You can install the Knock CLI using `npm`, a node package manager, with the foll
 npm install -g @knocklabs/cli
 ```
 
-Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via Homebrew for macOS, see the installation guide [here](/cli#installation).
+Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via Homebrew for macOS. See [the installation guide](/cli/overview/installation).
 
 ## Authenticating the CLI
 

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -18,7 +18,7 @@ You can install the Knock CLI using `npm`, a node package manager, with the foll
 npm install -g @knocklabs/cli
 ```
 
-Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via homebrew for macOS, see the installation guide [here](/cli#installation).
+Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via Homebrew for macOS, see the installation guide [here](/cli#installation).
 
 ## Authenticating the CLI
 

--- a/data/sidebars/cliSidebar.ts
+++ b/data/sidebars/cliSidebar.ts
@@ -1,6 +1,6 @@
-import { SidebarSection } from "../types";
+import { SidebarContent } from "../types";
 
-export const CLI_SIDEBAR: SidebarSection[] = [
+export const CLI_SIDEBAR: SidebarContent[] = [
   {
     title: "Getting started",
     slug: "/cli/overview",
@@ -12,6 +12,17 @@ export const CLI_SIDEBAR: SidebarSection[] = [
     ],
     sidebarMenuDefaultOpen: true,
   },
+
+  {
+    title: "Pull all resources",
+    slug: "/cli/pull",
+  },
+
+  {
+    title: "Push all resources",
+    slug: "/cli/push",
+  },
+
   {
     title: "Workflows",
     slug: "/cli/workflow",
@@ -71,15 +82,6 @@ export const CLI_SIDEBAR: SidebarSection[] = [
       { slug: "/get", title: "Get commits" },
       { slug: "/all", title: "Commit changes" },
       { slug: "/promote", title: "Promote changes" },
-    ],
-  },
-
-  {
-    title: "Misc.",
-    slug: "/cli",
-    pages: [
-      { slug: "/pull", title: "Pull all resources" },
-      { slug: "/push", title: "Push all resources" },
     ],
   },
 ];

--- a/data/sidebars/cliSidebar.ts
+++ b/data/sidebars/cliSidebar.ts
@@ -73,4 +73,13 @@ export const CLI_SIDEBAR: SidebarSection[] = [
       { slug: "/promote", title: "Promote changes" },
     ],
   },
+
+  {
+    title: "Misc.",
+    slug: "/cli",
+    pages: [
+      { slug: "/pull", title: "Pull all resources" },
+      { slug: "/push", title: "Push all resources" },
+    ],
+  },
 ];

--- a/pages/cli/[...slug].tsx
+++ b/pages/cli/[...slug].tsx
@@ -1,17 +1,17 @@
 import fs from "fs";
-import { serialize } from "next-mdx-remote/serialize";
 import { MDXRemote } from "next-mdx-remote";
-import remarkGfm from "remark-gfm";
+import { serialize } from "next-mdx-remote/serialize";
 import rehypeMdxCodeProps from "rehype-mdx-code-props";
+import remarkGfm from "remark-gfm";
 
-import { SidebarSection } from "@/data/types";
-import MDXLayout from "../../layouts/MDXLayout";
-import { CONTENT_DIR } from "../../lib/content.server";
-import eventPayload from "../../data/code/sources/eventPayload";
+import { SidebarContent } from "@/data/types";
+import { MDX_COMPONENTS } from "@/lib/mdxComponents";
+import AiChatButton from "../../components/AiChatButton";
 import datadogDashboardJson from "../../content/integrations/extensions/datadog_dashboard.json";
 import newRelicDashboardJson from "../../content/integrations/extensions/new_relic_dashboard.json";
-import AiChatButton from "../../components/AiChatButton";
-import { MDX_COMPONENTS } from "@/lib/mdxComponents";
+import eventPayload from "../../data/code/sources/eventPayload";
+import MDXLayout from "../../layouts/MDXLayout";
+import { CONTENT_DIR } from "../../lib/content.server";
 
 import { CLI_SIDEBAR } from "@/data/sidebars/cliSidebar";
 
@@ -57,13 +57,13 @@ export async function getStaticProps() {
 
 export async function getStaticPaths() {
   const paths: { params: { slug: string[] } }[] = [];
-  const pages: SidebarSection[] = CLI_SIDEBAR;
+  const pages: SidebarContent[] = CLI_SIDEBAR;
 
   for (const page of pages) {
     const slug = page.slug.split("/").pop() as string;
     paths.push({ params: { slug: [slug] } });
 
-    for (const subPage of page.pages) {
+    for (const subPage of page.pages ?? []) {
       paths.push({
         params: { slug: [slug, subPage.slug.replace("/", "")] },
       });


### PR DESCRIPTION
### Description

This PR:
- Updates the Knock CLI reference to describe the new `knock push` and `knock pull` commands.
- Updates the CI/CD guide to reference these new commands and fix broken links.

There’s a small bug that affects the CLI reference sidebar. Notice in the video below, as I scroll to the sections for `knock push` and `knock pull`, the sidebar doesn’t correctly highlight the corresponding entries. I plan to address this in a follow-up, so that this PR focuses on the docs content itself.

https://github.com/user-attachments/assets/c4c20353-856c-4c7c-8a88-868ad2dc9b76

### Tasks

[KNO-8819](https://linear.app/knock/issue/KNO-8819/docs-describe-new-knock-push-and-knock-pull-commands)