### PR TITLE
chore: add supported destinations to warehouse sync docs

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -33,20 +33,20 @@ We currently support the following destination database types:
 
 | Vendor            | Type           |
 | ----------------- | -------------- |
-| `snowflake`       | OLAP           |
-| `bigquery`        | OLAP           |
-| `redshift`        | OLAP           |
-| `databricks`      | OLAP           |
 | `athena`          | OLAP           |
+| `bigquery`        | OLAP           |
 | `clickhouse`      | OLAP           |
-| `postgres`        | OLTP           |
+| `databricks`      | OLAP           |
+| `redshift`        | OLAP           |
+| `snowflake`       | OLAP           |
+| `aurora_mysql`    | OLTP           |
 | `aurora_postgres` | OLTP           |
 | `mysql`           | OLTP           |
-| `aurora_mysql`    | OLTP           |
+| `postgres`        | OLTP           |
+| `abs`             | Object storage |
+| `gcs`             | Object storage |
 | `s3`              | Object storage |
 | `s3_compatible`   | Object storage |
-| `gcs`             | Object storage |
-| `abs`             | Object storage |
 | `google_sheets`   | Spreadsheet    |
 
 ## Available data

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -21,11 +21,33 @@ You can bring your notification analytics from Knock into your own data warehous
 
 ## Connecting your data warehouse
 
-Please [contact our support team](mailto:support@knock.app) to get started with the warehouse connection process. Your message should include the destination type of the warehouse that you'd like to connect; supported types are listed <a href="https://docs.prequel.co/docs/destinations-overview#supported-destinations" target="_blank">here</a>. You should also specify which of the tables you'd like to sync from the available data listed below.
+Please [contact our support team](mailto:support@knock.app) to get started with the warehouse connection process. Your message should include the [destination type](#supported-destinations) of the warehouse that you'd like to connect, as well as which of the tables you'd like to sync from the [available data](#available-data) listed below.
 
 We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard that will guide you through the remainder of the setup process.
 
 Upon successful connection, your first data sync will include a backfill of historical data. You will receive up-to-date data once every 24 hours after the initial backfill.
+
+## Supported destinations
+
+We currently support the following destination database types:
+
+| Vendor            | Type           |
+| ----------------- | -------------- |
+| `snowflake`       | OLAP           |
+| `bigquery`        | OLAP           |
+| `redshift`        | OLAP           |
+| `databricks`      | OLAP           |
+| `athena`          | OLAP           |
+| `clickhouse`      | OLAP           |
+| `postgres`        | OLTP           |
+| `aurora_postgres` | OLTP           |
+| `mysql`           | OLTP           |
+| `aurora_mysql`    | OLTP           |
+| `s3`              | Object storage |
+| `s3_compatible`   | Object storage |
+| `gcs`             | Object storage |
+| `abs`             | Object storage |
+| `google_sheets`   | Spreadsheet    |
 
 ## Available data
 


### PR DESCRIPTION
### Description

This PR adds a table of Prequel-supported warehouse destination types to our docs so that our customers don't need to click through to Prequel documentation. For now, this list does not include types that are in beta status.

https://docs-git-mk-kno-9345-knocklabs.vercel.app/integrations/extensions/data-sync

Original list for comparison: https://docs.prequel.co/docs/destinations-overview#supported-destinations 

### Questions

1. Right now these are in the same order as Prequel lists them (loosely organized by "type" of destination). Would it be better to simply list them alphabetically?
2. Do we want to include destinations that are marked as "beta" on Prequel? These are theoretically available, but mileage may vary pending any unforeseen issues Prequel-side.