### PR TITLE
chore(kno-8887): call out https protocol requirement

### DIFF
--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -148,7 +148,8 @@ Knock is able to identify many types of URLs for tracking:
   style={{ alignItems: "center" }}
   text={
     <>
-      In order for your URLs to be qualified as eligible for click tracking, they must include the <code>https://</code> protocol.
+      In order for your URLs to be qualified as eligible for click tracking,
+      they must include the <code>https://</code> protocol.
     </>
   }
 />

--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -141,6 +141,18 @@ Knock is able to identify many types of URLs for tracking:
 - **Chat app JSON** — Knock will traverse chat app JSON blobs (e.g. Slack Block Kit) and replace URL cards or anchor tags found within.
 - **Bare URLs** — In Markdown templates, Knock will replace full-form URLs with trackable links wrapping the origin URL. For example, `https://foobar.com/` would become `[https://foobar.com/](<knock-trackable-link>)`.
 
+<Callout
+  emoji="⚠️"
+  title="Note:"
+  bgColor="accent"
+  style={{ alignItems: "center" }}
+  text={
+    <>
+      In order for your URLs to be qualified as eligible for click tracking, they must include the <code>https://</code> protocol.
+    </>
+  }
+/>
+
 There are two types of trackable links Knock may generate: standard and short. Standard links encode the target URL (and other event metadata) into a variable-length token added to the link path. Short links instead use a lookup key added to the link that maps to a record of the target URL. The short link lookup key will always be 10-characters in length, with short links always 31-characters long in total.
 
 Given their brevity and consistent length, Knock will use short links for channels that often have character constraints. Specifically these are:


### PR DESCRIPTION
### Description

This PR adds a callout to our link click tracking documentation to make it more-obvious that the https:// protocol is required for link tracking to work.
