### PR TITLE
Update "what is knock" page content

### DIFF
--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -5,7 +5,7 @@ tags: ["getting started", "explainer", "explained"]
 section: Getting started
 ---
 
-Knock is messaging infrastructure that helps you implement messaging your users will love, without the effort of building and maintaining your own in-house messaging system.
+Knock is product and customer messaging infrastructure. You can use Knock to power all of your product's messaging needs, from transactional messaging, lifecycle marketing, one-time announcements, and in-product messaging, without the effort of building and maintaining your own in-house messaging system.
 
 Knock enables you to power three core types of messaging experiences:
 

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -10,7 +10,7 @@ Knock is product and customer messaging infrastructure. You can use Knock to pow
 Knock enables you to power three core types of messaging experiences:
 
 - **Workflows** - Transactional and lifecycle messaging flows that respond to user actions and events
-- **Broadcasts** - One-time messages sent to groups of users for announcements, updates, and campaigns  
+- **Broadcasts** - One-time messages sent to groups of users for announcements, updates, and campaigns
 - **Guides** - In-app lifecycle messaging that helps users discover features and complete key actions
 
 In this overview, we'll cover some of the foundational concepts of Knock. Knock is designed with both developers and product teams in mind: it's easy for developers to implement quickly, and simple for less-technical users to maintain with our intuitive dashboard.
