### PR TITLE
chore: improvements to new SDK migration docs

### DIFF
--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -46,7 +46,7 @@ Knock will preemptively schedule workflow runs for the recipient(s) that you've 
 
 To schedule a workflow for a recipient using recurring schedules, you must first have a valid, committed workflow in your environment. We can then set a schedule with `repeats` for one or more recipients (up to 100 at a time).
 
-```typescript
+```typescript title="Creating a recurring schedule for multiple recipients"
 import Knock from "@knocklabs/node";
 const client = new Knock({ apiKey: process.env["KNOCK_API_KEY"] });
 
@@ -72,7 +72,7 @@ const schedules = await client.schedules.create({
 
 To schedule a workflow for a recipient using a non-recurring schedule, you must also have a valid and committed workflow in your environment. We can then set a schedule with the `scheduled_at` property, specifying the moment when this workflow should be executed.
 
-```typescript
+```typescript title="Creating a one-off schedule for a specific date and time"
 import Knock from "@knocklabs/node";
 const client = new Knock({ apiKey: process.env["KNOCK_API_KEY"] });
 
@@ -135,7 +135,7 @@ Every recurring schedule accepts one or more repeat rules, which allow you to ex
 
 A schedule repeat has the following type structure:
 
-```typescript
+```typescript title="ScheduleRepeat type definitions"
 enum DaysOfWeek {
   Mon = "mon",
   Tue = "tue",
@@ -169,7 +169,7 @@ To illustrate how to model a repeat rule, here are some common examples:
 
 **Every Monday at 9am**
 
-```
+```json title="Schedule repeat for every Monday at 9am"
 {
   "frequency": "weekly",
   "days": ["mon"],
@@ -179,7 +179,7 @@ To illustrate how to model a repeat rule, here are some common examples:
 
 **Every weekday at 10.30am**
 
-```
+```json title="Schedule repeat for every weekday at 10:30am"
 {
   "frequency": "weekly",
   "days": "weekdays",
@@ -190,7 +190,7 @@ To illustrate how to model a repeat rule, here are some common examples:
 
 **Every other Monday, Tuesday, and Friday at 6pm**
 
-```
+```json title="Schedule repeat for every other week on specific days"
 {
   "frequency": "weekly",
   "interval": 2,
@@ -204,7 +204,7 @@ To illustrate how to model a repeat rule, here are some common examples:
 
 Up to 100 recipient schedules can be updated in a single call. Keep in mind that the properties passed in will be applied to all schedules.
 
-```typescript title="Updating schedules"
+```typescript title="Updating existing schedules"
 import Knock from "@knocklabs/node";
 const client = new Knock({ apiKey: process.env["KNOCK_API_KEY"] });
 
@@ -219,7 +219,7 @@ const schedules = await client.schedules.update({
 
 Up to 100 schedules can be deleted at a time, causing any already enqueued schedules to be cancelled for a recipient.
 
-```typescript title="Removing schedules"
+```typescript title="Deleting schedules"
 import Knock from "@knocklabs/node";
 const client = new Knock({ apiKey: process.env["KNOCK_API_KEY"] });
 

--- a/content/developer-tools/migration-guides/go.mdx
+++ b/content/developer-tools/migration-guides/go.mdx
@@ -137,9 +137,9 @@ The new SDK introduces cursor-based pagination with auto-pagination helpers.
 
 ## Common operations
 
-### Triggering workflows
-
-**Old SDK:**
+<AccordionGroup>
+  <Accordion title="Triggering workflows">
+    **Old SDK:**
 
 ```go title="Triggering workflows with the old SDK"
 req := &knock.TriggerWorkflowRequest{
@@ -178,9 +178,9 @@ response, err := client.Workflows.Trigger(
 )
 ```
 
-### Identifying users
-
-**Old SDK:**
+  </Accordion>
+  <Accordion title="Identifying users">
+  **Old SDK:**
 
 ```go title="Identifying users with the old SDK"
 user, _ := client.Users.Identify(ctx, &knock.IdentifyUserRequest{
@@ -209,8 +209,8 @@ user, err := client.Users.Update(
 )
 ```
 
-### Working with objects
-
+  </Accordion>
+  <Accordion title="Working with objects">
 **Old SDK:**
 
 ```go title="Setting object properties with the old SDK"
@@ -239,6 +239,9 @@ object, err := client.Objects.Set(
     },
 )
 ```
+
+  </Accordion>
+</AccordionGroup>
 
 ## Need help?
 

--- a/content/developer-tools/migration-guides/go.mdx
+++ b/content/developer-tools/migration-guides/go.mdx
@@ -1,14 +1,16 @@
 ---
 title: Go SDK upgrade (v0.x to v1.0)
-description: This guide will help you upgrade from the previous Knock Go SDK to the new v1.0 Go SDK.
+description: Learn how to upgrade to v1.0 of the Knock Go SDK.
 section: Developer tools
 ---
 
-## Basic Changes
+## Basic changes
 
-### Client Initialization
+### Client initialization
 
-```go
+The new SDK uses updated configuration methods:
+
+```go title="Initializing the Knock client"
 import (
     "context"
     "os"
@@ -25,107 +27,120 @@ client := knock.NewClient(
 )
 ```
 
-## New Features in v1.0
+## What's new in v1.0
 
-1. **Strong Type System**: Improved type safety with field wrappers
+The v1.0 SDK brings significant improvements to type safety, error handling, and developer experience.
 
-   ```go
-   // New SDK uses a Field wrapper to distinguish between zero values and unset fields
-   knock.F("value")       // Set a field
-   knock.Null[string]()   // Explicitly set to null
-   knock.Raw[string](123) // Send a value of a different type than the field's type
-   ```
+### Strong type system
 
-2. **Auto-pagination**: Easily iterate through paginated resources
+The new SDK uses field wrappers to distinguish between zero values and unset fields:
 
-   ```go
-   // Automatically fetches more pages as needed
-   iter := client.Users.ListAutoPaging(ctx, knock.UserListParams{})
-   for iter.Next() {
-     user := iter.Current()
-     fmt.Printf("%+v\n", user)
-   }
-   if err := iter.Err(); err != nil {
-     panic(err.Error())
-   }
-   ```
+```go title="Using field wrappers for type safety"
+// Set a field
+knock.F("value")
 
-3. **Enhanced Error Handling**: Better error types with detailed information
+// Explicitly set to null
+knock.Null[string]()
 
-   ```go
-   _, err := client.Users.Get(ctx, "dnedry")
-   if err != nil {
-       var apiErr *knock.Error
-       if errors.As(err, &apiErr) {
-           fmt.Println(string(apiErr.DumpRequest(true)))  // Print the serialized HTTP request
-           fmt.Println(string(apiErr.DumpResponse(true))) // Print the serialized HTTP response
-       }
-   }
-   ```
+// Send a value of a different type than the field's type
+knock.Raw[string](123)
+```
 
-4. **Request Options**: More flexible configuration for requests
+### Auto-pagination
 
-   ```go
-   // Configure per-request options
-   client.Users.Get(
-       ctx,
-       "dnedry",
-       option.WithHeader("X-Custom-Header", "custom_value"),
-       option.WithRequestTimeout(20*time.Second),
-   )
-   ```
+Iterate through paginated resources without manual page management:
 
-5. **Raw JSON Access**: Access raw JSON data for advanced use cases
+```go title="Auto-pagination through user list"
+// Automatically fetches more pages as needed
+iter := client.Users.ListAutoPaging(ctx, knock.UserListParams{})
+for iter.Next() {
+  user := iter.Current()
+  fmt.Printf("%+v\n", user)
+}
+if err := iter.Err(); err != nil {
+  panic(err.Error())
+}
+```
 
-   ```go
-   user, _ := client.Users.Get(ctx, "jhammond")
+### Enhanced error handling
 
-   // Check if a field is null or missing
-   if user.Name == "" {
-       if user.JSON.Name.IsNull() {
-           fmt.Println("Name is explicitly null")
-       }
-       if user.JSON.Name.IsMissing() {
-           fmt.Println("Name field was not present in the response")
-       }
-   }
+Get detailed error information with better debugging utilities:
 
-   // Access extra fields not defined in the struct
-   extraField := user.JSON.ExtraFields["custom_field"].Raw()
-   ```
+```go title="Handling errors with detailed debugging"
+_, err := client.Users.Get(ctx, "dnedry")
+if err != nil {
+    var apiErr *knock.Error
+    if errors.As(err, &apiErr) {
+        fmt.Println(string(apiErr.DumpRequest(true)))  // Print the serialized HTTP request
+        fmt.Println(string(apiErr.DumpResponse(true))) // Print the serialized HTTP response
+    }
+}
+```
 
-## Breaking Changes
+### Request options
 
-1. **Request Parameter Style**:
+Configure requests with flexible per-request options:
 
-   - The new SDK wraps all request parameters with `param.Field` using helpers like `knock.F()` to distinguish between zero values and unset fields
+```go title="Configuring per-request options"
+// Configure per-request options
+client.Users.Get(
+    ctx,
+    "dnedry",
+    option.WithHeader("X-Custom-Header", "custom_value"),
+    option.WithRequestTimeout(20*time.Second),
+)
+```
 
-2. **Method Signatures**:
+### Raw JSON access
 
-   - Most methods now take IDs as positional parameters, followed by a params struct
-   - The new SDK spreads parameters across the method signature for better readability
+Access raw JSON data for advanced use cases:
 
-3. **Type System**:
+```go title="Accessing raw JSON response data"
+user, _ := client.Users.Get(ctx, "jhammond")
 
-   - The new SDK uses a strong type system with special wrapper types
-   - Field values need to be wrapped with `knock.F()` to be included in requests
-   - Union types are used for parameters that can have multiple types
+// Check if a field is null or missing
+if user.Name == "" {
+    if user.JSON.Name.IsNull() {
+        fmt.Println("Name is explicitly null")
+    }
+    if user.JSON.Name.IsMissing() {
+        fmt.Println("Name field was not present in the response")
+    }
+}
 
-4. **Error Handling**:
+// Access extra fields not defined in the struct
+extraField := user.JSON.ExtraFields["custom_field"].Raw()
+```
 
-   - Error types and handling mechanisms have changed significantly
-   - The new SDK provides more detailed error information and better debugging utilities
+## Breaking changes
 
-5. **Pagination**:
-   - The new SDK introduces cursor-based pagination with auto-pagination helpers
+### Request parameter style
 
-## Common Operations
+The new SDK wraps all request parameters with `param.Field` using helpers like `knock.F()` to distinguish between zero values and unset fields.
 
-### Triggering Workflows
+### Method signatures
+
+Most methods now take IDs as positional parameters, followed by a params struct. The new SDK spreads parameters across the method signature for better readability.
+
+### Type system
+
+The new SDK uses a strong type system with special wrapper types. Field values need to be wrapped with `knock.F()` to be included in requests. Union types are used for parameters that can have multiple types.
+
+### Error handling
+
+Error types and handling mechanisms have changed significantly. The new SDK provides more detailed error information and better debugging utilities.
+
+### Pagination
+
+The new SDK introduces cursor-based pagination with auto-pagination helpers.
+
+## Common operations
+
+### Triggering workflows
 
 **Old SDK:**
 
-```go
+```go title="Triggering workflows with the old SDK"
 req := &knock.TriggerWorkflowRequest{
     Workflow: "dinosaurs-loose",
     Data: map[string]interface{}{
@@ -144,7 +159,7 @@ workflow, _ := client.Workflows.Trigger(ctx, req, &knock.MethodOptions{
 
 **New SDK:**
 
-```go
+```go title="Triggering workflows with the new SDK"
 response, err := client.Workflows.Trigger(
     ctx,
     "dinosaurs-loose",
@@ -162,11 +177,11 @@ response, err := client.Workflows.Trigger(
 )
 ```
 
-### Identifying Users
+### Identifying users
 
 **Old SDK:**
 
-```go
+```go title="Identifying users with the old SDK"
 user, _ := client.Users.Identify(ctx, &knock.IdentifyUserRequest{
     ID:   "jhammond",
     Name: "John Hammond",
@@ -178,7 +193,7 @@ user, _ := client.Users.Identify(ctx, &knock.IdentifyUserRequest{
 
 **New SDK:**
 
-```go
+```go title="Identifying users with the new SDK"
 user, err := client.Users.Update(
     ctx,
     "jhammond",
@@ -193,11 +208,11 @@ user, err := client.Users.Update(
 )
 ```
 
-### Working with Objects
+### Working with objects
 
 **Old SDK:**
 
-```go
+```go title="Setting object properties with the old SDK"
 object, _ := client.Objects.Set(ctx, &knock.SetObjectRequest{
     Collection: "dinosaurs",
     ID:         "trex1",
@@ -210,7 +225,7 @@ object, _ := client.Objects.Set(ctx, &knock.SetObjectRequest{
 
 **New SDK:**
 
-```go
+```go title="Setting object properties with the new SDK"
 object, err := client.Objects.Set(
     ctx,
     "dinosaurs",
@@ -224,6 +239,6 @@ object, err := client.Objects.Set(
 )
 ```
 
-## Support
+## Need help?
 
-If you encounter any issues during migration, please [reach out to our support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-go/issues).
+If you run into any issues during your migration, reach out to our [support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-go/issues).

--- a/content/developer-tools/migration-guides/go.mdx
+++ b/content/developer-tools/migration-guides/go.mdx
@@ -15,8 +15,9 @@ import (
     "context"
     "os"
 
-    "github.com/stainless-sdks/knock-go"
-    "github.com/stainless-sdks/knock-go/option"
+    "github.com/knocklabs/knock-go"
+	"github.com/knocklabs/knock-go/option"
+	"github.com/knocklabs/knock-go/shared"
 )
 
 ctx := context.Background()

--- a/content/developer-tools/migration-guides/java.mdx
+++ b/content/developer-tools/migration-guides/java.mdx
@@ -1,14 +1,16 @@
 ---
 title: Java SDK upgrade (v0.x to v1.0)
-description: This guide will help you upgrade from the previous Knock Java SDK to the new v1.0 Java SDK.
+description: Learn how to upgrade to v1.0 of the Knock Java SDK.
 section: Developer tools
 ---
 
-## Basic Changes
+## Basic changes
 
-### Client Initialization
+### Client initialization
 
-```java
+Initialize your client using environment variables or explicit configuration:
+
+```java title="Initializing the Knock client"
 import app.knock.api.client.KnockClient;
 import app.knock.api.client.okhttp.KnockOkHttpClient;
 
@@ -22,119 +24,131 @@ KnockClient client = KnockOkHttpClient.builder()
     .build();
 ```
 
-## New Features in v1.0
+## What's new in v1.0
 
-1. **Asynchronous Execution**: Easily switch to asynchronous operations
+The v1.0 SDK introduces significant improvements for Java developers, including async support, immutable objects, and better error handling.
 
-   ```java
-   // Perform operations asynchronously
-   CompletableFuture<User> userFuture = client.async().users().get(
-       UserGetParams.builder().userId("jhammond").build()
-   );
+### Asynchronous execution
 
-   // Or create an async client from the beginning
-   KnockClientAsync asyncClient = KnockOkHttpClientAsync.fromEnv();
-   ```
+Switch to asynchronous operations when needed:
 
-2. **Immutable Objects**: All objects are immutable for thread safety
+```java title="Using asynchronous client operations"
+// Perform operations asynchronously
+CompletableFuture<User> userFuture = client.async().users().get(
+    UserGetParams.builder().userId("jhammond").build()
+);
 
-   ```java
-   // Each class is immutable once constructed and has a toBuilder() method
-   // for creating modified copies if needed
-   UserUpdateParams params = UserUpdateParams.builder()
-       .userId("jhammond")
-       .name("John Hammond")
-       .build();
+// Or create an async client from the beginning
+KnockClientAsync asyncClient = KnockOkHttpClientAsync.fromEnv();
+```
 
-   // Create a modified copy
-   UserUpdateParams updatedParams = params.toBuilder()
-       .email("john@ingen.com")
-       .build();
-   ```
+### Immutable objects
 
-3. **Pagination Helpers**: Easily work with paginated resources
+All objects are immutable for thread safety:
 
-   ```java
-   // Auto-pagination for iterating through all results
-   UserListPage page = client.users().list(params);
-   for (User user : page.autoPager()) {
-       System.out.println(user);
-   }
+```java title="Working with immutable parameter objects"
+// Each class is immutable once constructed and has a toBuilder() method
+// for creating modified copies if needed
+UserUpdateParams params = UserUpdateParams.builder()
+    .userId("jhammond")
+    .name("John Hammond")
+    .build();
 
-   // Or as a Stream
-   client.users().list(params).autoPager().stream()
-       .limit(50)
-       .forEach(user -> System.out.println(user));
-   ```
+// Create a modified copy
+UserUpdateParams updatedParams = params.toBuilder()
+    .email("john@ingen.com")
+    .build();
+```
 
-4. **Raw Response Access**: Work with raw HTTP responses when needed
+### Pagination helpers
 
-   ```java
-   // Access the raw HTTP response
-   HttpResponseFor<User> userResponse = client.users().withRawResponse().get(
-       UserGetParams.builder().userId("jhammond").build()
-   );
+Work with paginated resources more easily:
 
-   int statusCode = userResponse.statusCode();
-   Headers headers = userResponse.headers();
-   User user = userResponse.parse();
-   ```
+```java title="Auto-pagination through user list"
+// Auto-pagination for iterating through all results
+UserListPage page = client.users().list(params);
+for (User user : page.autoPager()) {
+    System.out.println(user);
+}
 
-5. **Enhanced Error Handling**: Better error types with detailed information
+// Or as a Stream
+client.users().list(params).autoPager().stream()
+    .limit(50)
+    .forEach(user -> System.out.println(user));
+```
 
-   ```java
-   try {
-       client.users().get(UserGetParams.builder().userId("nonexistent").build());
-   } catch (NotFoundException e) {
-       // Handle 404 error
-   } catch (KnockServiceException e) {
-       // Handle other API errors
-   } catch (KnockException e) {
-       // Handle generic errors
-   }
-   ```
+### Raw response access
 
-6. **Additional Properties**: Add undocumented parameters when needed
-   ```java
-   WorkflowTriggerParams params = WorkflowTriggerParams.builder()
-       .putAdditionalHeader("Secret-Header", "42")
-       .putAdditionalQueryParam("secret_query_param", "42")
-       .putAdditionalBodyProperty("secretProperty", JsonValue.from("42"))
-       .build();
-   ```
+Access raw HTTP responses when needed:
 
-## Breaking Changes
+```java title="Accessing raw HTTP response data"
+// Access the raw HTTP response
+HttpResponseFor<User> userResponse = client.users().withRawResponse().get(
+    UserGetParams.builder().userId("jhammond").build()
+);
 
-1. **Request Parameter Style**:
+int statusCode = userResponse.statusCode();
+Headers headers = userResponse.headers();
+User user = userResponse.parse();
+```
 
-   - The new SDK uses builder patterns for all request parameters
-   - Parameters are grouped into structured objects rather than flat lists
+### Enhanced error handling
 
-2. **Method Signatures**:
+Handle errors more efficiently with more detailed error information:
 
-   - Most methods now take parameter objects instead of individual parameters
-   - The new SDK uses a more consistent naming convention across all methods
+```java title="Handling different types of API errors"
+try {
+    client.users().get(UserGetParams.builder().userId("nonexistent").build());
+} catch (NotFoundException e) {
+    // Handle 404 error
+} catch (KnockServiceException e) {
+    // Handle other API errors
+} catch (KnockException e) {
+    // Handle generic errors
+}
+```
 
-3. **Type System**:
+### Additional properties
 
-   - The new SDK uses `JsonValue` and typed fields for better type safety
-   - Field access methods have changed to accommodate the new type system
+Add undocumented parameters when needed:
 
-4. **Error Handling**:
+```java title="Adding custom headers and properties"
+WorkflowTriggerParams params = WorkflowTriggerParams.builder()
+    .putAdditionalHeader("Secret-Header", "42")
+    .putAdditionalQueryParam("secret_query_param", "42")
+    .putAdditionalBodyProperty("secretProperty", JsonValue.from("42"))
+    .build();
+```
 
-   - The new SDK provides more detailed and structured error information
+## Breaking changes
 
-5. **API Key Configuration**:
+### Request parameter style
 
-   - API key is now passed as a bearer token instead of a dedicated API key parameter
+The new SDK uses builder patterns for all request parameters. Parameters are grouped into structured objects rather than flat lists.
 
-## Common Operations
+### Method signatures
 
-### Triggering Workflows
+Most methods now take parameter objects instead of individual parameters. The new SDK uses a more consistent naming convention across all methods.
+
+### Type system
+
+The new SDK uses `JsonValue` and typed fields for better type safety. Field access methods have changed to accommodate the new type system.
+
+### Error handling
+
+The new SDK provides more detailed and structured error information.
+
+### API key configuration
+
+API key is now passed as a bearer token instead of a dedicated API key parameter.
+
+## Common operations
+
+### Triggering workflows
 
 **Old SDK:**
 
-```java
+```java title="Triggering workflows with the old SDK"
 WorkflowTrigger workflowTrigger = WorkflowTrigger.builder()
   .key("dinosaurs-loose")
   .actor("dnedry")
@@ -148,7 +162,7 @@ WorkflowTriggerResult result = client.workflows().trigger(workflowTrigger);
 
 **New SDK:**
 
-```java
+```java title="Triggering workflows with the new SDK"
 import app.knock.api.core.JsonValue;
 import app.knock.api.models.workflows.WorkflowTriggerParams;
 import app.knock.api.models.workflows.WorkflowTriggerResponse;
@@ -166,14 +180,14 @@ WorkflowTriggerParams params = WorkflowTriggerParams.builder()
         .build())
     .build();
 
-WorkflowTriggerResponse response = client.workflows().trigger(params);`
+WorkflowTriggerResponse response = client.workflows().trigger(params);
 ```
 
-### User Preferences
+### User preferences
 
 **Old SDK:**
 
-```java
+```java title="Setting user preferences with the old SDK"
 // Set preference set for user
 PreferenceSetRequest request = PreferenceSetRequest.builder()
     .channelTypes(
@@ -203,7 +217,7 @@ PreferenceSet specificPrefs = client.users().getPreferencesById("jhammond", "oth
 
 **New SDK:**
 
-```java
+```java title="Setting user preferences with the new SDK"
 import app.knock.api.core.JsonValue;
 import app.knock.api.models.recipients.preferences.PreferenceSetRequest;
 import app.knock.api.models.users.UserSetPreferencesParams;
@@ -265,11 +279,11 @@ var specificPrefs = client.users().getPreferences(
 );
 ```
 
-### Identifying Users
+### Identifying users
 
 **Old SDK:**
 
-```java
+```java title="Identifying users with the old SDK"
 UserIdentity userIdentity = UserIdentity.builder()
         .id("jhammond")
         .name("John Hammond")
@@ -282,7 +296,7 @@ client.users().identify(userIdentity);
 
 **New SDK:**
 
-```java
+```java title="Identifying users with the new SDK"
 import app.knock.api.core.JsonValue;
 import app.knock.api.models.users.UserUpdateParams;
 
@@ -296,11 +310,11 @@ client.users().update(
 );
 ```
 
-### Setting Channel Data
+### Setting channel data
 
 **Old SDK:**
 
-```java
+```java title="Setting channel data with the old SDK"
 String channelId = "114a928a-5b35-4e1b-9069-ac873ee972d3";
 ChannelData channelData = client.users().setChannelData(
     "jhammond",
@@ -317,7 +331,7 @@ client.users().unsetUserChannelData("jhammond", channelId);
 
 **New SDK:**
 
-```java
+```java title="Setting channel data with the new SDK"
 import app.knock.api.core.JsonValue;
 import app.knock.api.models.users.UserSetChannelDataParams;
 import app.knock.api.models.users.UserGetChannelDataParams;
@@ -353,6 +367,6 @@ client.users().unsetChannelData(
 );
 ```
 
-## Support
+## Need help?
 
-If you encounter any issues during migration, please [reach out to our support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-java/issues).
+If you run into any issues during your migration, reach out to our [support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-java/issues).

--- a/content/developer-tools/migration-guides/java.mdx
+++ b/content/developer-tools/migration-guides/java.mdx
@@ -144,8 +144,8 @@ API key is now passed as a bearer token instead of a dedicated API key parameter
 
 ## Common operations
 
-### Triggering workflows
-
+<AccordionGroup>
+  <Accordion title="Triggering workflows">
 **Old SDK:**
 
 ```java title="Triggering workflows with the old SDK"
@@ -183,9 +183,40 @@ WorkflowTriggerParams params = WorkflowTriggerParams.builder()
 WorkflowTriggerResponse response = client.workflows().trigger(params);
 ```
 
-### User preferences
+  </Accordion>
+  <Accordion title="Identifying users">
+    **Old SDK:**
 
-**Old SDK:**
+```java title="Identifying users with the old SDK"
+UserIdentity userIdentity = UserIdentity.builder()
+        .id("jhammond")
+        .name("John Hammond")
+        .email("jhammond@ingen.com")
+        .property("expenses_spared", "none")
+        .build();
+
+client.users().identify(userIdentity);
+```
+
+**New SDK:**
+
+```java title="Identifying users with the new SDK"
+import app.knock.api.core.JsonValue;
+import app.knock.api.models.users.UserUpdateParams;
+
+client.users().update(
+    UserUpdateParams.builder()
+        .userId("jhammond")
+        .name("John Hammond")
+        .email("jhammond@ingen.com")
+        .putAdditionalBodyProperty("expenses_spared", JsonValue.from("none"))
+        .build()
+);
+```
+
+  </Accordion>
+  <Accordion title="Working with preferences">
+    **Old SDK:**
 
 ```java title="Setting user preferences with the old SDK"
 // Set preference set for user
@@ -279,40 +310,9 @@ var specificPrefs = client.users().getPreferences(
 );
 ```
 
-### Identifying users
-
-**Old SDK:**
-
-```java title="Identifying users with the old SDK"
-UserIdentity userIdentity = UserIdentity.builder()
-        .id("jhammond")
-        .name("John Hammond")
-        .email("jhammond@ingen.com")
-        .property("expenses_spared", "none")
-        .build();
-
-client.users().identify(userIdentity);
-```
-
-**New SDK:**
-
-```java title="Identifying users with the new SDK"
-import app.knock.api.core.JsonValue;
-import app.knock.api.models.users.UserUpdateParams;
-
-client.users().update(
-    UserUpdateParams.builder()
-        .userId("jhammond")
-        .name("John Hammond")
-        .email("jhammond@ingen.com")
-        .putAdditionalBodyProperty("expenses_spared", JsonValue.from("none"))
-        .build()
-);
-```
-
-### Setting channel data
-
-**Old SDK:**
+  </Accordion>
+  <Accordion title="Setting channel data">
+  **Old SDK:**
 
 ```java title="Setting channel data with the old SDK"
 String channelId = "114a928a-5b35-4e1b-9069-ac873ee972d3";
@@ -366,6 +366,9 @@ client.users().unsetChannelData(
         .build()
 );
 ```
+
+  </Accordion>
+</AccordionGroup>
 
 ## Need help?
 

--- a/content/developer-tools/migration-guides/node.mdx
+++ b/content/developer-tools/migration-guides/node.mdx
@@ -173,9 +173,9 @@ The new SDK returns the data directly in most cases rather than wrapped in a `da
 
 ## Common operations
 
-### Triggering workflows
-
-**Old version:**
+<AccordionGroup>
+  <Accordion title="Triggering workflows">
+  **Old version:**
 
 ```javascript title="Triggering workflows with the old SDK"
 await knockClient.notify("dinosaurs-loose", {
@@ -205,9 +205,9 @@ await client.workflows.trigger("dinosaurs-loose", {
 });
 ```
 
-### Identifying users
-
-**Old version:**
+  </Accordion>
+  <Accordion title="Identifying users">
+  **Old version:**
 
 ```javascript title="Identifying users with the old SDK"
 await client.users.identify("jhammond", {
@@ -224,6 +224,10 @@ await client.users.update("jhammond", {
   email: "jhammond@ingen.net",
 });
 ```
+
+  </Accordion>
+
+</AccordionGroup>
 
 ## Need help?
 

--- a/content/developer-tools/migration-guides/node.mdx
+++ b/content/developer-tools/migration-guides/node.mdx
@@ -107,9 +107,9 @@ await client.audiences.addMembers("audience-id", {
 
 ## Breaking changes
 
-### Method naming
+### Client initialization
 
-The `notify` method is now `workflows.trigger`. Client initialization accepts an options object instead of just the API key.
+[Client initialization](/developer-tools/migration-guides/node#client-initialization) accepts an options object instead of just the API key.
 
 ### Parameter changes
 
@@ -139,10 +139,11 @@ const token = await signUserToken("user-1", {
 });
 ```
 
-### Method naming convention changes
+### Method changes
 
 Several method names have changed:
 
+- `notify()` is now `workflows.trigger()`
 - `users.getSchedules()` is now `users.listSchedules()`
 - `workflows.createSchedules()` is now `schedules.create()`
 - `workflows.listSchedules()` is now `schedules.list()`

--- a/content/developer-tools/migration-guides/node.mdx
+++ b/content/developer-tools/migration-guides/node.mdx
@@ -88,7 +88,7 @@ const client = new Knock({
 
 1. The `notify` method is now `workflows.trigger`
 2. Client initialization accepts an options object instead of just the API key
-3. Some parameter names have changed to match the API (e.g., `cancellationKey` → `cancellation_key`)
+3. Some parameter names have changed to match the API (e.g., `cancellationKey` is now `cancellation_key`)
 4. Error handling has been completely revamped with typed errors
 5. The `signUserToken` method should now be imported from `@knocklabs/node/lib/tokenSigner` if referenced directly.
 

--- a/content/developer-tools/migration-guides/node.mdx
+++ b/content/developer-tools/migration-guides/node.mdx
@@ -1,150 +1,183 @@
 ---
 title: Node.js SDK upgrade (v0.x to v1.0)
-description: This guide will help you upgrade your existing Knock Node.js SDK to the 1.0 release.
+description: Learn how to upgrade to v1.0 of the Knock Node.js SDK.
 section: Developer tools
 ---
 
-## Basic Changes
+## Basic changes
 
-### Import Style
+### Import style
 
-```javascript
+Import the SDK using the standard ES6 import syntax:
+
+```javascript title="Importing the Knock SDK"
 import Knock from "@knocklabs/node";
 ```
 
-### Client Initialization
+### Client initialization
 
-```javascript
+Initialize your client with an options object:
+
+```javascript title="Initializing the Knock client"
 const client = new Knock({
   apiKey: process.env["KNOCK_API_KEY"], // This is the default and can be omitted
 });
 ```
 
-## New Features in v1.0
+## What's new in v1.0
 
-1. **Fully Typed API**: Complete TypeScript definitions for all requests and responses
+The v1.0 SDK brings complete TypeScript support, improved error handling, and new resources to the Node.js ecosystem.
 
-   ```typescript
-   const user: Knock.User = await client.users.get("dnedry");
-   ```
+### Fully typed API
 
-2. **Enhanced Error Handling**: Typed errors with better context
+Complete TypeScript definitions for all requests and responses:
 
-   ```typescript
-   try {
-     await client.users.get("dnedry");
-   } catch (err) {
-     if (err instanceof Knock.APIError) {
-       console.log(err.status, err.name, err.headers);
-     }
-   }
-   ```
+```typescript title="Using TypeScript definitions"
+const user: Knock.User = await client.users.get("dnedry");
+```
 
-3. **Auto-pagination**: Easily iterate through paginated resources
+### Enhanced error handling
 
-   ```typescript
-   // Automatically fetches all pages
-   const allUsers = [];
-   for await (const user of client.users.list()) {
-     allUsers.push(user);
-   }
-   ```
+Typed errors with better context:
 
-4. **Request/Response Access**: More control over raw responses
+```typescript title="Handling API errors with types"
+try {
+  await client.users.get("dnedry");
+} catch (err) {
+  if (err instanceof Knock.APIError) {
+    console.log(err.status, err.name, err.headers);
+  }
+}
+```
 
-   ```typescript
-   const { data: user, response } = await client.users
-     .get("dnedry")
-     .withResponse();
-   console.log(response.headers.get("X-My-Header"));
-   ```
+### Auto-pagination
 
-5. **Configurable Logging**: Better debugging capabilities
+Iterate through paginated resources automatically:
 
-   ```typescript
-   const client = new Knock({
-     logLevel: "debug", // Show all log messages
-   });
-   ```
+```typescript title="Auto-pagination through user list"
+// Automatically fetches all pages
+const allUsers = [];
+for await (const user of client.users.list()) {
+  allUsers.push(user);
+}
+```
 
-6. **Configurable Timeouts and Retries**: Fine-tune request behavior
+### Request/response access
 
-   ```typescript
-   const client = new Knock({
-     timeout: 20 * 1000, // 20 seconds
-     maxRetries: 3,
-   });
-   ```
+Get more control over raw responses:
 
-7. **New Resources**: Additional resources like Audiences, Channels, and Integrations
-   ```typescript
-   // Working with audiences
-   await client.audiences.addMembers("audience-id", {
-     members: ["user-1", "user-2"],
-   });
-   ```
+```typescript title="Accessing raw response data"
+const { data: user, response } = await client.users
+  .get("dnedry")
+  .withResponse();
+console.log(response.headers.get("X-My-Header"));
+```
 
-## Breaking Changes
+### Configurable logging
 
-1. The `notify` method is now `workflows.trigger`
-2. Client initialization accepts an options object instead of just the API key
-3. Some parameter names have changed to match the API (e.g., `cancellationKey` is now `cancellation_key`)
-4. Error handling has been completely revamped with typed errors
-5. The `signUserToken` method should now be imported from `@knocklabs/node/lib/tokenSigner` if referenced directly.
+Better debugging capabilities:
 
-   ```javascript
-   import {
-     signUserToken,
-     buildUserTokenGrant,
-     Grants,
-   } from "@knocklabs/node/lib/tokenSigner";
+```typescript title="Configuring client logging"
+const client = new Knock({
+  logLevel: "debug", // Show all log messages
+});
+```
 
-   const token = await signUserToken("user-1", {
-     grants: [
-       buildUserTokenGrant({ type: "tenant", id: "org_3sh72ds78" }, [
-         Grants.MsTeamsChannelsRead,
-       ]),
-     ],
-   });
-   ```
+### Configurable timeouts and retries
 
-6. Method naming convention changes:
+Fine-tune request behavior:
 
-   - `users.getPreferences()` now requires a preference set ID parameter
-   - `users.bulkIdentify()` is now `users.bulk.identify()`
-   - `users.bulkDelete()` is now `users.bulk.delete()`
-   - `users.bulkSetPreferences()` is now `users.bulk.setPreferences()`
-   - `users.getSchedules()` is now `users.listSchedules()`
-   - `workflows.createSchedules()` is now `schedules.create()`
-   - `workflows.listSchedules()` is now `schedules.list()`
-   - `workflows.updateSchedules()` is now `schedules.update()`
-   - `workflows.deleteSchedules()` is now `schedules.delete()`
-   - Bulk schedule updates are available via `schedules.bulk.create()`
+```typescript title="Configuring timeouts and retries"
+const client = new Knock({
+  timeout: 20 * 1000, // 20 seconds
+  maxRetries: 3,
+});
+```
 
-7. Parameter style changes:
+### New resources
 
-   - All parameters are now in camelCase in the method signature but use snake_case in the request body
-   - Query parameters are now passed as a separate object in most list methods
+Additional resources like Audiences, Channels, and Integrations:
 
-   ```javascript
-   // Old SDK
-   await knockClient.users.list({ page: 2, pageSize: 50 });
+```typescript title="Working with audience resources"
+// Working with audiences
+await client.audiences.addMembers("audience-id", {
+  members: ["user-1", "user-2"],
+});
+```
 
-   // New SDK
-   await client.users.list({ page: 2, page_size: 50 });
-   ```
+## Breaking changes
 
-8. Response handling:
-   - The new SDK returns the data directly in most cases rather than wrapped in a `data` property
-   - Pagination is handled differently with cursor-based pagination
+### Method naming
 
-## Common Operations
+The `notify` method is now `workflows.trigger`. Client initialization accepts an options object instead of just the API key.
 
-### Triggering Workflows
+### Parameter changes
+
+Some parameter names have changed to match the API (e.g., `cancellationKey` is now `cancellation_key`).
+
+### Error handling
+
+Error handling has been completely revamped with typed errors.
+
+### Token signing
+
+The `signUserToken` method should now be imported from `@knocklabs/node/lib/tokenSigner` if referenced directly:
+
+```javascript title="Importing token signing utilities"
+import {
+  signUserToken,
+  buildUserTokenGrant,
+  Grants,
+} from "@knocklabs/node/lib/tokenSigner";
+
+const token = await signUserToken("user-1", {
+  grants: [
+    buildUserTokenGrant({ type: "tenant", id: "org_3sh72ds78" }, [
+      Grants.MsTeamsChannelsRead,
+    ]),
+  ],
+});
+```
+
+### Method naming convention changes
+
+Several method names have changed:
+
+- `users.getSchedules()` is now `users.listSchedules()`
+- `workflows.createSchedules()` is now `schedules.create()`
+- `workflows.listSchedules()` is now `schedules.list()`
+- `workflows.updateSchedules()` is now `schedules.update()`
+- `workflows.deleteSchedules()` is now `schedules.delete()`
+
+### Bulk operations
+
+Bulk operations are now organized in their own namespaces: `users.bulk.*`, `objects.bulk.*`, `schedules.bulk.*`, etc.
+
+### Parameter changes
+
+A `PreferenceSet` ID parameter is now required for `users.getPreferences()`.
+
+All parameters are now in camelCase in the method signature but use snake_case in the request body. Query parameters are now passed as a separate object in most list methods:
+
+```javascript title="Parameter style comparison"
+// Old SDK
+await knockClient.users.list({ page: 2, pageSize: 50 });
+
+// New SDK
+await client.users.list({ page: 2, page_size: 50 });
+```
+
+### Response handling
+
+The new SDK returns the data directly in most cases rather than wrapped in a `data` property. Pagination is handled differently with cursor-based pagination.
+
+## Common operations
+
+### Triggering workflows
 
 **Old version:**
 
-```javascript
+```javascript title="Triggering workflows with the old SDK"
 await knockClient.notify("dinosaurs-loose", {
   actor: "dnedry",
   recipients: ["jhammond", "agrant"],
@@ -157,9 +190,9 @@ await knockClient.notify("dinosaurs-loose", {
 });
 ```
 
-**1.x release:**
+**New version:**
 
-```javascript
+```javascript title="Triggering workflows with the new SDK"
 await client.workflows.trigger("dinosaurs-loose", {
   actor: "dnedry",
   recipients: ["jhammond", "agrant"],
@@ -172,26 +205,26 @@ await client.workflows.trigger("dinosaurs-loose", {
 });
 ```
 
-### Identifying Users
+### Identifying users
 
 **Old version:**
 
-```javascript
+```javascript title="Identifying users with the old SDK"
 await client.users.identify("jhammond", {
   name: "John Hammond",
   email: "jhammond@ingen.net",
 });
 ```
 
-**1.x release:**
+**New version:**
 
-```javascript
+```javascript title="Identifying users with the new SDK"
 await client.users.update("jhammond", {
   name: "John Hammond",
   email: "jhammond@ingen.net",
 });
 ```
 
-## Support
+## Need help?
 
-If you encounter any issues during migration, please [reach out to our support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-node/issues).
+If you run into any issues during your migration, reach out to our [support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-node/issues).

--- a/content/developer-tools/migration-guides/python.mdx
+++ b/content/developer-tools/migration-guides/python.mdx
@@ -1,135 +1,149 @@
 ---
 title: Python SDK upgrade (v0.x to v1.0)
-description: This guide will help you upgrade from the previous Knock Python SDK to the new v1.0 Python SDK.
+description: Learn how to upgrade to v1.0 of the Knock Python SDK.
 section: Developer tools
 ---
 
-## Basic Changes
+## Basic changes
 
-### Client Initialization
+### Client initialization
 
-```python
+Initialize your client with the API key:
+
+```python title="Initializing the Knock client"
 from knockapi import Knock
 
 client = Knock(api_key="sk_12345")  # defaults to ENV["KNOCK_API_KEY"]
 ```
 
-## New Features in v1.0
+## What's new in v1.0
 
-1. **Async Support**: First-class async/await support
+The v1.0 SDK introduces async support, strong type checking, and improved developer experience for Python applications.
 
-   ```python
-   from knockapi import AsyncKnock
+### Async support
 
-   client = AsyncKnock(api_key="sk_12345")
+First-class async/await support:
 
-   async def main():
-       response = await client.workflows.trigger(
-           key="dinosaurs-loose",
-           recipients=["dnedry"],
-           data={"dinosaur": "triceratops"},
-       )
-       print(response.workflow_run_id)
-   ```
+```python title="Using the async client"
+from knockapi import AsyncKnock
 
-2. **Strong Type Checking**: Improved type hints with TypedDict and Pydantic models
+client = AsyncKnock(api_key="sk_12345")
 
-   ```python
-   # With type checking enabled, you get IDE support and validation
-   from knockapi.types import User
+async def main():
+    response = await client.workflows.trigger(
+        key="dinosaurs-loose",
+        recipients=["dnedry"],
+        data={"dinosaur": "triceratops"},
+    )
+    print(response.workflow_run_id)
+```
 
-   user: User = client.users.get("dnedry")
-   ```
+### Strong type checking
 
-3. **Auto-pagination**: Easily iterate through paginated resources
+Improved type hints with TypedDict and Pydantic models:
 
-   ```python
-   # Automatically fetches more pages as needed
-   all_users = []
-   for user in client.users.list():
-       all_users.append(user)
+```python title="Using type hints for better IDE support"
+# With type checking enabled, you get IDE support and validation
+from knockapi.types import User
 
-   # Or asynchronously
-   async for user in async_client.users.list():
-       process_user(user)
-   ```
+user: User = client.users.get("dnedry")
+```
 
-4. **Enhanced Error Handling**: More specific error classes
+### Auto-pagination
 
-   ```python
-   import knockapi
+Iterate through paginated resources automatically:
 
-   try:
-       client.users.get("dnedry")
-   except knockapi.APIConnectionError as e:
-       print("The server could not be reached")
-   except knockapi.RateLimitError as e:
-       print("A 429 status code was received; we should back off")
-   except knockapi.APIStatusError as e:
-       print("Status code:", e.status_code)
-   ```
+```python title="Auto-pagination through user list"
+# Automatically fetches more pages as needed
+all_users = []
+for user in client.users.list():
+    all_users.append(user)
 
-5. **Configurable Timeouts and Retries**: Fine-tune request behavior
+# Or asynchronously
+async for user in async_client.users.list():
+    process_user(user)
+```
 
-   ```python
-   # Configure the default for all requests:
-   client = Knock(
-       timeout=20.0,  # 20 seconds (default is 60)
-       max_retries=3  # default is 2
-   )
+### Enhanced error handling
 
-   # Or, configure per-request:
-   client.with_options(max_retries=5).users.get("dnedry")
-   ```
+More specific error classes:
 
-6. **Access to Raw Response Data**: More control over HTTP interactions
-   ```python
-   # Get raw response data including headers
-   response = client.with_raw_response.users.get("dnedry")
-   print(response.headers.get("X-Request-ID"))
-   ```
+```python title="Handling different types of API errors"
+import knockapi
 
-## Breaking Changes
+try:
+    client.users.get("dnedry")
+except knockapi.APIConnectionError as e:
+    print("The server could not be reached")
+except knockapi.RateLimitError as e:
+    print("A 429 status code was received; we should back off")
+except knockapi.APIStatusError as e:
+    print("Status code:", e.status_code)
+```
 
-1. **Client Design**: The new SDK has a cleaner interface with direct method calls
+### Configurable timeouts and retries
 
-   - The old approach of passing all parameters as keyword arguments is replaced with specific method signatures
-   - Parameters that were previously named keyword arguments may now be positional arguments
+Fine-tune request behavior:
 
-2. **Method Naming Changes**:
+```python title="Configuring timeouts and retries"
+# Configure the default for all requests:
+client = Knock(
+    timeout=20.0,  # 20 seconds (default is 60)
+    max_retries=3  # default is 2
+)
 
-   - `client.users.identify()` is now `client.users.update()`
-   - `client.users.get_user()` is now `client.users.get()`
-   - Client-level `.notify()` shorthand is removed, use `client.workflows.trigger()` instead
-   - `client.users.getSchedules()` is now `client.users.listSchedules()`
-   - `client.workflows.createSchedules()` is now `client.schedules.create()`
-   - `client.workflows.listSchedules()` is now `client.schedules.list()`
-   - `client.workflows.updateSchedules()` is now `client.schedules.update()`
-   - `client.workflows.deleteSchedules()` is now `client.schedules.delete()`
+# Or, configure per-request:
+client.with_options(max_retries=5).users.get("dnedry")
+```
 
-3. **Method Parameters**: Parameters are now passed differently
+### Access to raw response data
 
-   - Most methods now take the ID(s) as positional parameter(s), followed by named parameters
-   - The `data` wrapper is removed for user properties (they're now top-level parameters)
-   - Parameter names have changed in some cases (e.g., `id` is now `user_id`)
-   - Preference methods require an explicit preference set ID parameter
+Get more control over HTTP interactions:
 
-4. **Response Types**:
+```python title="Accessing raw response data"
+# Get raw response data including headers
+response = client.with_raw_response.users.get("dnedry")
+print(response.headers.get("X-Request-ID"))
+```
 
-   - The new SDK returns typed Pydantic model instances instead of dictionaries
-   - Use `.model_dump()` to get a dictionary representation of a response object
-   - Pagination is handled via cursor-based pagination instead of page-based
+## Breaking changes
 
-5. **Bulk Operations**:
-   - Bulk operations are now organized in their own namespaces: `client.users.bulk.*`, `client.objects.bulk.*`, `client.schedules.bulk.*`, etc.
+### Client design
 
-## Common Operations
+The new SDK has a cleaner interface with direct method calls. The old approach of passing all parameters as keyword arguments is replaced with specific method signatures. Parameters that were previously named keyword arguments may now be positional arguments.
 
-### Triggering Workflows
+### Method naming changes
+
+Several method names have changed:
+
+- `client.users.identify()` is now `client.users.update()`
+- `client.users.get_user()` is now `client.users.get()`
+- Client-level `.notify()` shorthand is removed, use `client.workflows.trigger()` instead
+- `client.users.getSchedules()` is now `client.users.listSchedules()`
+- `client.workflows.createSchedules()` is now `client.schedules.create()`
+- `client.workflows.listSchedules()` is now `client.schedules.list()`
+- `client.workflows.updateSchedules()` is now `client.schedules.update()`
+- `client.workflows.deleteSchedules()` is now `client.schedules.delete()`
+
+### Bulk operations
+
+Bulk operations are now organized in their own namespaces: `client.users.bulk.*`, `client.objects.bulk.*`, `client.schedules.bulk.*`, etc.
+
+### Method parameters
+
+Most methods now take the ID(s) as positional parameter(s), followed by named parameters. The `data` wrapper is removed for user properties (they're now top-level parameters). Parameter names have changed in some cases (e.g., `id` is now `user_id`). Preference methods require an explicit preference set ID parameter.
+
+### Response types
+
+The new SDK returns typed Pydantic model instances instead of dictionaries. Use `.model_dump()` to get a dictionary representation of a response object. Pagination is handled via cursor-based pagination instead of page-based.
+
+## Common operations
+
+### Triggering workflows
 
 **Old SDK:**
 
-```python
+```python title="Triggering workflows with the old SDK"
 client.notify(
   key="dinosaurs-loose",
   actor="dnedry",
@@ -145,7 +159,7 @@ client.notify(
 
 **New SDK:**
 
-```python
+```python title="Triggering workflows with the new SDK"
 client.workflows.trigger(
   key="dinosaurs-loose",
   recipients=["jhammond", "agrant"],
@@ -159,11 +173,11 @@ client.workflows.trigger(
 )
 ```
 
-### Identifying Users
+### Identifying users
 
 **Old SDK:**
 
-```python
+```python title="Identifying users with the old SDK"
 client.users.identify(
   id="jhammond",
   data={
@@ -175,7 +189,7 @@ client.users.identify(
 
 **New SDK:**
 
-```python
+```python title="Identifying users with the new SDK"
 client.users.update(
   user_id="jhammond",
   name="John Hammond",
@@ -183,11 +197,11 @@ client.users.update(
 )
 ```
 
-### Working with Preferences
+### Working with preferences
 
 **Old SDK:**
 
-```python
+```python title="Setting user preferences with the old SDK"
 client.users.set_preferences(
   user_id="jhammond",
   channel_types={'email': True},
@@ -197,7 +211,7 @@ client.users.set_preferences(
 
 **New SDK:**
 
-```python
+```python title="Setting user preferences with the new SDK"
 client.users.set_preferences(
   user_id="jhammond",
   id="default",
@@ -206,11 +220,11 @@ client.users.set_preferences(
 )
 ```
 
-### Working with Objects
+### Working with objects
 
 **Old SDK:**
 
-```python
+```python title="Setting object properties with the old SDK"
 client.objects.set(
   collection="dinosaurs",
   id="trex1",
@@ -223,7 +237,7 @@ client.objects.set(
 
 **New SDK:**
 
-```python
+```python title="Setting object properties with the new SDK"
 client.objects.set(
   collection="dinosaurs",
   id="trex1",
@@ -232,6 +246,6 @@ client.objects.set(
 )
 ```
 
-## Support
+## Need help?
 
-If you encounter any issues during migration, please [reach out to our support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-python/issues).
+If you run into any issues during your migration, reach out to our [support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-python/issues).

--- a/content/developer-tools/migration-guides/python.mdx
+++ b/content/developer-tools/migration-guides/python.mdx
@@ -98,8 +98,8 @@ client = Knock(api_key="sk_12345")  # defaults to ENV["KNOCK_API_KEY"]
 
 2. **Method Naming Changes**:
 
-   - `client.users.identify()` → `client.users.update()`
-   - `client.users.get_user()` → `client.users.get()`
+   - `client.users.identify()` is now `client.users.update()`
+   - `client.users.get_user()` is now `client.users.get()`
    - Client-level `.notify()` shorthand is removed, use `client.workflows.trigger()` instead
    - `client.users.getSchedules()` is now `client.users.listSchedules()`
    - `client.workflows.createSchedules()` is now `client.schedules.create()`
@@ -112,7 +112,7 @@ client = Knock(api_key="sk_12345")  # defaults to ENV["KNOCK_API_KEY"]
 
    - Most methods now take the ID(s) as positional parameter(s), followed by named parameters
    - The `data` wrapper is removed for user properties (they're now top-level parameters)
-   - Parameter names have changed in some cases (e.g., `id` → `user_id`)
+   - Parameter names have changed in some cases (e.g., `id` is now `user_id`)
    - Preference methods require an explicit preference set ID parameter
 
 4. **Response Types**:

--- a/content/developer-tools/migration-guides/python.mdx
+++ b/content/developer-tools/migration-guides/python.mdx
@@ -139,9 +139,9 @@ The new SDK returns typed Pydantic model instances instead of dictionaries. Use 
 
 ## Common operations
 
-### Triggering workflows
-
-**Old SDK:**
+<AccordionGroup>
+  <Accordion title="Triggering workflows">
+  **Old SDK:**
 
 ```python title="Triggering workflows with the old SDK"
 client.notify(
@@ -173,9 +173,9 @@ client.workflows.trigger(
 )
 ```
 
-### Identifying users
-
-**Old SDK:**
+  </Accordion>
+  <Accordion title="Identifying users">
+  **Old SDK:**
 
 ```python title="Identifying users with the old SDK"
 client.users.identify(
@@ -197,9 +197,9 @@ client.users.update(
 )
 ```
 
-### Working with preferences
-
-**Old SDK:**
+  </Accordion>
+  <Accordion title="Working with preferences">
+    **Old SDK:**
 
 ```python title="Setting user preferences with the old SDK"
 client.users.set_preferences(
@@ -220,9 +220,9 @@ client.users.set_preferences(
 )
 ```
 
-### Working with objects
-
-**Old SDK:**
+  </Accordion>
+  <Accordion title="Working with objects">
+    **Old SDK:**
 
 ```python title="Setting object properties with the old SDK"
 client.objects.set(
@@ -245,6 +245,9 @@ client.objects.set(
   species="Tyrannosaurus rex"
 )
 ```
+
+  </Accordion>
+</AccordionGroup>
 
 ## Need help?
 

--- a/content/developer-tools/migration-guides/python.mdx
+++ b/content/developer-tools/migration-guides/python.mdx
@@ -106,7 +106,6 @@ client = Knock(api_key="sk_12345")  # defaults to ENV["KNOCK_API_KEY"]
    - `client.workflows.listSchedules()` is now `client.schedules.list()`
    - `client.workflows.updateSchedules()` is now `client.schedules.update()`
    - `client.workflows.deleteSchedules()` is now `client.schedules.delete()`
-   - Bulk schedule updates are available via `client.schedules.bulk.create()`
 
 3. **Method Parameters**: Parameters are now passed differently
 
@@ -122,7 +121,7 @@ client = Knock(api_key="sk_12345")  # defaults to ENV["KNOCK_API_KEY"]
    - Pagination is handled via cursor-based pagination instead of page-based
 
 5. **Bulk Operations**:
-   - Bulk operations are now organized in their own namespaces: `client.users.bulk.*`, `client.objects.bulk.*`
+   - Bulk operations are now organized in their own namespaces: `client.users.bulk.*`, `client.objects.bulk.*`, `client.schedules.bulk.*`, etc.
 
 ## Common Operations
 

--- a/content/developer-tools/migration-guides/ruby.mdx
+++ b/content/developer-tools/migration-guides/ruby.mdx
@@ -119,91 +119,96 @@ The new SDK returns model instances rather than raw hashes. Pagination is handle
 
 ## Common operations
 
-### Triggering workflows
+<AccordionGroup>
+  <Accordion title="Triggering workflows">
 
-**Old SDK:**
+    **Old SDK:**
 
-```ruby title="Triggering workflows with the old SDK"
-Knock::Workflows.trigger(
-  key: "dinosaurs-loose",
-  actor: "dnedry",
-  recipients: ["jhammond", "agrant"],
-  data: {
-    type: "trex",
-    priority: 1,
-  },
-  cancellation_key: trigger_alert.id,
-)
-```
+    ```ruby title="Triggering workflows with the old SDK"
+    Knock::Workflows.trigger(
+      key: "dinosaurs-loose",
+      actor: "dnedry",
+      recipients: ["jhammond", "agrant"],
+      data: {
+        type: "trex",
+        priority: 1,
+      },
+      cancellation_key: trigger_alert.id,
+    )
+    ```
 
-**New SDK:**
+    **New SDK:**
 
-```ruby title="Triggering workflows with the new SDK"
-knock.workflows.trigger(
-  "dinosaurs-loose",
-  recipients: ["jhammond", "agrant"],
-  actor: "dnedry",
-  data: {
-    type: "trex",
-    priority: 1,
-  },
-  cancellation_key: trigger_alert.id,
-)
-```
+    ```ruby title="Triggering workflows with the new SDK"
+    knock.workflows.trigger(
+      "dinosaurs-loose",
+      recipients: ["jhammond", "agrant"],
+      actor: "dnedry",
+      data: {
+        type: "trex",
+        priority: 1,
+      },
+      cancellation_key: trigger_alert.id,
+    )
+    ```
 
-### Identifying users
+  </Accordion>
 
-**Old SDK:**
+  <Accordion title="Identifying users">
+    **Old SDK:**
 
-```ruby title="Identifying users with the old SDK"
-Knock::Users.identify(
-  id: "jhammond",
-  data: {
-    name: "John Hammond",
-    email: "jhammond@ingen.net",
-  }
-)
-```
+    ```ruby title="Identifying users with the old SDK"
+    Knock::Users.identify(
+      id: "jhammond",
+      data: {
+        name: "John Hammond",
+        email: "jhammond@ingen.net",
+      }
+    )
+    ```
 
-**New SDK:**
+    **New SDK:**
 
-```ruby title="Identifying users with the new SDK"
-knock.users.update(
-  "jhammond",
-  name: "John Hammond",
-  email: "jhammond@ingen.net"
-)
-```
+    ```ruby title="Identifying users with the new SDK"
+    knock.users.update(
+      "jhammond",
+      name: "John Hammond",
+      email: "jhammond@ingen.net"
+    )
+    ```
 
-### Working with preferences
+  </Accordion>
+  <Accordion title="Working with preferences">
+    **Old SDK:**
 
-**Old SDK:**
+    ```ruby title="Setting user preferences with the old SDK"
+    Knock::Users.set_preferences(
+      user_id: "jhammond",
+      channel_types: { email: true, sms: false },
+      workflows: {
+        'dinosaurs-loose': {
+          channel_types: { email: false, in_app_feed: false }
+        }
+      }
+    )
+    ```
 
-```ruby title="Setting user preferences with the old SDK"
-Knock::Users.set_preferences(
-  user_id: "jhammond",
-  channel_types: { email: true, sms: false },
-  workflows: {
-    'dinosaurs-loose': {
-      channel_types: { email: false, in_app_feed: false }
-    }
-  }
-)
-```
+    **New SDK:**
 
-**New SDK:**
+    ```ruby title="Setting user preferences with the new SDK"
+    knock.recipients.preferences.set(
+      "users", "jhammond", "default",
+      channel_types: { email: true, sms: false },
+      workflows: {
+        'dinosaurs-loose': {
+          channel_types: { email: false, in_app_feed: false }
+        }
+      }
+    )
+    ```
 
-```ruby title="Setting user preferences with the new SDK"
-knock.recipients.preferences.set(
-  "users", "jhammond", "default",
-  channel_types: { email: true, sms: false },
-  workflows: {
-    'dinosaurs-loose': {
-      channel_types: { email: false, in_app_feed: false }
-    }
-  }
-)
-```
+  </Accordion>
+</AccordionGroup>
 
 ## Need help?
 

--- a/content/developer-tools/migration-guides/ruby.mdx
+++ b/content/developer-tools/migration-guides/ruby.mdx
@@ -75,7 +75,7 @@ knock = Knockapi::Client.new(
 2. **Method Naming and Organization**:
 
    - The main module is now `Knockapi` instead of `Knock`
-   - Bulk operations are now organized in their own namespaces: `knock.users.bulk.*`, `knock.objects.bulk.*`
+   - Bulk operations are now organized in their own namespaces: `knock.users.bulk.*`, `knock.objects.bulk.*`, `knock.schedules.bulk.*`, etc.
    - `Knock::Users.identify()` is now `knock.users.update()`
    - `Knock::Users.set_preferences()` is now `knock.recipients.preferences.set()`
    - `Knock::Users.get_channel_data()` is now `knock.recipients.channel_data.get()`
@@ -84,7 +84,6 @@ knock = Knockapi::Client.new(
    - `Knock::Workflows.listSchedules()` is now `knock.schedules.list()`
    - `Knock::Workflows.updateSchedules()` is now `knock.schedules.update()`
    - `Knock::Workflows.deleteSchedules()` is now `knock.schedules.delete()`
-   - Bulk schedule updates are available via `knock.schedules.bulk.create()`
 
 3. **Method Parameters**: Parameters are now passed differently
 

--- a/content/developer-tools/migration-guides/ruby.mdx
+++ b/content/developer-tools/migration-guides/ruby.mdx
@@ -76,9 +76,9 @@ knock = Knockapi::Client.new(
 
    - The main module is now `Knockapi` instead of `Knock`
    - Bulk operations are now organized in their own namespaces: `knock.users.bulk.*`, `knock.objects.bulk.*`
-   - `Knock::Users.identify()` → `knock.users.update()`
-   - `Knock::Users.set_preferences()` → `knock.recipients.preferences.set()`
-   - `Knock::Users.get_channel_data()` → `knock.recipients.channel_data.get()`
+   - `Knock::Users.identify()` is now `knock.users.update()`
+   - `Knock::Users.set_preferences()` is now `knock.recipients.preferences.set()`
+   - `Knock::Users.get_channel_data()` is now `knock.recipients.channel_data.get()`
    - `Knock::Users.getSchedules()` is now `knock.users.listSchedules()`
    - `Knock::Workflows.createSchedules()` is now `knock.schedules.create()`
    - `Knock::Workflows.listSchedules()` is now `knock.schedules.list()`
@@ -89,7 +89,7 @@ knock = Knockapi::Client.new(
 3. **Method Parameters**: Parameters are now passed differently
 
    - Most methods now take the ID(s) as positional parameter(s), followed by named parameters
-   - Resource IDs moved from named parameters to positional parameters (e.g., `id: "user-1"` → `"user-1"`)
+   - Resource IDs moved from named parameters to positional parameters (e.g., `id: "user-1"` is now `"user-1"`)
    - `data:` parameters have been flattened in most methods
 
 4. **Preference Management**:

--- a/content/developer-tools/migration-guides/ruby.mdx
+++ b/content/developer-tools/migration-guides/ruby.mdx
@@ -1,14 +1,16 @@
 ---
 title: Ruby SDK upgrade (v0.x to v1.0)
-description: This guide will help you upgrade from the previous Knock Ruby SDK to the new v1.0 Ruby SDK.
+description: Learn how to upgrade to v1.0 of the Knock Ruby SDK.
 section: Developer tools
 ---
 
-## Basic Changes
+## Basic changes
 
-### Client Initialization
+### Client initialization
 
-```ruby
+Initialize a client instance with your API key:
+
+```ruby title="Initializing the Knock client"
 require "knockapi"
 
 # Initialize a client instance
@@ -17,96 +19,111 @@ knock = Knockapi::Client.new(
 )
 ```
 
-## New Features in v1.0
+## What's new in v1.0
 
-1. **Strong Typing with Sorbet**: Improved type definitions for better IDE integration
+The v1.0 SDK brings strong typing with Sorbet, auto-pagination, and enhanced error handling to the Ruby ecosystem.
 
-2. **Auto-pagination**: Easily iterate through paginated resources
+### Strong typing with Sorbet
 
-   ```ruby
-   # Automatically fetches more pages as needed.
-   page = knock.users.list
-   page.auto_paging_each do |user|
-     puts user.id
-   end
-   ```
+Improved type definitions for better IDE integration.
 
-3. **Enhanced Error Handling**: More specific error classes
+### Auto-pagination
 
-   ```ruby
-   begin
-     user = knock.users.get("dnedry")
-   rescue Knockapi::Errors::APIError => e
-     puts e.status # 400
-   end
-   ```
+Iterate through paginated resources automatically:
 
-4. **Configurable Timeouts and Retries**: Fine-tune request behavior
+```ruby title="Auto-pagination through user list"
+# Automatically fetches more pages as needed.
+page = knock.users.list
+page.auto_paging_each do |user|
+  puts user.id
+end
+```
 
-   ```ruby
-   knock = Knockapi::Client.new(
-     timeout: 20, # 20 seconds (default is 60)
-     max_retries: 3 # default is 2
-   )
-   ```
+### Enhanced error handling
 
-5. **New Resources**: Additional resources like Audiences, Channels, and Integrations
+Handle errors more effectively with improved error classes:
 
-   ```ruby
-   # Working with audiences
-   knock.audiences.add_members(
-     "audience-id",
-     members: ["user-1", "user-2"]
-   )
-   ```
+```ruby title="Handling API errors with specific classes"
+begin
+  user = knock.users.get("dnedry")
+rescue Knockapi::Errors::APIError => e
+  puts e.status # 400
+end
+```
 
-6. **Request Options**: More control over individual requests
-   ```ruby
-   knock.users.get("dnedry", request_options: { timeout: 5 })
-   ```
+### Configurable timeouts and retries
 
-## Breaking Changes
+Fine-tune request behavior by customizing timeouts and retry limits:
 
-1. **Client Design**: The new SDK uses an instance-based client rather than module functions
+```ruby title="Configuring timeouts and retries"
+knock = Knockapi::Client.new(
+  timeout: 20, # 20 seconds (default is 60)
+  max_retries: 3 # default is 2
+)
+```
 
-   - Create a client instance with `knock = Knockapi::Client.new()`
-   - Call methods via the client: `knock.workflows.trigger()` instead of `Knock::Workflows.trigger()`
+### New resources
 
-2. **Method Naming and Organization**:
+Work with additional resources like [Audiences](/concepts/audiences), [Channels](http://localhost:3002/concepts/channels), and [Integrations](/integrations/sources/overview):
 
-   - The main module is now `Knockapi` instead of `Knock`
-   - Bulk operations are now organized in their own namespaces: `knock.users.bulk.*`, `knock.objects.bulk.*`, `knock.schedules.bulk.*`, etc.
-   - `Knock::Users.identify()` is now `knock.users.update()`
-   - `Knock::Users.set_preferences()` is now `knock.recipients.preferences.set()`
-   - `Knock::Users.get_channel_data()` is now `knock.recipients.channel_data.get()`
-   - `Knock::Users.getSchedules()` is now `knock.users.listSchedules()`
-   - `Knock::Workflows.createSchedules()` is now `knock.schedules.create()`
-   - `Knock::Workflows.listSchedules()` is now `knock.schedules.list()`
-   - `Knock::Workflows.updateSchedules()` is now `knock.schedules.update()`
-   - `Knock::Workflows.deleteSchedules()` is now `knock.schedules.delete()`
+```ruby title="Working with audience resources"
+# Working with audiences
+knock.audiences.add_members(
+  "audience-id",
+  members: ["user-1", "user-2"]
+)
+```
 
-3. **Method Parameters**: Parameters are now passed differently
+### Request options
 
-   - Most methods now take the ID(s) as positional parameter(s), followed by named parameters
-   - Resource IDs moved from named parameters to positional parameters (e.g., `id: "user-1"` is now `"user-1"`)
-   - `data:` parameters have been flattened in most methods
+More control over individual requests:
 
-4. **Preference Management**:
+```ruby title="Setting per-request options"
+knock.users.get("dnedry", request_options: { timeout: 5 })
+```
 
-   - Preferences are now handled through the `recipients.preferences` module
-   - The preference set ID must be explicitly provided (usually "default")
+## Breaking changes
 
-5. **Response Handling**:
-   - The new SDK returns model instances rather than raw hashes
-   - Pagination is handled via cursor-based pagination instead of page-based
+### Client design
 
-## Common Operations
+The new SDK uses an instance-based client rather than module functions. Create a client instance with `knock = Knockapi::Client.new()` and call methods via the client: `knock.workflows.trigger()` instead of `Knock::Workflows.trigger()`.
 
-### Triggering Workflows
+### Method naming and organization
+
+The main module is now `Knockapi` instead of `Knock`.
+
+Bulk operations are now organized in their own namespaces: `knock.users.bulk.*`, `knock.objects.bulk.*`, `knock.schedules.bulk.*`, etc.
+
+Several method names have changed:
+
+- `Knock::Users.identify()` is now `knock.users.update()`
+- `Knock::Users.set_preferences()` is now `knock.recipients.preferences.set()`
+- `Knock::Users.get_channel_data()` is now `knock.recipients.channel_data.get()`
+- `Knock::Users.getSchedules()` is now `knock.users.listSchedules()`
+- `Knock::Workflows.createSchedules()` is now `knock.schedules.create()`
+- `Knock::Workflows.listSchedules()` is now `knock.schedules.list()`
+- `Knock::Workflows.updateSchedules()` is now `knock.schedules.update()`
+- `Knock::Workflows.deleteSchedules()` is now `knock.schedules.delete()`
+
+### Method parameters
+
+Most methods now take the ID(s) as positional parameter(s), followed by named parameters. Resource IDs moved from named parameters to positional parameters (e.g., `id: "user-1"` is now `"user-1"`). `data:` parameters have been flattened in most methods.
+
+### Preference management
+
+Preferences are now handled through the `recipients.preferences` module. The preference set ID must be explicitly provided (usually "default").
+
+### Response handling
+
+The new SDK returns model instances rather than raw hashes. Pagination is handled via cursor-based pagination instead of page-based.
+
+## Common operations
+
+### Triggering workflows
 
 **Old SDK:**
 
-```ruby
+```ruby title="Triggering workflows with the old SDK"
 Knock::Workflows.trigger(
   key: "dinosaurs-loose",
   actor: "dnedry",
@@ -121,7 +138,7 @@ Knock::Workflows.trigger(
 
 **New SDK:**
 
-```ruby
+```ruby title="Triggering workflows with the new SDK"
 knock.workflows.trigger(
   "dinosaurs-loose",
   recipients: ["jhammond", "agrant"],
@@ -134,11 +151,11 @@ knock.workflows.trigger(
 )
 ```
 
-### Identifying Users
+### Identifying users
 
 **Old SDK:**
 
-```ruby
+```ruby title="Identifying users with the old SDK"
 Knock::Users.identify(
   id: "jhammond",
   data: {
@@ -150,7 +167,7 @@ Knock::Users.identify(
 
 **New SDK:**
 
-```ruby
+```ruby title="Identifying users with the new SDK"
 knock.users.update(
   "jhammond",
   name: "John Hammond",
@@ -158,11 +175,11 @@ knock.users.update(
 )
 ```
 
-### Working with Preferences
+### Working with preferences
 
 **Old SDK:**
 
-```ruby
+```ruby title="Setting user preferences with the old SDK"
 Knock::Users.set_preferences(
   user_id: "jhammond",
   channel_types: { email: true, sms: false },
@@ -176,7 +193,7 @@ Knock::Users.set_preferences(
 
 **New SDK:**
 
-```ruby
+```ruby title="Setting user preferences with the new SDK"
 knock.recipients.preferences.set(
   "users", "jhammond", "default",
   channel_types: { email: true, sms: false },
@@ -188,6 +205,6 @@ knock.recipients.preferences.set(
 )
 ```
 
-## Support
+## Need help?
 
-If you encounter any issues during migration, please [reach out to our support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-ruby/issues).
+If you run into any issues during your migration, reach out to our [support team](mailto:support@knock.app) or open an issue on [GitHub](https://github.com/knocklabs/knock-ruby/issues).


### PR DESCRIPTION
### Description
Made updates to the following pages to improve consistency, align pages with Knock's style guide, and correct errors in code examples.

- [/concepts/schedules](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/)
- [/developer-tools/migration-guides/node](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/developer-tools/migration-guides/node)
- [/developer-tools/migration-guides/python](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/developer-tools/migration-guides/python)
- [/developer-tools/migration-guides/java](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/developer-tools/migration-guides/java)
- [/developer-tools/migration-guides/ruby](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/developer-tools/migration-guides/ruby)
- [/developer-tools/migration-guides/go](https://docs-git-sd-kno-8865-sdk-migration-guides-knocklabs.vercel.app/developer-tools/migration-guides/go)

### Tasks
[KNO-8865](https://linear.app/knock/issue/KNO-8865/docs-update-sdk-migration-guides-to-match-style-guide)