### PR TITLE
chore: add MCP email migration tutorial

### DIFF
--- a/content/tutorials/migrate-email-with-mcp-server.mdx
+++ b/content/tutorials/migrate-email-with-mcp-server.mdx
@@ -15,7 +15,7 @@ tags:
 section: Tutorials
 ---
 
-Storing your email templates in Knock comes with [many advantages](/designing-workflows/template-editor/overview#frequently-asked-questions). In this guide, we'll walk you through how to leverage Knock's [MCP server](/developer-tools/mcp-server) with the large language model (LLM) of your choice as a low-effort solution to quickly migrate your email templates to Knock.
+Storing your email templates in Knock comes with [many advantages](/designing-workflows/template-editor/overview#frequently-asked-questions). In this tutorial, we'll walk you through how to leverage Knock's [MCP server](/developer-tools/mcp-server) with the large language model (LLM) of your choice as a low-effort solution to quickly migrate your email templates to Knock.
 
 ## Prerequisites
 
@@ -25,14 +25,14 @@ Before getting started, you'll need access to the following:
 - A configured [email provider](/integrations/email/overview) in your Knock account. Navigate to **Integrations** > **Channels** in your dashboard to set this up if you haven't already done so.
 - A [service token](https://docs.knock.app/developer-tools/service-tokens) for your Knock account.
 - An MCP-compatible client (such as Cursor or Claude Desktop). We recommend Cursor for working with a large collection of HTML files.
-- For the purposes of this guide, we will assume that you're familiar with prompting an agentic LLM and understand how to provide access to files as context for your prompts. If you're not sure what this means, we recommend checking out this <a href="https://docs.cursor.com/en/guides/working-with-context" target="_blank">guide on working with context</a> from Cursor.
+- For the purposes of this tutorial, we will assume that you're familiar with prompting an agentic LLM and understand how to provide access to files as context for your prompts. If you're not sure what this means, we recommend checking out this <a href="https://docs.cursor.com/en/guides/working-with-context" target="_blank">guide on working with context</a> from Cursor.
 - Your existing email template files. Your templates will be upserted to Knock as HTML, so if you're using a format like MJML or React Email, you'll want to convert them to HTML before you begin.
 
 For more information on setting up the Knock MCP server, see the [Get started](/developer-tools/mcp-server#get-started) section of the MCP documentation.
 
 ### Required MCP tools
 
-When working with MCP servers, it's recommended that you expose only the tools you need for your use case to your LLM. The steps in this guide will require access to the following tools:
+When working with MCP servers, it's recommended that you expose only the tools you need for your use case to your LLM. The steps in this tutorial will require access to the following tools:
 
 - `documentation.*`
 - `channels.*`

--- a/data/sidebars/tutorialsSidebar.ts
+++ b/data/sidebars/tutorialsSidebar.ts
@@ -50,6 +50,6 @@ export const TUTORIALS_SIDEBAR: SidebarContent[] = [
   },
   {
     slug: `${baseSlug}/migrate-email-with-mcp-server`,
-    title: "MCP for email template migration",
+    title: "Email template migration",
   },
 ];


### PR DESCRIPTION
### Description

This PR introduces a new tutorial to walk a user through using the Knock MCP server to migrate their existing email templates into Knock.

https://docs-iobz43has-knocklabs.vercel.app/tutorials/migrate-email-with-mcp-server

### Todos

- [x] Test prompts against a real set of email templates
- [x] Blocked by fix on MCP tool to create/update user 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new tutorial on migrating email templates to Knock using the MCP server and links it in the Tutorials sidebar.
> 
> - **Docs**:
>   - **New tutorial**: `content/tutorials/migrate-email-with-mcp-server.mdx` detailing how to migrate email templates to Knock using the MCP server, including prerequisites, required tools, step-by-step prompts, verification, and testing.
> - **Navigation**:
>   - **Sidebar**: Adds entry in `data/sidebars/tutorialsSidebar.ts` with slug `tutorials/migrate-email-with-mcp-server` titled "Email template migration".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 636a9703aacb9a1351ef156bd5f1beb23161bf1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->