### PR TITLE
chore: remove references to the react-native-example app, add version compatibility notice to expo sdk

### DIFF
--- a/content/in-app-ui/expo/sdk/overview.mdx
+++ b/content/in-app-ui/expo/sdk/overview.mdx
@@ -22,6 +22,101 @@ Our [`@knocklabs/expo`](https://www.npmjs.com/package/@knocklabs/expo) library l
 
 The Expo library is built on top of the `@knocklabs/client` JS SDK and includes that library as an implicit dependency.
 
+### Installation
+
+```bash title="Installing dependencies"
+npm install @knocklabs/expo
+```
+
+<Callout
+  emoji="ℹ️"
+  title="Version compatibility"
+  text="The @knocklabs/expo package is compatible with Expo version 53 and above."
+/>
+
+### Configuration
+
+To configure the feed you will need:
+
+1. A public API key (found in the Knock dashboard)
+2. A user ID and an auth token
+
+   <Callout
+     emoji="💡"
+     text={
+       <>
+         Auth tokens are strongly recommended for production environments and
+         are required when enhanced security mode is enabled. For more
+         information, see our{" "}
+         <a href="/in-app-ui/security-and-authentication#authentication-with-enhanced-security">
+           Security & Authentication documentation
+         </a>
+         .
+       </>
+     }
+   />
+
+3. If integrating an in-app feed, a feed channel ID (found in the Knock dashboard)
+
+### Usage
+
+You can integrate the feed into your app as follows:
+
+```typescript
+import {
+  KnockProvider,
+  KnockFeedProvider,
+  NotificationFeed,
+} from "@knocklabs/expo";
+
+const YourAppLayout = () => {
+  return (
+    <KnockProvider apiKey={process.env.KNOCK_PUBLIC_API_KEY} userId={userId}>
+      {/* Optionally, use the KnockFeedProvider to connect an in-app feed */}
+      <KnockFeedProvider feedId={process.env.KNOCK_FEED_ID}>
+        <NotificationFeed
+          onRowTap={(item) => {
+            console.log("Notification tapped:", item);
+          }}
+        />
+      </KnockFeedProvider>
+    </KnockProvider>
+  );
+};
+```
+
+### Headless usage
+
+Alternatively, if you don't want to use our components you can render the feed in a headless mode using our hooks:
+
+```typescript
+import {
+  useAuthenticatedKnockClient,
+  useNotifications,
+  useNotificationStore,
+} from "@knocklabs/expo";
+
+const YourAppLayout = () => {
+  const knockClient = useAuthenticatedKnockClient(
+    process.env.KNOCK_PUBLIC_API_KEY,
+    currentUser.id,
+  );
+
+  const notificationFeed = useNotifications(
+    knockClient,
+    process.env.KNOCK_FEED_ID,
+  );
+
+  const { metadata } = useNotificationStore(notificationFeed);
+
+  useEffect(() => {
+    notificationFeed.fetch();
+  }, [notificationFeed]);
+
+  return <Text>Total unread: {metadata.unread_count}</Text>;
+};
+```
+
 **Quick links:**
 
 - [`@knocklabs/expo` on npm](https://www.npmjs.com/package/@knocklabs/expo)

--- a/content/in-app-ui/react-native/sdk/overview.mdx
+++ b/content/in-app-ui/react-native/sdk/overview.mdx
@@ -36,7 +36,7 @@ Using the React Native SDK it's possible to build:
 
 ## Example app
 
-You can find a basic example application that uses the React Native SDK [here](https://github.com/knocklabs/javascript/tree/main/examples/react-native-example). The app shows patterns for handling push token registration, building an in-app feed, and managing user notification preferences.
+You can find a basic example application that uses the React Native SDK [here](https://github.com/knocklabs/javascript/tree/main/examples/expo-example). The app shows patterns for handling push token registration, building an in-app feed, and managing user notification preferences.
 
 ## Need help?
 

--- a/content/in-app-ui/react-native/sdk/push-notifications.mdx
+++ b/content/in-app-ui/react-native/sdk/push-notifications.mdx
@@ -141,13 +141,13 @@ Use the Knock dashboard or API to send a test notification to ensure your setup 
     <>
       Check out our{" "}
       <a
-        href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example"
+        href="https://github.com/knocklabs/javascript/tree/main/examples/expo-example"
         target="_blank"
       >
-        React Native example app
+        Expo example app
       </a>{" "}
       to see a fully working example of how to integrate push notifications with
-      Knock, Firebase Cloud Messaging, and React Native Firebase.
+      Knock.
     </>
   }
 />


### PR DESCRIPTION
### Description
We're temporarily removing the react native example app until we're able to prioritize work to create a working example. This PR updates those link references to go to our expo example app instead. It also adds a notice to our expo SDK that version 53 or up is required, to do this an installation section was added to the expo docs as well. 