@@ -64,6 +64,7 @@ Your application can trigger workflows using our REST API, any one of our [avail
 Broadcasts enable you to send one-time messages to groups of users for announcements, product updates, marketing campaigns, and other communications that aren't triggered by individual user actions. Unlike workflows that are event-driven, broadcasts are initiated directly from the Knock dashboard or via API and can target specific audiences based on user properties, segments, or custom criteria.
 
 Broadcasts are perfect for:
+
 - Product announcements and feature releases
 - Marketing campaigns and promotional messages
 - System maintenance notifications
@@ -75,6 +76,7 @@ Broadcasts are perfect for:
 Guides power in-app lifecycle messaging that helps users discover features, complete onboarding steps, and take key actions within your application. Unlike traditional messaging that happens outside your app, guides appear contextually within your product interface to provide timely, relevant guidance.
 
 Guides enable you to:
+
 - Create interactive onboarding flows
 - Highlight new features and updates
 - Guide users through complex workflows

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -1,11 +1,17 @@
 ---
 title: What is Knock?
-description: Learn more about what Knock does and how it helps power your product notifications.
+description: Learn more about what Knock does and how it helps power your product messaging.
 tags: ["getting started", "explainer", "explained"]
 section: Getting started
 ---
 
-Knock is notifications infrastructure that helps you implement notifications your users will love, without the effort of building and maintaining your own in-house notifications system.
+Knock is messaging infrastructure that helps you implement messaging your users will love, without the effort of building and maintaining your own in-house messaging system.
+
+Knock enables you to power three core types of messaging experiences:
+
+- **Workflows** - Transactional and lifecycle messaging flows that respond to user actions and events
+- **Broadcasts** - One-time messages sent to groups of users for announcements, updates, and campaigns  
+- **Guides** - In-app lifecycle messaging that helps users discover features and complete key actions
 
 In this overview, we'll cover some of the foundational concepts of Knock. Knock is designed with both developers and product teams in mind: it's easy for developers to implement quickly, and simple for less-technical users to maintain with our intuitive dashboard.
 
@@ -39,7 +45,7 @@ In this overview, we'll cover some of the foundational concepts of Knock. Knock 
 
 ## Workflows
 
-Workflows are a foundational concept in Knock. They allow you to easily model complex messaging flows across channels using a variety of logical function steps while respecting a user’s individual preferences. Workflows are a primary method for sending notifications in Knock.
+Workflows are a foundational concept in Knock. They enable you to easily model complex messaging flows across channels using a variety of logical function steps while respecting a user's individual preferences. Workflows power both transactional messaging (like order confirmations, password resets, and account updates) and lifecycle messaging (like onboarding sequences, engagement campaigns, and retention flows).
 
 <Image
   src="/images/what-is-knock/workflow-diagram-3.png"
@@ -53,7 +59,29 @@ Your application can trigger workflows using our REST API, any one of our [avail
 
 <MultiLangCodeBlock snippet="workflows.trigger" title="Trigger a workflow" />
 
-Knock processes each workflow run using a combination of the following concepts:
+## Broadcasts
+
+Broadcasts enable you to send one-time messages to groups of users for announcements, product updates, marketing campaigns, and other communications that aren't triggered by individual user actions. Unlike workflows that are event-driven, broadcasts are initiated directly from the Knock dashboard or via API and can target specific audiences based on user properties, segments, or custom criteria.
+
+Broadcasts are perfect for:
+- Product announcements and feature releases
+- Marketing campaigns and promotional messages
+- System maintenance notifications
+- Company updates and newsletters
+- Time-sensitive alerts and emergency communications
+
+## Guides
+
+Guides power in-app lifecycle messaging that helps users discover features, complete onboarding steps, and take key actions within your application. Unlike traditional messaging that happens outside your app, guides appear contextually within your product interface to provide timely, relevant guidance.
+
+Guides enable you to:
+- Create interactive onboarding flows
+- Highlight new features and updates
+- Guide users through complex workflows
+- Drive adoption of key product features
+- Provide contextual help and tips
+
+Knock processes each workflow run and manages broadcasts and guides using a combination of the following concepts:
 
 ## Recipients
 
@@ -81,7 +109,7 @@ Recipients are in most cases users in your application. As you trigger workflows
 
 ## Channels
 
-Channels in Knock represent a specific provider you have configured to send notifications. You can include channel steps in your workflows to send notifications with the providers you already use in production.
+Channels in Knock represent a specific provider you have configured to send messages. You can include channel steps in your workflows or use them in broadcasts to send messages with the providers you already use in production.
 Knock supports the following channel types and providers:
 
 <AccordionGroup>
@@ -127,7 +155,7 @@ Knock supports the following channel types and providers:
   </Accordion>
 </AccordionGroup>
 
-A notification that is generated as a part of a workflow is called a `Message`, and Knock allows you to define dynamic message templates using a combination of a drag-and-drop editor and the Liquid templating language.
+A message that is generated as a part of a workflow or broadcast is called a `Message`, and Knock enables you to define dynamic message templates using a combination of a drag-and-drop editor and the Liquid templating language.
 
 This helps product and marketing teams standardize on one templating system instead of using different templating languages for different providers. It also has the added benefit of lifting these messages out of your codebase so you can iterate quickly on customer communications without a developer.
 
@@ -161,7 +189,7 @@ You can combine the following function steps with any number of channel steps to
   <Accordion title="Fetch">
     [A fetch step](/designing-workflows/fetch-function) makes an HTTP request to
     an external service and uses the returned data in subsequent steps, e.g.
-    query an MLS API for recent home sales in the user’s zip code and render
+    query an MLS API for recent home sales in the user's zip code and render
     them in an email.
   </Accordion>
   <Accordion title="Trigger workflow">
@@ -188,7 +216,7 @@ In addition to giving your technical and non-technical users the ability to cons
 
 ## Preferences
 
-In Knock, each workflow run is executed on behalf of a recipient, and each recipient can specify their preferences to receive notifications across a number of different criteria: channel types, individual workflows, and workflow categories.
+In Knock, each workflow run and broadcast is executed on behalf of a recipient, and each recipient can specify their preferences to receive messages across a number of different criteria: channel types, individual workflows, workflow categories, and broadcast types.
 
 <Image
   src="/images/what-is-knock/preferences.png"
@@ -198,7 +226,7 @@ In Knock, each workflow run is executed on behalf of a recipient, and each recip
   className="rounded-md mx-auto border border-gray-200"
 />
 
-Application developers have control over how these preference sets are presented to the user and which options to surface, but Knock enforces these preferences during every workflow run automatically.
+Application developers have control over how these preference sets are presented to the user and which options to surface, but Knock enforces these preferences during every workflow run and broadcast automatically.
 
 You can learn more about how to set a user's preferences in our [preferences overview](/preferences/overview).
 
@@ -246,7 +274,7 @@ If you want to keep learning about Knock using a curated example application, ch
 
 ### Keep learning
 
-While the workflow engine is at the heart of Knock, our goal is to build a complete notification system for our customers. Here is an overview of some of the more-advanced features that we provide:
+While workflows, broadcasts, and guides are at the heart of Knock, our goal is to build a complete messaging system for our customers. Here is an overview of some of the more-advanced features that we provide:
 
 #### UI components
 
@@ -257,7 +285,7 @@ Knock provides developers with React components like `<NotificationFeed/>` and `
 There is a lot more to learn about Knock, and our [concepts overview page](/concepts/overview) is a good place to start. Here are use cases our customers commonly solve with Knock:
 
 - Powering [translation and localization](/concepts/translations) and managing timezone-aware delivery
-- Creating advanced notification logic using [subscriptions](/concepts/subscriptions) and [schedules](/concepts/schedules)
+- Creating advanced messaging logic using [subscriptions](/concepts/subscriptions) and [schedules](/concepts/schedules)
 - Integrating Knock with your application's data model, using [tenants](/concepts/tenants) and [objects](/concepts/objects) to power customized experiences
 - Using [the template editor](/designing-workflows/template-editor/overview) to standarize messaging templates across providers
 
@@ -265,4 +293,4 @@ There is a lot more to learn about Knock, and our [concepts overview page](/conc
 
 Knock is a developer-first platform, with both [environment](/concepts/environments) and [commit models](/concepts/commits). If you want to work with Knock resources in code, you can use our [Management API](/developer-tools/management-api) or [CLI](/developer-tools/knock-cli).
 
-Once you're sending notifications through Knock, we offer observability tools like [workflow run logs](/send-notifications/debugging-workflows) (to examine all steps of workflow execution in your dashboard) and data streaming into a monitoring system like Datadog with [extensions](/integrations/extensions/overview).
+Once you're sending messages through Knock, we offer observability tools like [workflow run logs](/send-notifications/debugging-workflows) (to examine all steps of workflow execution in your dashboard) and data streaming into a monitoring system like Datadog with [extensions](/integrations/extensions/overview).

--- a/content/getting-started/what-is-knock.mdx
+++ b/content/getting-started/what-is-knock.mdx
@@ -5,15 +5,15 @@ tags: ["getting started", "explainer", "explained"]
 section: Getting started
 ---
 
-Knock is product and customer messaging infrastructure. You can use Knock to power all of your product's messaging needs, from transactional messaging, lifecycle marketing, one-time announcements, and in-product messaging, without the effort of building and maintaining your own in-house messaging system.
+Knock is product and customer messaging infrastructure. You can use Knock to power all of your product's messaging needs, including transactional messaging, lifecycle marketing, one-time announcements, and in-product messaging, without the effort of building and maintaining your own in-house messaging system.
 
-Knock enables you to power three core types of messaging experiences:
+Knock enables you to power three core messaging experiences:
 
-- **Workflows** - Transactional and lifecycle messaging flows that respond to user actions and events
-- **Broadcasts** - One-time messages sent to groups of users for announcements, updates, and campaigns
-- **Guides** - In-app lifecycle messaging that helps users discover features and complete key actions
+- **Workflows.** Transactional and lifecycle messaging flows that respond to user actions and events.
+- **Broadcasts.** One-time messages sent to groups of users for announcements, updates, and campaigns.
+- **Guides.** In-app lifecycle messaging that helps users discover features and complete key actions.
 
-In this overview, we'll cover some of the foundational concepts of Knock. Knock is designed with both developers and product teams in mind: it's easy for developers to implement quickly, and simple for less-technical users to maintain with our intuitive dashboard.
+In this overview, we'll cover the foundational concepts of Knock. Knock is designed with both developers and product teams in mind. It's easy for developers to implement, and simple for less-technical users to maintain in our dashboard.
 
 <div
   style={{
@@ -45,7 +45,7 @@ In this overview, we'll cover some of the foundational concepts of Knock. Knock 
 
 ## Workflows
 
-Workflows are a foundational concept in Knock. They enable you to easily model complex messaging flows across channels using a variety of logical function steps while respecting a user's individual preferences. Workflows power both transactional messaging (like order confirmations, password resets, and account updates) and lifecycle messaging (like onboarding sequences, engagement campaigns, and retention flows).
+Workflows are a foundational concept in Knock. They enable you to easily model complex messaging flows across channels using a variety of logical function steps while respecting a user's individual preferences. Workflows power both transactional messaging (such as order confirmations, password resets, and account updates) and lifecycle messaging (such as onboarding sequences, engagement campaigns, and retention flows).
 
 <Image
   src="/images/what-is-knock/workflow-diagram-3.png"
@@ -87,7 +87,7 @@ Knock processes each workflow run and manages broadcasts and guides using a comb
 
 ## Recipients
 
-Recipients are in most cases users in your application. As you trigger workflows for recipients, Knock creates a cache of the data needed to notify them on different platforms, like an email address, phone number, avatar URL, or push token. Knock also stores custom properties you pass from your application to customize their notifications, like a plan type, user role, or timezone.
+In most cases, recipients are users in your application. As you trigger workflows for recipients, Knock creates a cache of the data needed to notify them on different platforms, such as an email address, phone number, avatar URL, or push token. Knock also stores custom properties you pass from your application to customize their notifications, such as a plan type, user role, or timezone.
 
 ```javascript title="An object used to create a User"
 {
@@ -276,7 +276,7 @@ If you want to keep learning about Knock using a curated example application, ch
 
 ### Keep learning
 
-While workflows, broadcasts, and guides are at the heart of Knock, our goal is to build a complete messaging system for our customers. Here is an overview of some of the more-advanced features that we provide:
+While workflows, broadcasts, and guides are at the heart of Knock, our goal is to build a complete messaging system for our customers. Here is an overview of some of the more-advanced features that we provide.
 
 #### UI components
 
@@ -286,13 +286,15 @@ Knock provides developers with React components like `<NotificationFeed/>` and `
 
 There is a lot more to learn about Knock, and our [concepts overview page](/concepts/overview) is a good place to start. Here are use cases our customers commonly solve with Knock:
 
-- Powering [translation and localization](/concepts/translations) and managing timezone-aware delivery
-- Creating advanced messaging logic using [subscriptions](/concepts/subscriptions) and [schedules](/concepts/schedules)
-- Integrating Knock with your application's data model, using [tenants](/concepts/tenants) and [objects](/concepts/objects) to power customized experiences
-- Using [the template editor](/designing-workflows/template-editor/overview) to standarize messaging templates across providers
+- Powering [translation and localization](/concepts/translations) and managing timezone-aware delivery.
+- Creating advanced messaging logic using [subscriptions](/concepts/subscriptions) and [schedules](/concepts/schedules).
+- Integrating Knock with your application's data model, using [tenants](/concepts/tenants) and [objects](/concepts/objects) to power customized experiences.
+- Using [the template editor](/designing-workflows/template-editor/overview) to standardize messaging templates across providers.
 
 #### Developer tools
 
 Knock is a developer-first platform, with both [environment](/concepts/environments) and [commit models](/concepts/commits). If you want to work with Knock resources in code, you can use our [Management API](/developer-tools/management-api) or [CLI](/developer-tools/knock-cli).
+
+Knock also supports an [MCP](/developer-tools/mcp-server) server, which allows you to work with Knock resources in your IDE, entirely using natural language. Our MCP server is a great way to migrate from a legacy system to Knock, or to make updates across many Knock resources at once.
 
 Once you're sending messages through Knock, we offer observability tools like [workflow run logs](/send-notifications/debugging-workflows) (to examine all steps of workflow execution in your dashboard) and data streaming into a monitoring system like Datadog with [extensions](/integrations/extensions/overview).


### PR DESCRIPTION
### Description

This PR updates the "What is Knock?" documentation page to provide a more comprehensive overview of Knock's capabilities.

**Why:**
The primary goal is to reflect that Knock powers a broader range of messaging needs beyond just workflows, specifically including:
- **Workflows:** Transactional and lifecycle messaging.
- **Broadcasts:** One-time announcements and campaigns.
- **Guides:** In-app lifecycle messaging.
The terminology has also been updated to consistently use "messaging" instead of "notifications" to better reflect this broader scope and position Knock as a complete messaging platform.

**How:**
- The introductory paragraph has been rewritten to clearly state Knock's role as "product and customer messaging infrastructure" and list the core messaging types.
- New dedicated sections for "Broadcasts" and "Guides" have been added, detailing their purpose and use cases.
- The "Workflows" section has been expanded to clarify its application for both transactional and lifecycle messaging.
- Terminology has been updated throughout the document, replacing "notifications" with "messaging" where appropriate, and ensuring all core concepts (e.g., channels, messages, preferences) account for workflows, broadcasts, and guides.

### Todos

### Tasks

### Screenshots