### PR TITLE
chore: add tags for audiences and broadcasts

### DIFF
--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -1,7 +1,18 @@
 ---
 title: Audiences
 description: Learn how to use Audiences to power your lifecycle marketing use cases.
-tags: []
+tags:
+  [
+    "segmentation",
+    "user segmentation",
+    "lifecycle",
+    "marketing",
+    "transactional",
+    "audience",
+    "groups",
+    "segments",
+    "cohorts",
+  ]
 section: Concepts
 ---
 

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -1,7 +1,21 @@
 ---
 title: Broadcasts
 description: Power one-time, cross-channel messaging to your users through Knock.
-tags: []
+tags:
+  [
+    "segmentation",
+    "user segmentation",
+    "lifecycle",
+    "marketing",
+    "audience",
+    "groups",
+    "segments",
+    "one-time",
+    "one-off",
+    "cross-channel",
+    "broadcast",
+    "broadcasts",
+  ]
 section: Concepts
 ---
 


### PR DESCRIPTION
### Description

Our audiences and broadcast pages currently lack tags, this PR should help people find what they're looking for in docs search when they want to learn more about targeting messages to specific user cohorts and one-time sends.
