### PR TITLE
chore(KNO-9264): reference Graph API client credentials in MS Teams docs

### DIFF
--- a/content/in-app-ui/react/sdk/reference.mdx
+++ b/content/in-app-ui/react/sdk/reference.mdx
@@ -589,7 +589,7 @@ Renders a notification bell icon, with a badge showing the number of unseen item
   <Attribute
     name="graphApiClientId*"
     type="string"
-    description="The ID of your Microsoft Teams bot."
+    description={`The client ID of your Microsoft Graph API-enabled application registered with Microsoft Entra. This should match the "Graph API client ID" setting of your Microsoft Teams channel in the Knock dashboard.`}
   />
   <Attribute
     name="redirectUrl"

--- a/content/in-app-ui/react/sdk/reference.mdx
+++ b/content/in-app-ui/react/sdk/reference.mdx
@@ -587,7 +587,7 @@ Renders a notification bell icon, with a badge showing the number of unseen item
 
 <Attributes>
   <Attribute
-    name="msTeamsBotId*"
+    name="graphApiClientId*"
     type="string"
     description="The ID of your Microsoft Teams bot."
   />
@@ -1025,9 +1025,9 @@ Builds a Microsoft Teams authorization URL generator and a disconnect function.
 
 <Attributes>
   <Attribute
-    name="msTeamsBotId"
+    name="graphApiClientId"
     type="string"
-    description="The ID of your Microsoft Teams bot"
+    description={`The client ID of your Microsoft Graph API-enabled application registered with Microsoft Entra. This should match the "Graph API client ID" setting of your Microsoft Teams channel in the Knock dashboard.`}
   />
   <Attribute
     name="redirectUrl"

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -62,7 +62,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container
 <MsTeamsAuthButton
-    msTeamsBotId="Microsoft Teams bot ID"
+    graphApiClientId="Microsoft Graph API client ID"
     redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
 />
 
@@ -70,7 +70,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 <MsTeamsAuthContainer
     actionButton={
         <MsTeamsAuthButton
-            msTeamsBotId="Microsoft Teams bot ID"
+            graphApiClientId="Microsoft Graph API client ID"
             redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
         />
     }
