### PR TITLE
chore: update cursor install instructions

### DIFF
--- a/content/developer-tools/mcp-server.mdx
+++ b/content/developer-tools/mcp-server.mdx
@@ -56,8 +56,8 @@ Click this button to add the Knock MCP server to Cursor (version 1.0 or higher i
 
 #### Manual installation
 
-1. Go to your Cursor settings and find the "MCP" section
-2. Click "Add new global MCP server"
+1. Go to **Settings** > **Cursor Settings** and find the "Tools & Integrations" section.
+2. Click "New MCP server" under **MCP Tools**.
 3. Inside of your `mcp.json` file under the `mcpServers` key, add the following:
 
 ```json
@@ -75,9 +75,9 @@ Click this button to add the Knock MCP server to Cursor (version 1.0 or higher i
 
 ### Claude Desktop
 
-1. Open the Claude Desktop settings and find the "Developer" section
-2. Click to "Edit Config"
-3. Open your `claude_desktop_config.json` file in your preferred text editor
+1. Open the Claude Desktop settings and find the "Developer" section.
+2. Click to "Edit Config".
+3. Open your `claude_desktop_config.json` file in your preferred text editor.
 4. Add the following contents to the file (or add to the `mcpServers` section if it exists):
 
 ```json

--- a/content/developer-tools/mcp-server.mdx
+++ b/content/developer-tools/mcp-server.mdx
@@ -76,7 +76,7 @@ Click this button to add the Knock MCP server to Cursor (version 1.0 or higher i
 ### Claude Desktop
 
 1. Open the Claude Desktop settings and find the "Developer" section.
-2. Click to "Edit Config".
+2. Click to "Edit Config."
 3. Open your `claude_desktop_config.json` file in your preferred text editor.
 4. Add the following contents to the file (or add to the `mcpServers` section if it exists):
 


### PR DESCRIPTION
### Description

This PR updates the manual MCP server install instructions to reflect updates that Cursor made to their settings: 

<img width="700" alt="image" src="https://github.com/user-attachments/assets/1fe95f74-86c9-4645-9965-cbc1c1dacedf" />
