### PR TITLE
chore: update Teams instructions for adding channel

### DIFF
--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -36,7 +36,7 @@ Additionally, if you intend to use [TeamsKit](/in-app-ui/react/teams-kit) or Kno
 
 ### Add Teams to Knock as a channel
 
-First you'll need to add Teams as a channel in Knock. Navigate to the “Channels” page within Knock and click “Create channel” to add Microsoft Teams.
+First you'll need to add Teams as a channel in Knock. Navigate to **Integrations** > **Channels** within your Knock dashboard and click “Create channel” to add Microsoft Teams.
 
 If you're using an incoming webhook URL, no additional environment configuration is required.
 


### PR DESCRIPTION
### Description

Updates the Microsoft Teams overview page to correctly reference the Integrations tab in our dashboard for setting up a new Teams channel in Knock.

H/T @jonathanberger
