### PR TITLE
chore(kno-8867): clarify inline attachment usage and preview limitations

### DIFF
--- a/content/integrations/email/attachments.mdx
+++ b/content/integrations/email/attachments.mdx
@@ -72,7 +72,7 @@ filesAndRecipients.forEach(({ id, file }) => {
 
 ## Referencing attachment files inline
 
-If you're using SendGrid or Postmark as your email provider, you can reference attachment files inline in your email template by providing a `content_id` property on the attachment object that you send in your trigger call. This will cause the attachment to be included in the email as an inline attachment, which can be referenced in your email template using the `cid:` prefix along with the value of the `content_id` property.
+If you're using SendGrid or Postmark as your email provider, you can reference attachment files inline in your email template by providing a `content_id` property on the attachment object you send in your trigger call. Adding a `content_id` to the attachment embeds it in the email as an inline attachment, which you can reference in your template using the `cid:` prefix and the `content_id` value.
 
 ```html title="Referencing an attachment file inline"
 <img src="cid:my-attachment" />


### PR DESCRIPTION
### Description

This PR clarifies limitations around previewing attachments in our dashboard (not currently supported, including for inline-attached images) as well as guidance on how to reference inline-attached images within your email template using the `cid` prefix for your image `src`.

https://docs-myape0eap-knocklabs.vercel.app/integrations/email/attachments