### PR TITLE
chore: add breaking change to tenants page + python migration guide

### DIFF
--- a/content/developer-tools/migration-guides/python.mdx
+++ b/content/developer-tools/migration-guides/python.mdx
@@ -247,6 +247,42 @@ client.objects.set(
 ```
 
   </Accordion>
+  <Accordion title="Working with tenants">
+    **Old SDK:**
+
+```python title="Setting tenant properties with the old SDK"
+client.tenants.set(
+  id="jurassic-park",
+  name="Jurassic Park",
+  logo_url="https://example.com/jp-logo.png",
+  settings={
+    "branding": {
+      "primary_color": "#FF6B35",
+      "logo_url": "https://example.com/jp-logo.png"
+    }
+  }
+)
+```
+
+**New SDK:**
+
+```python title="Setting tenant properties with the new SDK"
+client.tenants.set(
+  id="jurassic-park",
+  settings={
+    "branding": {
+      "primary_color": "#FF6B35",
+      "logo_url": "https://example.com/jp-logo.png"
+    }
+  },
+  extra_body={
+    "name": "Jurassic Park",
+    "logo_url": "https://example.com/jp-logo.png"
+  }
+)
+```
+
+  </Accordion>
 </AccordionGroup>
 
 ## Need help?

--- a/data/sidebars/tutorialsSidebar.ts
+++ b/data/sidebars/tutorialsSidebar.ts
@@ -40,8 +40,4 @@ export const TUTORIALS_SIDEBAR: SidebarContent[] = [
     slug: `${baseSlug}/modeling-users-objects-and-tenants`,
     title: "Modeling Users, Objects, and Tenants",
   },
-  {
-    slug: `${baseSlug}/launchdarkly-knock`,
-    title: "Using LaunchDarkly with Knock to A/B test messaging",
-  },
 ];


### PR DESCRIPTION
Added documentation for a breaking change in the Python SDK's tenant management API. The new example shows how to migrate from the old SDK's direct property setting to the new SDK's `extra_body` parameter approach for tenant `name` and custom properties.

Changes:
- Added "Working with tenants" accordion section to Python migration guide
- Added callout about breaking change to tenants concept page
- [Unrelated] Removed duplicative copy from Batch concept page