### PR TITLE
fix(kno-9514): remove outdated help references

### DIFF
--- a/content/in-app-ui/android/sdk/overview.mdx
+++ b/content/in-app-ui/android/sdk/overview.mdx
@@ -26,7 +26,7 @@ Our Android SDK is worked on full-time by the Knock Mobile team.
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/knock-android/issues/new)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/expo/sdk/overview.mdx
+++ b/content/in-app-ui/expo/sdk/overview.mdx
@@ -151,7 +151,7 @@ Ask questions and find answers on the following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/javascript/issues/new)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/flutter/sdk/overview.mdx
+++ b/content/in-app-ui/flutter/sdk/overview.mdx
@@ -32,7 +32,7 @@ Ask questions and find answers on the following platforms:
 
 ### Provide feedback
 
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/ios/sdk/overview.mdx
+++ b/content/in-app-ui/ios/sdk/overview.mdx
@@ -26,7 +26,7 @@ Our Swift SDK is worked on full-time by the Knock Mobile team.
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/knock-swift/issues/new)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/javascript/sdk/overview.mdx
+++ b/content/in-app-ui/javascript/sdk/overview.mdx
@@ -37,7 +37,7 @@ Ask questions and find answers on the following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/javascript/issues)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/react-native/sdk/overview.mdx
+++ b/content/in-app-ui/react-native/sdk/overview.mdx
@@ -51,7 +51,7 @@ Ask questions and find answers on the following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/javascript/issues/new)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/in-app-ui/react/sdk/overview.mdx
+++ b/content/in-app-ui/react/sdk/overview.mdx
@@ -55,7 +55,7 @@ Ask questions and find answers on those following platforms:
 ### Provide feedback
 
 - [Open an issue](https://github.com/knocklabs/javascript/issues/new)
-- Use the "Help" dropdown at the top of this page to contact support.
+- Click the "Contact support" button at the top of this page to reach our support team.
 
 ### Contributing
 

--- a/content/manage-your-account/data-retention.mdx
+++ b/content/manage-your-account/data-retention.mdx
@@ -16,7 +16,8 @@ Knock applies a retention policy to some of the data within your account. Once d
   text={
     <>
       If custom retention windows are critical to your usage of Knock, please
-      use the "Help" dropdown at the top of this page to contact support.
+      click the "Contact support" button at the top of this page to reach our
+      support team.
     </>
   }
 />


### PR DESCRIPTION
### Description

This PR removes outdated references to a "Help" dropdown to contact support from throughout the docs.
