### PR TITLE
chore(kno-9044): add replace strategy and clarify merge hierarchy

### DIFF
--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -205,7 +205,7 @@ There are four steps to building a preference center with Knock:
 
 ## Merging preferences
 
-When a default `PreferenceSet` exists for an environment or tenant, Knock will merge all applicable preferences for a recipient when evaluating whether or not to send a notification. Any preferences set at the recipient-level will take precedence in the merge.
+When a default `PreferenceSet` exists for an environment or tenant, Knock will merge all applicable preferences for a recipient when evaluating whether or not to send a notification. Any preferences set at the recipient level will take precedence in the merge, according to the hierarchy outlined below.
 
 ## Preference evaluation rules
 
@@ -215,6 +215,22 @@ When a workflow is triggered, Knock will evaluate the preferences for each `reci
   <Accordion title="General preference rules">
     - If you do not set a preference for a given channel, workflow, or workflow category, Knock defaults them to `true`.
     - When a recipient clicks an unsubscribe link, their `default` preference set will be updated, marking `commercial_unsubscribe` as `true`. They will be opted-out of commercial messages, and they will continue to receive transactional messages based on their other preferences. Read more about commercial unsubscribe [here](/preferences/commercial-unsubscribe).
+  </Accordion>
+  <Accordion title="Merge hierarchy">
+    The following hierarchies are used when merging preferences (in order of highest precedence to lowest):
+
+    **When no `tenant` is applied to the workflow trigger:**
+    - A recipient's `default` preference set
+    - The environment-level default preference set
+    <br />
+    **When a `tenant` is applied to the workflow trigger:**
+    - A recipient's tenant-specific preference set
+    - The `tenant`'s default preference set
+    - The recipient's `default` preference set (only evaluated if neither of the above exist)
+    - The environment-level default preference set
+    <br />
+    See the [Frequently asked questions](#frequently-asked-questions) section below for more information on overriding this hierarchy.
+
   </Accordion>
   <Accordion title="Resolving preference conflicts">
     Knock only sends a notification if all preference combinations that exist on the recipient evaluate to `true`.
@@ -252,9 +268,10 @@ You can update the preferences of up to 1000 users in a single batch by using th
 
 ## Advanced concepts
 
-- [Per-tenant preferences.](/preferences/tenant-preferences) In multi-tenant B2B applications, an advanced use case is customer admins who want to set the tenant-level default `PreferenceSet` for new users within their tenant.
+- [Per-tenant preferences](/preferences/tenant-preferences). In multi-tenant B2B applications, an advanced use case is customer admins who want to set the tenant-level default `PreferenceSet` for new users within their tenant.
 - [Object preferences](/preferences/object-preferences). In the guide above, we referred to user preferences. You can also set preferences for objects.
 - [Preference conditions](/preferences/preference-conditions). You can build advanced conditions and store them on Knock’s preference model to power use cases such as per-resource muting (example: mute notifications about this task) or threshold alerts (example: only notify me if my account balance is below $5).
+- Merge strategy. It's possible to configure the merge strategy on specific preferences within a `PreferenceSet`. This allows you to override the default merge hierarchy when preferences are evaluated. See the [Frequently asked questions](#frequently-asked-questions) section below for more details and use cases.
 - Workflow overrides. If you need to override a recipient's notification preferences to send notifications like a password reset email, you can override the preferences model. To do this, go to your workflow, click "Manage workflow," and enable "Override recipient preferences." You will need to commit this change for it to take effect. When enabled, the workflow will send to all of its channels, regardless of the recipient's preferences.
 - [Commercial unsubscribe](/preferences/commercial-unsubscribe). You can configure 1-click unsubscribe links to help users opt-out of commercial or promotional notifications and comply with CAN-SPAM requirements.
 
@@ -324,6 +341,74 @@ You can update the preferences of up to 1000 users in a single batch by using th
       }
     }
     ```
+
+  </Accordion>
+  <Accordion title="What is the merge strategy, and how can I use it to override the merge hierarchy?">
+    By default, a recipient's individual preferences will always take the highest precedence in the merge when preferences are evaluated (according to the hierarchy outlined under [Preference evaluation rules](#preference-evaluation-rules) above).
+    
+    Some applications have use cases where it's necessary for a preference that is set at the tenant level to override a user's individual preference. For example, you may want to allow a team admin to disable a certain type of notification for their entire team, regardless of whether an individual user has opted in to that notification. To achieve this, you can set the `__strategy__` key on the preference you'd like to override to a value of `"replace"`.
+
+    In the following example, although the user has specifically opted into receiving email notifications for the `collaboration` category, the workflow will not send because the `tenant`'s default preference set has set the `collaboration` category to `false`.
+
+    ```json title="A user's tenant-specific preference set"
+    {
+      "categories": {
+        "collaboration": {
+          "channel_types": {
+            "email": true
+          }
+        },
+        "project-updates": {
+          "channel_types": {
+            "email": true
+          }
+        }
+      }
+    }
+    ```
+
+    ```json title="The tenant's default preference set"
+    {
+      "categories": {
+        "collaboration": {
+          "__strategy__": "replace",
+          "channel_types": {
+            "email": false
+          }
+        },
+        "project-updates": {
+          "channel_types": {
+            "email": false
+          }
+        }
+      }
+    }
+    ```
+    <br />
+    This `replace` strategy will also be reflected when you request the user's preferences via API. Although the user's tenant-specific preferences have explicitly been set to the above, the `__strategy__` key will be present on the `PreferenceSet` returned, indicating that their preference has been overridden by the tenant's:
+
+    ```json title="The returned user preference set"
+    {
+      "categories": {
+        "collaboration": {
+          "__strategy__": "replace",
+          "channel_types": {
+            "email": false
+          }
+        },
+        "project-updates": {
+          "channel_types": {
+            "email": true
+          }
+        }
+      }
+    }
+    ```
+    <br />
+    Here are some important thing to keep in mind when using the `replace` strategy:
+    - This strategy will only apply to the specific preference(s) where it's included; there's no way to override the entire `PreferenceSet` at the top level.
+    - The `__strategy__` key can only be used on a combined `workflows`-`channel_types` or `categories`-`channel_types` preference, as seen in the example above.
+    - When the preference with the `replace` strategy is removed, any existing preferences that were overridden by the `replace` strategy will be immediately restored to their original values. For the example above, the user will once again be opted in to `collaboration` notifications.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

This PR updates our preferences overview page:
- Adds a section on merge hierarchy to explicitly outline the order in which various preferences take precedence when merged
- Adds a bullet point under "Advanced concepts" on setting the merge strategy
- Adds an FAQ outlining implementation and considerations for using the `replace` merge strategy
