### PR TITLE
chore(KNO-8866): add PreTextDiagram component

### DIFF
--- a/components/ui/PreTextDiagram.tsx
+++ b/components/ui/PreTextDiagram.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  description: string;
+};
+
+const PreTextDiagram = ({ children, description }: Props) => {
+  return (
+    <pre
+      role="img"
+      aria-label={description}
+      style={{
+        marginLeft: "16px",
+        marginRight: "16px",
+        marginBottom: "16px",
+        whiteSpace: "pre",
+        fontSize: "14px",
+        lineHeight: "18px",
+      }}
+    >
+      {children}
+    </pre>
+  );
+};
+
+export { PreTextDiagram };

--- a/components/ui/PreTextDiagram.tsx
+++ b/components/ui/PreTextDiagram.tsx
@@ -1,3 +1,4 @@
+import { Code } from "@telegraph/typography";
 import { ReactNode } from "react";
 
 type Props = {
@@ -7,20 +8,16 @@ type Props = {
 
 const PreTextDiagram = ({ children, description }: Props) => {
   return (
-    <pre
+    <Code
+      as="pre"
       role="img"
       aria-label={description}
-      style={{
-        marginLeft: "16px",
-        marginRight: "16px",
-        marginBottom: "16px",
-        whiteSpace: "pre",
-        fontSize: "14px",
-        lineHeight: "18px",
-      }}
+      mx="4"
+      mb="4"
+      leading="1"
     >
       {children}
-    </pre>
+    </Code>
   );
 };
 

--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -117,13 +117,13 @@ Pulls the contents of all Knock resources (workflows, partials, email layouts, a
 Resources will be grouped by resource type within subdirectories of the target directory path set by the `--knock-dir` flag. For example, invoking `knock pull --knock-dir=./knock` will create the following directory structure:
 
 {/* prettier-ignore */}
-<pre role="img" aria-label="Directory structure created by the knock pull command" style={{ marginLeft: "16px" }}>
-./knock/
+<PreTextDiagram description="Directory structure created by the knock pull command">
+{`./knock/
 ├── layouts/
 ├── partials/
 ├── translations/
-├── workflows/
-</pre>
+└── workflows/`}
+</PreTextDiagram>
 
 ### Flags
 

--- a/content/concepts/translations.mdx
+++ b/content/concepts/translations.mdx
@@ -306,15 +306,16 @@ The Knock CLI can also be used to commit changes and promote them to production,
 
 When translations are pulled from Knock, they are stored in directories named by their locale codes. Their filename will be their locale code. Any namespaced translations will prepend the namespace to the filename, with `.` used as a separator.
 
-```txt title="Local translation files structure"
-translations/
+{/* prettier-ignore */}
+<PreTextDiagram description="Local translation files structure">
+{`translations/
 ├── en/
 │  ├── en.json
 │  └── admin.en.json
 └── en-GB/
    ├── en-GB.json
-   └── tasks.en-GB.json
-```
+   └── tasks.en-GB.json`}
+</PreTextDiagram>
 
 If you're migrating your local translation files into Knock, you can arrange them using the file structure above and then push them into Knock with a single command using [`knock translation push --all`](/cli#translation-push). Each `<locale>.json` or `<namespace>.<locale>.json` file should follow the structure defined [here](/mapi-reference/translations/schemas/translation).
 

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -152,8 +152,9 @@ The Knock CLI can also be used to commit changes and promote them to production,
 
 When workflows are pulled from Knock, they are stored in directories named by their workflow key. In addition to a `workflow.json` file that describes all of a given workflow's steps, each workflow directory also contains individual folders for each of the [channel steps](/designing-workflows/channel-step) in the workflow that hold additional content and formatting data.
 
-```txt title="Local workflow files structure"
-workflows/
+{/* prettier-ignore */}
+<PreTextDiagram description="Local workflow files structure">
+{`workflows/
 └── my-workflow/
     ├── email_1/
     │   ├── visual_blocks/
@@ -161,8 +162,8 @@ workflows/
     │   └── visual_blocks.json
     ├── in_app_feed_1/
     │   └── markdown_body.md
-    └── workflow.json
-```
+    └── workflow.json`}
+</PreTextDiagram>
 
 If you're migrating your local workflow files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock workflow push --all`](/cli#workflow-push). Each `workflow.json` file should follow the structure defined [here](/mapi-reference/workflows/schemas/workflow).
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -276,8 +276,9 @@ The Knock CLI can also be used to commit changes and promote them to production,
 
 When email layouts are pulled from Knock, they are stored in directories named by their layout key.
 
-```txt title="Local layout files structure"
-layouts/
+{/* prettier-ignore */}
+<PreTextDiagram description="Local layout files structure">
+{`layouts/
 ├── default/
 │   ├── html_layout.html
 │   ├── layout.json
@@ -285,8 +286,8 @@ layouts/
 └── custom-layout/
     ├── html_layout.html
     ├── layout.json
-    └── text_layout.txt
-```
+    └── text_layout.txt`}
+</PreTextDiagram>
 
 If you're migrating your local layout files into Knock, you can arrange them using the example file structure above and then push them into Knock with a single command using [`knock layout push --all`](/cli#email-layout-push). Each `layout.json` file should follow the example shown below; additional information on the Layout structure is defined [here](/mapi-reference/email_layouts/schemas/email_layout).
 

--- a/lib/mdxComponents.tsx
+++ b/lib/mdxComponents.tsx
@@ -39,6 +39,7 @@ import { Tag } from "@telegraph/tag";
 import SectionHeading from "@/components/ui/SectionHeading";
 import { ContentActions } from "@/components/ui/ContentActions";
 import PermissionsMatrix from "@/components/ui/PermissionsMatrix";
+import { PreTextDiagram } from "@/components/ui/PreTextDiagram";
 
 export const MDX_COMPONENTS = {
   pre: (props) => <CodeBlock mb="2" {...props} />,
@@ -101,4 +102,5 @@ export const MDX_COMPONENTS = {
   Tag,
   ContentActions,
   PermissionsMatrix,
+  PreTextDiagram
 };

--- a/lib/mdxComponents.tsx
+++ b/lib/mdxComponents.tsx
@@ -102,5 +102,5 @@ export const MDX_COMPONENTS = {
   Tag,
   ContentActions,
   PermissionsMatrix,
-  PreTextDiagram
+  PreTextDiagram,
 };


### PR DESCRIPTION
### Description

This PR adds a new component `<PreTextDiagram>` to render diagrams made of pre-formatted text, including file tree diagrams.

### Tasks

[KNO-8866](https://linear.app/knock/issue/KNO-8866/docs-add-pre-formatted-text-diagram-component)

### Screenshots

#### Before

<img width="730" alt="Screenshot 2025-06-11 at 2 46 16 PM" src="https://github.com/user-attachments/assets/7d98c88e-a8c1-4cc2-b8d4-d24d9a01448e" />

#### After

<img width="730" alt="Screenshot 2025-06-11 at 2 46 31 PM" src="https://github.com/user-attachments/assets/eff41a29-224d-4707-925b-18ec456f7b3e" />
