### PR TITLE
chore: clean up setup instructions for data warehouse sync

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -5,7 +5,7 @@ layout: integrations
 section: Integrations > Extensions
 ---
 
-You can bring your notification analytics from Knock into your own data warehouse so that you can analyze it alongside the rest of your data. To set up this sync, please contact our [support team](mailto:support@knock.app).
+You can bring your notification analytics from Knock into your own data warehouse so that you can analyze it alongside the rest of your data.
 
 <Callout
   emoji="✨"
@@ -19,11 +19,13 @@ You can bring your notification analytics from Knock into your own data warehous
   }
 />
 
-## How it works
+## Connecting your data warehouse
 
-Knock integrates with your data warehouse using [Prequel](https://www.prequel.co/). There is no self-service UI to connect your account – please [contact our support team to get started](mailto:support@knock.app). We will need some information about your data warehouse, including its destination type. Depending on the type (supported databases listed [here](https://docs.prequel.co/docs/destinations-overview)), we may ask for additional details.
+Please [contact our support team](mailto:support@knock.app) to get started with the warehouse connection process. Your message should include the destination type of the warehouse that you'd like to connect; supported types are listed <a href="https://docs.prequel.co/docs/destinations-overview#supported-destinations" target="_blank">here</a>. You should also specify which of the tables you'd like to sync from the available data listed below.
 
-Once the necessary data warehouse information is provided, Knock will provide you with a unique magic link. This link will guide you through a step-by-step wizard tailored to your specific data warehouse destination. Upon successful connection, a [backfill of historical data](https://docs.prequel.co/docs/transfer-logic#backfills--full-refreshes) will begin and you will continue to receive the most up-to-date data every 24 hours.
+We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard that will guide you through the remainder of the setup process. 
+
+Upon successful connection, your first data sync will include a backfill of historical data. You will receive up-to-date data once every 24 hours after the initial backfill.
 
 ## Available data
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -23,7 +23,7 @@ You can bring your notification analytics from Knock into your own data warehous
 
 Please [contact our support team](mailto:support@knock.app) to get started with the warehouse connection process. Your message should include the destination type of the warehouse that you'd like to connect; supported types are listed <a href="https://docs.prequel.co/docs/destinations-overview#supported-destinations" target="_blank">here</a>. You should also specify which of the tables you'd like to sync from the available data listed below.
 
-We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard that will guide you through the remainder of the setup process. 
+We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard that will guide you through the remainder of the setup process.
 
 Upon successful connection, your first data sync will include a backfill of historical data. You will receive up-to-date data once every 24 hours after the initial backfill.
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -33,7 +33,7 @@ Upon successful connection, your first data sync will include a backfill of hist
 
 Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](/concepts/messages).
 
-Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the [destination type mapping](https://docs.prequel.co/docs/data-types#destination-type-mapping) in the Prequel docs.
+Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 
 <AccordionGroup>
 <Accordion title="Table definition example">
@@ -285,7 +285,7 @@ Each row has an `event_type` indicating how the event was generated. Possible va
 
 Events in the recipient change stream table are retained for 7 days.
 
-Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the [destination type mapping](https://docs.prequel.co/docs/data-types#destination-type-mapping) in the Prequel docs.
+Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 
 <AccordionGroup>
 <Accordion title="Table definition example">


### PR DESCRIPTION
### Description

This PR cleans up the language for the setup process in the data warehouse sync documentation based on some customer confusion and feedback that we've gotten. 