@@ -207,7 +207,7 @@ const NotificationSettings = () => {
     <MsTeamsAuthContainer
       actionButton={
         <MsTeamsAuthButton
-          msTeamsBotId={process.env.MS_TEAMS_BOT_ID}
+          graphApiClientId={process.env.MS_TEAMS_BOT_ID}
           redirectUrl={"www.my-example-app.com/notification-settings"}
         />
       }

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -8,7 +8,7 @@ Our `@knocklabs/react` library comes with pre-built components for allowing your
 
 ## Getting started
 
-To get started you'll need a [Knock account](https://dashboard.knock.app), a [Microsoft Teams channel connected to a Microsoft Teams bot](/integrations/chat/microsoft-teams/overview), and a workflow with a Microsoft Teams channel step.
+To get started you'll need a [Knock account](https://dashboard.knock.app), a [Microsoft Teams channel connected to a Microsoft Teams bot](/integrations/chat/microsoft-teams/overview), a [Graph API-enabled application](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra), and a workflow with a Microsoft Teams channel step.
 
 Depending on your use case, you can follow one of these guides for step-by-step instructions on how to set up your Microsoft Teams integration:
 
@@ -57,7 +57,7 @@ The `KnockMsTeamsProvider` gives your components access to the status of the con
   </figcaption>
 </figure>
 
-Your users will give your Microsoft Teams bot access to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
+Your users will connect your Microsoft Teams bot to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
 
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -178,7 +178,7 @@ Here's an example of these components in a React application.
 KNOCK_PUBLIC_API_KEY = "pk_test_12345";
 KNOCK_MS_TEAMS_CHANNEL_ID = "2e0e37c3-751b-4be5-a684-8296009e960e";
 
-MS_TEAMS_BOT_ID = "f1b85cf4-58e1-4cef-8d3f-ce6ccf60734d";
+GRAPH_API_CLIENT_ID = "f1b85cf4-58e1-4cef-8d3f-ce6ccf60734d";
 ```
 
 <br />
@@ -207,7 +207,7 @@ const NotificationSettings = () => {
     <MsTeamsAuthContainer
       actionButton={
         <MsTeamsAuthButton
-          graphApiClientId={process.env.MS_TEAMS_BOT_ID}
+          graphApiClientId={process.env.GRAPH_API_CLIENT_ID}
           redirectUrl={"www.my-example-app.com/notification-settings"}
         />
       }

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -32,7 +32,7 @@ If you're using an incoming webhook URL, there are no prerequisites.
 
 If you're using a Microsoft Teams bot, make sure your bot has been registered and deployed with Azure. Knock does not manage deploying and configuring your bot. To set up Knock to send notifications as your bot, you'll need your bot's ID and password. These are sometimes called the App ID and App Password, and were provided to you when you registered your bot with Azure or the <a href="https://dev.teams.microsoft.com/" target="_blank">Microsoft Teams Developer Portal</a>.
 
-Additionally, if you intend to use [TeamsKit](/in-app-ui/react/teams-kit) or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure your bot in the Microsoft Entra admin center](#configuring-your-bot-in-microsoft-entra).
+Additionally, if you intend to use [TeamsKit](/in-app-ui/react/teams-kit) or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure a Graph API-enabled application in the Microsoft Entra admin center](#configuring-a-graph-api-enabled-application-in-microsoft-entra).
 
 <Callout
   emoji="💡"
@@ -89,6 +89,14 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
     associated with your bot. Click the “Update settings” button to save your
     changes.
   </Step>
+  <Step title="Enter your Graph API-enabled client credentials">
+    If you intend to use TeamsKit, you'll need to enter the client ID and secret associated with a [Graph API-enabled application](#configuring-a-graph-api-enabled-application-in-microsoft-entra) registered with Microsoft Entra. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's credentials.
+
+    In the “Graph API client ID” and “Graph API client secret” fields, enter the client ID and secret associated with your application.
+
+    Click the “Update settings” button to save your changes.
+
+  </Step>
 </Steps>
 
 ### Add a Teams channel step to a workflow
@@ -108,16 +116,16 @@ Now you're ready to notify Teams. [Trigger the workflow](/send-notifications/tri
 
 Your Teams channel should have received a notification. If you need to debug your integration, you can view the logs page in the Knock dashboard.
 
-## Configuring your bot in Microsoft Entra
+## Configuring a Graph API-enabled application in Microsoft Entra
 
-To use TeamsKit, you'll need to configure the API permissions and OAuth redirect URL associated with your Microsoft Teams bot in the Microsoft Entra admin center.
+To use TeamsKit, you'll need to configure the API permissions and OAuth redirect URL associated with a Graph API-enabled application in the Microsoft Entra admin center. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's app registration.
 
 <Steps titleSize="h3">
-  <Step title="Find your bot in the Microsoft Entra admin center">
-    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Identity** > **Applications** > **App registrations**, and locate your bot.
+  <Step title="Find your application in the Microsoft Entra admin center">
+    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Entra ID** > **App registrations**, and locate your application.
   </Step>
-  <Step title="Add a redirect URL">
-    On your bot's app registration page, click **Authentication**. Under **Platform configurations**, click **Add a platform** and select **Web**.
+  <Step title="Configure OAuth">
+    On your app's registration page, click **Authentication**. Under **Platform configurations**, click **Add a platform** and select **Web**.
 
     Copy and paste the following URL into the **Redirect URI** text field:
 
@@ -128,7 +136,9 @@ To use TeamsKit, you'll need to configure the API permissions and OAuth redirect
 
     This will allow Knock to handle the OAuth redirect on behalf of your bot, and manage connecting a Microsoft Entra tenant to a Knock tenant.
 
-    Leave the **Front-channel logout URL** text field empty. Click **Configure** to save your changes.
+    Under **Supported account types**, select **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
+
+    Click **Configure** to save your changes.
 
   </Step>
   <Step title="Add API permissions">

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -134,7 +134,7 @@ To use TeamsKit, you'll need to configure the API permissions and OAuth redirect
       content="https://api.knock.app/providers/ms-teams/authenticate"
     />
 
-    This will allow Knock to handle the OAuth redirect on behalf of your bot, and manage connecting a Microsoft Entra tenant to a Knock tenant.
+    This will allow Knock to handle the OAuth redirect on behalf of your application, and manage connecting a Microsoft Entra tenant to a Knock tenant.
 
     Under **Supported account types**, select **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -146,7 +146,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container
 <MsTeamsAuthButton
-    msTeamsBotId="Microsoft Teams bot ID"
+    graphApiClientId="Microsoft Graph API client ID"
     redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
 />
 
@@ -154,7 +154,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 <MsTeamsAuthContainer
     actionButton={
         <MsTeamsAuthButton
-            msTeamsBotId="Microsoft Teams bot ID"
+            graphApiClientId="Microsoft Graph API client ID"
             redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
         />
     }

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -247,7 +247,7 @@ export class TeamsBot extends TeamsActivityHandler {
 
 Here, `KNOCK_MS_TEAMS_CHANNEL_ID` is the channel ID of your Microsoft Teams integration within Knock. `getKnockUserIdFromEmailAddress` is a function that you'll need to implement to look up a Knock `User` ID in your application's database for a given email address. How you get this ID depends upon your specific application.
 
-Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your Graph API-enabled app in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra-in-microsoft-entra).
+Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your Graph API-enabled app in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra).
 
 ## Triggering a workflow
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -141,7 +141,7 @@ The `KnockMsTeamsProvider` gives your components access to the status of the con
   </figcaption>
 </figure>
 
-Your users will give your Microsoft Teams bot access to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
+Your users will connect your Microsoft Teams bot to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
 
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container
@@ -247,7 +247,7 @@ export class TeamsBot extends TeamsActivityHandler {
 
 Here, `KNOCK_MS_TEAMS_CHANNEL_ID` is the channel ID of your Microsoft Teams integration within Knock. `getKnockUserIdFromEmailAddress` is a function that you'll need to implement to look up a Knock `User` ID in your application's database for a given email address. How you get this ID depends upon your specific application.
 
-Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your bot in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configuring-your-bot-in-microsoft-entra).
+Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your Graph API-enabled app in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra-in-microsoft-entra).
 
 ## Triggering a workflow
 

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -201,7 +201,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container
 <MsTeamsAuthButton
-    msTeamsBotId="Microsoft Teams bot ID"
+    graphApiClientId="Microsoft Graph API client ID"
     redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
 />
 
@@ -209,7 +209,7 @@ Your users will give your Microsoft Teams bot access to their own Microsoft Entr
 <MsTeamsAuthContainer
     actionButton={
         <MsTeamsAuthButton
-            msTeamsBotId="Microsoft Teams bot ID"
+            graphApiClientId="Microsoft Graph API client ID"
             redirectUrl="The URL of your application to return to once Microsoft Teams authorization is complete"
         />
     }

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -196,7 +196,7 @@ The `KnockMsTeamsProvider` gives your components access to the status of the con
   </figcaption>
 </figure>
 
-Your users will give your Microsoft Teams bot access to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
+Your users will connect your Microsoft Teams bot to their own Microsoft Entra tenants via the `MsTeamsAuthButton`. This button can be used on its own, or nested in the `MsTeamsAuthContainer` for a bigger visual footprint. Here's an example of how to use them:
 
 ```javascript title="Initiate OAuth and display auth state with MsTeamsAuthButton"
 // Without container


### PR DESCRIPTION
### Description

This PR updates the Microsoft Teams docs to replace references to bot credentials with Graph API-enabled application credentials wherever applicable. After knocklabs/control#5573 is released, TeamsKit will use two new channel settings, “Graph API client ID” and “Graph API client secret”, instead of the MS Teams bot’s own credentials.

### Tasks

[KNO-9264](https://linear.app/knock/issue/KNO-9264/docs-update-teamskit-docs-to-describe-new-graph-api-app-credentials)