### PR TITLE
chore(kno-6590): add new default attachments key behavior

### DIFF
--- a/content/integrations/email/attachments.mdx
+++ b/content/integrations/email/attachments.mdx
@@ -7,7 +7,7 @@ layout: integrations
 
 ## How attachments work in Knock
 
-1. Set an attachment key in your email template to tell Knock how to resolve attachments you send in the data payload of your trigger call. To set an attachment key, click the gear icon (⚙️) at the top of the email template editor, then set your desired key under the "Attachment key" field.
+1. Set an attachment key in your email template to tell Knock how to resolve attachments you send in the data payload of your trigger call. To set an attachment key, click the gear icon (⚙️) at the top of the email template editor, then set your desired key under the "Attachment key" field. This key will default to `attachments` if not specified.
 2. Include one or more attachment objects in the `data` payload of your trigger call, under the configured attachment key. Each attachment object should have the content of the file to be attached as a base64 encoded value.
 3. Knock automatically adds any attachments included in the attachment key of your trigger call to the emails sent by your email provider 🎉.
 


### PR DESCRIPTION
### Description

This PR documents the update made in KNO-6590 to make `attachments` the default key for email attachments

### Screenshots

<img width="550" alt="image" src="https://github.com/user-attachments/assets/3edca590-df80-4b6a-bc71-f5f57e9d5b24" />
