### PR TITLE
chore(kno-9469): add callout on CSV data upsert type

### DIFF
--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -63,6 +63,20 @@ You can access the broadcast state in the broadcast builder by toggling the stat
 
 When you upload a CSV of users to a broadcast, you can map any columns of your CSV to either the "User" or "Broadcast" schema. When you map them to the user, these properties will be persisted to the user object in Knock. When you map them to the broadcast, these properties will be available in the template editor for this broadcast only and cannot be reused in other broadcasts. You can access these properties in the template editor by using the `data` variable as you would with workflow data.
 
+<Callout
+  emoji="⚠️"
+  bgColor="yellow"
+  title="Note:"
+  text={
+    <>
+      Due to the nature of the CSV format, all data values (user or broadcast)
+      that are upserted via CSV as part of a broadcast will be treated as
+      strings. You'll need to account for this when using your data in your
+      templates or conditions.
+    </>
+  }
+/>
+
 ## Scheduling broadcasts
 
 Broadcasts can optionally be scheduled to send at a specific time. When a broadcast is scheduled, you will see the status of the broadcast reflected as scheduled on the date and time you specified. Scheduled broadcasts can be canceled before they are sent, should you wish to make any changes.


### PR DESCRIPTION
### Description

This PR adds a callout to the Broadcast concept page to make clear that all data upserted via CSV will be strings.

<img width="500" height="563" alt="image" src="https://github.com/user-attachments/assets/2974b066-493d-417f-a20c-39f3a96f9106" />

