### PR TITLE
chore: clarify segment identify event mapping

### DIFF
--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -113,7 +113,7 @@ Triggers are automatically enabled when you create them. If you want to stop an 
 
 ## Enabling Identify events
 
-When Segment sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `id`, `email`, `phone`, `avatar`, `name`, and any other custom properties.
+When Segment sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `userId` as the user's `id`, as well as `name`, `email`, `phone_number`, `avatar`, `locale`, `timezone`, and any additional custom properties provided in the `traits` object.
 
 To enable the handling of identify events, open the settings for the source in the environment. You can then enable or disable handling identify events accordingly.
 


### PR DESCRIPTION
### Description

This PR attempts to clarify expected mapping of traits from a Segment `Identify` event to a user in Knock.
