### PR TITLE
fix(KNO-9350): fix docs for CLI push and pull all commands

### DIFF
--- a/content/cli.mdx
+++ b/content/cli.mdx
@@ -114,7 +114,7 @@ The following flags are supported for every command.
 
 Pulls the contents of all Knock resources (workflows, partials, email layouts, and translations) from Knock into your local file system.
 
-Resources will be grouped by resource type within subdirectories of the target directory path set by the `--workflows-dir` flag. For example, invoking `knock pull --workflows-dir=./knock` will create the following directory structure:
+Resources will be grouped by resource type within subdirectories of the target directory path set by the `--knock-dir` flag. For example, invoking `knock pull --knock-dir=./knock` will create the following directory structure:
 
 {/* prettier-ignore */}
 <PreTextDiagram description="Directory structure created by the knock pull command">
@@ -134,7 +134,7 @@ Resources will be grouped by resource type within subdirectories of the target d
     description="The environment to use. Defaults to development."
   />
   <Attribute
-    name="--workflows-dir"
+    name="--knock-dir"
     type="directory"
     description="The target directory path to pull all resources into."
   />
@@ -154,7 +154,7 @@ Resources will be grouped by resource type within subdirectories of the target d
 <ExampleColumn>
 
 ```bash title="Pull all resources"
-knock pull --workflows-dir=./knock
+knock pull --knock-dir=./knock
 ```
 
 </ExampleColumn>
@@ -169,7 +169,7 @@ Pushes all local resource files (workflows, partials, email layouts, and transla
 
 <Attributes>
   <Attribute
-    name="--workflows-dir"
+    name="--knock-dir"
     type="directory"
     description="The target directory path to push all resources from."
   />
@@ -189,7 +189,7 @@ Pushes all local resource files (workflows, partials, email layouts, and transla
 <ExampleColumn>
 
 ```bash title="Push all resources"
-knock push --workflows-dir=./knock
+knock push --knock-dir=./knock
 ```
 
 </ExampleColumn>

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -59,10 +59,6 @@ Knock will automatically expose the following variables to the broadcast builder
 
 You can access the broadcast state in the broadcast builder by toggling the state pane. All of these variables are also available [in the template editor](/designing-workflows/template-editor/variables).
 
-### Per-recipient data
-
-When you upload a CSV of users to a broadcast, you can map any columns of your CSV to either the "User" or "Broadcast" schema. When you map them to the user, these properties will be persisted to the user object in Knock. When you map them to the broadcast, these properties will be available in the template editor for this broadcast only and cannot be reused in other broadcasts. You can access these properties in the template editor by using the `data` variable as you would with workflow data.
-
 ## Scheduling broadcasts
 
 Broadcasts can optionally be scheduled to send at a specific time. When a broadcast is scheduled, you will see the status of the broadcast reflected as scheduled on the date and time you specified. Scheduled broadcasts can be canceled before they are sent, should you wish to make any changes.

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -59,6 +59,10 @@ Knock will automatically expose the following variables to the broadcast builder
 
 You can access the broadcast state in the broadcast builder by toggling the state pane. All of these variables are also available [in the template editor](/designing-workflows/template-editor/variables).
 
+### Per-recipient data
+
+When you upload a CSV of users to a broadcast, you can map any columns of your CSV to either the "User" or "Broadcast" schema. When you map them to the user, these properties will be persisted to the user object in Knock. When you map them to the broadcast, these properties will be available in the template editor for this broadcast only and cannot be reused in other broadcasts. You can access these properties in the template editor by using the `data` variable as you would with workflow data.
+
 ## Scheduling broadcasts
 
 Broadcasts can optionally be scheduled to send at a specific time. When a broadcast is scheduled, you will see the status of the broadcast reflected as scheduled on the date and time you specified. Scheduled broadcasts can be canceled before they are sent, should you wish to make any changes.


### PR DESCRIPTION
### Description

It appears #1046 mistakenly updated the docs describing the `knock push` and `knock pull` (i.e. push and pull all commands), replacing the `--knock-dir` command line flag with `--workflows-dir`. [This comment](https://github.com/knocklabs/docs/pull/1046#discussion_r2226671505) seems to imply this was intentional, but [`--workflows-dir` is not a valid flag for the `pull` and `push` commands](https://github.com/knocklabs/knock-cli/blob/b1a044afda7d73baf9fef7c4d13f803d37a5fb1f/src/commands/pull.ts#L24).

So, this PR reverts those updates. I’ll check in with Meryl re. her comment.

### Tasks

[KNO-9350](https://linear.app/knock/issue/KNO-9350/docs-fix-docs-for-cli-push-and-pull-all-commands)
