### PR TITLE
chore: clarify identify events for segment and rudderstack

### DIFF
--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -91,9 +91,42 @@ Triggers are automatically enabled when you create them. If you want to stop an 
 
 ## Enabling Identify Events
 
-When RudderStack sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `id`, `email`, `phone`, `avatar`, `name`, and any other custom properties over.
+When RudderStack sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `userId` as the user's `id`, as well as `name`, `email`, `phone` (mapped as `phone_number` in Knock), `avatar`, `locale`, `timezone`, and any additional custom properties provided in the `traits` object.
 
-To enable handling of identify events, open the settings for the source in the environment. You can then enable or disable handling identify events accordingly.
+<Callout
+  emoji="⚠️"
+  title="Note:"
+  bgColor="yellow"
+  text={
+    <>
+      RudderStack's default <code>Identify</code>{" "}
+      <a
+        href="https://www.rudderstack.com/docs/event-spec/standard-events/identify/"
+        target="_blank"
+      >
+        event schema
+      </a>{" "}
+      has the <code>traits</code> object nested under a top-level{" "}
+      <code>context</code> key.{" "}
+      <a
+        href="https://www.rudderstack.com/docs/event-spec/standard-events/identify/#identify-traits"
+        target="_blank"
+      >
+        Some RudderStack SDKs
+      </a>{" "}
+      will also include a top-level <code>traits</code> object.
+      <br />
+      <br />
+      Knock expects user properties to be contained in a top-level <code>
+        traits
+      </code> object when processing an <code>Identify</code> event, so you may need
+      to apply a data transformation prior to sending these events to Knock depending
+      on which SDK you're using.
+    </>
+  }
+/>
+
+To enable handling of identify events, open the settings for the source in the relevant Knock environment. You can then enable or disable handling identify events accordingly.
 
 <Image
   src="/images/integrations/sources/rudderstack-identify.png"

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -113,9 +113,9 @@ Triggers are automatically enabled when you create them. If you want to stop an 
 
 ## Enabling Identify events
 
-When Segment sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `userId` as the user's `id`, as well as `name`, `email`, `phone_number`, `avatar`, `locale`, `timezone`, and any additional custom properties provided in the `traits` object.
+When Segment sends identify events, Knock will create and update user information accordingly. Knock will correctly map the `userId` as the user's `id`, as well as `name`, `email`, `phone` (mapped as `phone_number` in Knock), `avatar`, `locale`, `timezone`, and any additional custom properties provided in the `traits` object.
 
-To enable the handling of identify events, open the settings for the source in the environment. You can then enable or disable handling identify events accordingly.
+To enable the handling of identify events, open the settings for the source in the relevant Knock environment. You can then enable or disable handling identify events accordingly.
 
 <Image
   src="/images/integrations/sources/segment-identify.png"


### PR DESCRIPTION
### Description

This PR updates our Segment and RudderStack integration docs for `Identify` events to clarify the mapping of `phone` -> `phone_number` in Knock, and to call out the requirement for a top-level `traits` object to map user properties into Knock (the RudderStack `Identify` event has these under `context.traits`)

- [Segment](https://docs-git-mk-kno-9552-knocklabs.vercel.app/integrations/sources/segment#enabling-identify-events)
- [RudderStack](https://docs-git-mk-kno-9552-knocklabs.vercel.app/integrations/sources/rudderstack#enabling-identify-events)