### PR TITLE
chore(KNO-8908): add version override for prismjs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "typescript": "^5.2.2"
   },
   "resolutions": {
-    "react-syntax-highlighter/refractor/prismjs": "^1.30.0"
+    "react-syntax-highlighter/**/prismjs": "^1.30.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,5 +88,8 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.19.4",
     "typescript": "^5.2.2"
+  },
+  "resolutions": {
+    "react-syntax-highlighter/refractor/prismjs": "^1.30.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6771,10 +6771,10 @@ prismjs@^1.27.0:
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
 
-prismjs@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
+prismjs@^1.30.0, prismjs@~1.27.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
+  integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
 
 progress@^2.0.0:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6766,12 +6766,7 @@ prism-react-renderer@2.4.1:
     "@types/prismjs" "^1.26.0"
     clsx "^2.0.0"
 
-prismjs@^1.27.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
-  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
-
-prismjs@^1.30.0, prismjs@~1.27.0:
+prismjs@^1.27.0, prismjs@^1.30.0, prismjs@~1.27.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==


### PR DESCRIPTION
### Description

Prism v1.29.0 has a security vulnerability. (See [the Dependabot alert for CVE-2024-53382](https://github.com/knocklabs/docs/security/dependabot/25).)

Prism is required by both [React Syntax Highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter) and [refractor](https://github.com/wooorm/refractor), a transitive dependency of React Syntax Highlighter.

The author of refractor has indicated [he does not intend to cut a v3.6.1 release of refractor to update Prism](https://github.com/wooorm/refractor/issues/75#issuecomment-2815231981). In addition, there’s been no movement on upgrading refractor in the React Syntax Highlighter codebase. (See react-syntax-highlighter/react-syntax-highlighter#591 and react-syntax-highlighter/react-syntax-highlighter#592.)

So, to resolve this security vulnerability, this PR adds a version override for Prism.

### Tasks

[KNO-8908](https://linear.app/knock/issue/KNO-8908/docs-add-override-for-prismjs-dependency)