### PR TITLE
chore: fix key for expo silent push

### DIFF
--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -48,7 +48,7 @@ When sending a notification to Expo, we also pass through the following attribut
 
 We support sending Expo notifications as "silent," data-only notifications within Knock. You can enable this per push notification template by clicking the gear icon (⚙️) at the top of the template editor to open the template settings modal.
 
-When silent push is enabled, we'll no longer pass through the content payload and your message will be sent with the `content-available: true` flag as expected by Expo. All properties in the data payload described above will be sent with your notification.
+When silent push is enabled, we'll no longer pass through the content payload and your message will be sent with the `_contentAvailable: true` flag as expected by Expo. All properties in the data payload described above will be sent with your notification.
 
 ## Using overrides to customize notifications
 


### PR DESCRIPTION
### Description

This PR updates the Expo "silent" push documentation to reflect the changes made in KNO-9285 to send the correct key (`_contentAvailable`) for silent push. 
