### PR TITLE
chore(kno-9043): clarify trigger data limits

### DIFF
--- a/content/send-notifications/triggering-workflows/api.mdx
+++ b/content/send-notifications/triggering-workflows/api.mdx
@@ -61,7 +61,7 @@ Triggering a workflow will always return a unique UUID v4 representing the workf
 
 ## Passing data to your trigger
 
-Pass schema data required by the workflow in your `trigger` call. The payload must be a valid JSON object. There is a 1024 byte limit on the size of any single string value (with the exception of [email attachments](/integrations/email/attachments)), and a 10MB limit on the size of the full `data` payload.
+Pass schema data required by the workflow in your `trigger` call. The payload must be a valid JSON object. There is a 10MB limit on the size of the full `data` payload. Any individual string value greater than 1024 bytes in length will be [truncated](/developer-tools/api-logs#log-truncation) in your logs.
 
 The workflow builder determines which data keys are required.
 


### PR DESCRIPTION
### Description

This PR updates the description for trigger data to clarify limits on string size for log truncation.