### PR TITLE
chore: update terminology to remove "guide"

### DIFF
--- a/content/__api-reference/content.mdx
+++ b/content/__api-reference/content.mdx
@@ -79,7 +79,7 @@ Each endpoint in the Knock API is rate limited. Knock uses a tier system to dete
   }
 />
 
-Knock's default behavior scopes rate limits based on the authorizing credential used in your requests. When you use a public or private API key to authorize a request, Knock will scope the rate limit for each endpoint by the [environment](/concepts/environments) associated with the key. If you use a signed user token as your authorizing credential, Knock will scope the rate limit by both the key's environment and the signing user. See our guide on [enhanced security mode](/in-app-ui/security-and-authentication#authentication-with-enhanced-security) for more details on working with signed user tokens.
+Knock's default behavior scopes rate limits based on the authorizing credential used in your requests. When you use a public or private API key to authorize a request, Knock will scope the rate limit for each endpoint by the [environment](/concepts/environments) associated with the key. If you use a signed user token as your authorizing credential, Knock will scope the rate limit by both the key's environment and the signing user. See our documentation on [enhanced security mode](/in-app-ui/security-and-authentication#authentication-with-enhanced-security) for more details on working with signed user tokens.
 
 If you're concerned about exceeding a Knock rate limit, please [contact us](https://knock.app/contact-sales) and we can help figure out a usage rate that's right for your specific needs.
 

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -93,7 +93,7 @@ Sent broadcasts include a recipient summary that highlights key delivery and eng
 - **Read**: The number of messages that were opened and read by the recipient at least once.
 - **Interacted**: The number of messages that were interacted with (e.g. the recipient clicked a link).
 
-To learn more, see our [message statuses guide](/send-notifications/message-statuses).
+To learn more, see our [message status documentation](/send-notifications/message-statuses).
 
 <Image
   src="/images/concepts/broadcasts/broadcast_analytics_summary.png"

--- a/content/concepts/channels.mdx
+++ b/content/concepts/channels.mdx
@@ -26,7 +26,7 @@ You can create and manage channels within Knock from the dashboard under the **I
 
 ## Channel settings
 
-For each channel you create in the Knock dashboard, you will need to configure the channel per environment for it to be valid. Each provider requires different configuration data, and you can see the required settings in the [integrations guide](/integrations/overview).
+For each channel you create in the Knock dashboard, you will need to configure the channel per environment for it to be valid. Each provider requires different configuration data, and you can see the required settings in the [integrations documentation](/integrations/overview).
 
 Given that channel configuration is **per-environment** this makes it possible to have separate settings for your testing/sandbox environments vs your production environments. Channel settings can easily be cloned across environments when needed.
 

--- a/content/concepts/channels.mdx
+++ b/content/concepts/channels.mdx
@@ -26,7 +26,7 @@ You can create and manage channels within Knock from the dashboard under the **I
 
 ## Channel settings
 
-For each channel you create in the Knock dashboard, you will need to configure the channel per environment for it to be valid. Each provider requires different configuration data, and you can see the required settings in the [integrations documentation](/integrations/overview).
+For each channel you create in the Knock dashboard, you will need to configure the channel per environment for it to be valid. Each provider requires different configuration data, and you can see the required settings in the [integrations overview](/integrations/overview).
 
 Given that channel configuration is **per-environment** this makes it possible to have separate settings for your testing/sandbox environments vs your production environments. Channel settings can easily be cloned across environments when needed.
 

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -49,7 +49,7 @@ Knock's shared conditions model supports the following types of conditions:
       conditions. You can learn more about how to work with message status
       conditions in our{" "}
       <a href="/designing-workflows/step-conditions">
-        guide on step-level conditions
+        documentation on step-level conditions
       </a>
       .
     </>

--- a/content/concepts/guides.mdx
+++ b/content/concepts/guides.mdx
@@ -50,7 +50,7 @@ Guides include an analytics summary that highlights key metrics over the last N 
 - **Interacted**: The number of users who interacted with this guide.
 - **Archived**: The number of users who archived this guide.
 
-To learn more, see our [message statuses guide](/send-notifications/message-statuses).
+To learn more, see our [message status documentation](/send-notifications/message-statuses).
 
 ## Learn more
 

--- a/content/concepts/messages.mdx
+++ b/content/concepts/messages.mdx
@@ -42,10 +42,10 @@ Messages have two types of statuses. These are:
 
 Knock captures changes in message status as events that can be sent to [outbound webhooks](/developer-tools/outbound-webhooks/overview).
 
-To learn more, see our [message statuses guide](/send-notifications/message-statuses).
+To learn more, see our [message status documentation](/send-notifications/message-statuses).
 
 ## Link and open tracking
 
 Knock provides opt-in, provider agnostic tracking capabilities for your notifications. With link tracking, Knock will capture link-click actions by your recipients as a message event. With open tracking, Knock will embed tracking pixels in email channel messages to help gauge when recipients are opening and reading your email notifications.
 
-To learn more, see the [Knock tracking guide](/send-notifications/tracking).
+To learn more, see the [Knock tracking documentation](/send-notifications/tracking).

--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -7,7 +7,7 @@ section: Concepts
 
 An [Object](/api-reference/objects) represents a resource in your system that you want to map into Knock.
 
-In this guide we'll walk through how to use objects for a few different use cases in Knock.
+In this documentation we'll walk through how to use objects for a few different use cases in Knock.
 
 We'll start with an overview of objects and how to use them, then we'll walk through two common use cases for objects: Slack channel notifications and handling mutable data on long-running notifications (such as digests).
 

--- a/content/concepts/objects.mdx
+++ b/content/concepts/objects.mdx
@@ -139,7 +139,7 @@ Or, we can load an object by a dynamic identifier. For example, if we have a wor
 
 Once an object is loaded into a template, you can reference any of the properties of that object using the dot notation.
 
-You can read more about referencing data in templates in our [guide on referencing data in templates](/designing-workflows/template-editor/referencing-data).
+You can read more about referencing data in templates in our [documentation on referencing data in templates](/designing-workflows/template-editor/referencing-data).
 
 ## Examples
 

--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -37,8 +37,7 @@ Knock will preemptively schedule workflow runs for the recipient(s) that you've 
     <>
       Breaking changes to Schedules methods were introduced in the v1.0 release
       of the Knock SDKs. Learn more about the new syntax in the{" "}
-      <a href="/developer-tools/migration-guides/node">SDK migration manuals</a>
-      .
+      <a href="/developer-tools/migration-guides/node">SDK migration manuals</a>.
     </>
   }
 />

--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -37,7 +37,8 @@ Knock will preemptively schedule workflow runs for the recipient(s) that you've 
     <>
       Breaking changes to Schedules methods were introduced in the v1.0 release
       of the Knock SDKs. Learn more about the new syntax in the{" "}
-      <a href="/developer-tools/migration-guides/node">SDK migration guides</a>.
+      <a href="/developer-tools/migration-guides/node">SDK migration manuals</a>
+      .
     </>
   }
 />

--- a/content/concepts/tenants.mdx
+++ b/content/concepts/tenants.mdx
@@ -136,7 +136,7 @@ the `id` of the tenant.
 Tagging messages by the tenant makes it possible to query for tenant-specific
 messages in both the API and the dashboard. We also expose this behavior for
 in-app feed messages, making it possible to expose per-user, per-tenant feeds
-([see below for an expanded guide](#scoping-in-app-feeds) on this usecase).
+([see below for additional information](#scoping-in-app-feeds) on this use case).
 
 ## Working with tenants in the Knock dashboard
 
@@ -249,7 +249,7 @@ Another advanced tenancy use case is managing different sets of preferences for 
 
 We also support the ability to set per-tenant defaults, where an admin in a tenant within your product can set the default preferences for all users within that tenant.
 
-You can learn more about how to set per-tenant preferences and tenant preference defaults in [our preferences guide](/preferences/tenant-preferences).
+You can learn more about how to set per-tenant preferences and tenant preference defaults in [our preferences documentation](/preferences/tenant-preferences).
 
 ## Frequently asked questions
 

--- a/content/concepts/tenants.mdx
+++ b/content/concepts/tenants.mdx
@@ -150,7 +150,7 @@ Tenant data is also exposed in the Knock dashboard. From the dashboard it's poss
 
 You can find tenant information under the "Tenants" section in the left-hand menu of the dashboard.
 
-## Guides for using tenants
+## Using tenants
 
 ### Scoping in-app feeds
 

--- a/content/designing-workflows/batch-function.mdx
+++ b/content/designing-workflows/batch-function.mdx
@@ -16,7 +16,7 @@ Here's a step-by-step breakdown of how a batch function works:
 
 - When a given per-recipient workflow run hits a batch step, the batch function will stay open for an interval of time which you define (the [batch window](#setting-the-batch-window)).
 - While that interval is open, the batch function aggregates any additional incoming triggers **for that recipient**. If a [batch key](#selecting-a-batch-key) is provided in your batch step, the incoming triggers **for that recipient** will be grouped into **separate batches based on batch key.**
-- When the batch window interval closes, the workflow continues to the next step, with the data collected in the batch available in the workflow run scope. You can read more in the ["using batch variables" section](#using-batch-variables) of this guide.
+- When the batch window interval closes, the workflow continues to the next step, with the data collected in the batch available as [variables](#using-batch-variables) in the workflow run scope.
 
 <Callout
   emoji="🌠"

--- a/content/designing-workflows/channel-step.mdx
+++ b/content/designing-workflows/channel-step.mdx
@@ -22,7 +22,7 @@ If the step continues, Knock will render [the template](/designing-workflows/tem
 
 ## Channel support
 
-You can read more about configuring channels in our [integrations documentation](/integrations/overview).
+You can read more about configuring channels in our [integrations overview](/integrations/overview).
 
 ### In-app notifications
 

--- a/content/designing-workflows/channel-step.mdx
+++ b/content/designing-workflows/channel-step.mdx
@@ -22,7 +22,7 @@ If the step continues, Knock will render [the template](/designing-workflows/tem
 
 ## Channel support
 
-You can read more about configuring channels in our [integrations guide](/integrations/overview).
+You can read more about configuring channels in our [integrations documentation](/integrations/overview).
 
 ### In-app notifications
 

--- a/content/designing-workflows/fetch-function.mdx
+++ b/content/designing-workflows/fetch-function.mdx
@@ -34,7 +34,7 @@ As with channel steps, you use the Knock template editor to configure the shape 
 
 Aside from the request method selector, each of the above fields is a Liquid-compatible input. This means you can use Liquid variables and control flow to inject variable data, access Knock-controlled workflow state attributes (e.g., `recipient`), and dynamically shape the request per workflow run.
 
-See the [Knock template editor reference](/send-notifications/designing-workflows/template-editor) for a detailed guide on working with Liquid templates in Knock.
+See the [Knock template editor reference](/send-notifications/designing-workflows/template-editor) for detailed information on working with Liquid templates in Knock.
 
 ## Request execution
 
@@ -167,7 +167,7 @@ If the request encounters an error, you can also expect to see details about the
   </figcaption>
 </figure>
 
-See the [guide on debugging workflows](/send-notifications/debugging-workflows) for more details about workflow debugging and run logs.
+See the [documentation on debugging workflows](/send-notifications/debugging-workflows) for more details about workflow debugging and run logs.
 
 ## Securing fetch requests
 

--- a/content/designing-workflows/overview.mdx
+++ b/content/designing-workflows/overview.mdx
@@ -49,7 +49,7 @@ A channel step sends a notification to a recipient. When the workflow engine rea
 
 Each channel has a notification template (designed by you in the Knock dashboard) which inserts the `data` from your trigger call into a [styled template](/send-notifications/designing-workflows/template-editor) for that step's given channel.
 
-You can add any of the major [channel types supported by Knock](/integrations/overview#supported-channel-providers) into your workflow. By default, we show all of our supported channel types, but you'll need to configure a provider with each channel before you can actually use them in a workflow. For more information on how to configure channels in your Knock account, see our [integration documentation](/integrations/overview).
+You can add any of the major [channel types supported by Knock](/integrations/overview#supported-channel-providers) into your workflow. By default, we show all of our supported channel types, but you'll need to configure a provider with each channel before you can actually use them in a workflow. For more information on how to configure channels in your Knock account, see our [integration overview](/integrations/overview).
 
 ### Function steps
 

--- a/content/designing-workflows/overview.mdx
+++ b/content/designing-workflows/overview.mdx
@@ -49,7 +49,7 @@ A channel step sends a notification to a recipient. When the workflow engine rea
 
 Each channel has a notification template (designed by you in the Knock dashboard) which inserts the `data` from your trigger call into a [styled template](/send-notifications/designing-workflows/template-editor) for that step's given channel.
 
-You can add any of the major [channel types supported by Knock](/integrations/overview#supported-channel-providers) into your workflow. By default, we show all of our supported channel types, but you'll need to configure a provider with each channel before you can actually use them in a workflow. For more information on how to configure channels in your Knock account, see our [integration guides](/integrations/overview).
+You can add any of the major [channel types supported by Knock](/integrations/overview#supported-channel-providers) into your workflow. By default, we show all of our supported channel types, but you'll need to configure a provider with each channel before you can actually use them in a workflow. For more information on how to configure channels in your Knock account, see our [integration documentation](/integrations/overview).
 
 ### Function steps
 

--- a/content/designing-workflows/step-conditions.mdx
+++ b/content/designing-workflows/step-conditions.mdx
@@ -23,9 +23,9 @@ Some examples of the kinds of step conditions you can design include:
 - Only execute a delay step if `delay == true` in the workflow trigger.
 - Only send an email in your development environment if the recipient's email matches a particular domain.
 
-See our [guide on the Knock conditions model](/concepts/conditions) for more information about how conditions work across Knock and how to [debug your conditions within your workflow runs](/concepts/conditions#debugging-conditions).
+See our [documentation on the Knock conditions model](/concepts/conditions) for more information about how conditions work across Knock and how to [debug your conditions within your workflow runs](/concepts/conditions#debugging-conditions).
 
-In this guide, we cover features specific to step conditions, most importantly message status conditions.
+This page covers features specific to step conditions, most importantly message status conditions.
 
 ## Types of step conditions
 

--- a/content/designing-workflows/template-editor/reference-liquid-helpers.mdx
+++ b/content/designing-workflows/template-editor/reference-liquid-helpers.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Liquid helpers"
-description: A reference guide to help you work with the Liquid templating language in Knock.
+description: A reference to help you work with the Liquid templating language in Knock.
 tags: ["liquid", "template", "variables", "currency", "timezone", "pluralize"]
 section: Designing workflows
 ---
 
-The Knock template editor uses Liquid syntax for control flow and variable declaration. Here are a few of the most common Liquid keywords our customers use within Knock. For a complete reference guide, we recommend the excellent [Liquid documentation](https://shopify.github.io/liquid/).
+The Knock template editor uses Liquid syntax for control flow and variable declaration. Here are a few of the most common Liquid keywords our customers use within Knock. We recommend referencing the [Liquid documentation](https://shopify.github.io/liquid/) for comprehensive syntax and usage information.
 
 | Keyword         | Description                                                                                             |
 | --------------- | ------------------------------------------------------------------------------------------------------- |

--- a/content/designing-workflows/template-editor/referencing-data.mdx
+++ b/content/designing-workflows/template-editor/referencing-data.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Referencing data in templates"
-description: A guide for working with data in your templates.
+description: Documentation outlining how to work with data in your templates.
 tags: ["liquid", "template", "objects", "users", "tenants"]
 section: Designing workflows
 ---

--- a/content/designing-workflows/template-editor/variables.mdx
+++ b/content/designing-workflows/template-editor/variables.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Template editor variables"
-description: "A reference guide for the variables available in the Knock template editor."
+description: "A reference for the variables available in the Knock template editor."
 tags: ["liquid", "template", "variables"]
 section: Designing workflows
 ---

--- a/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
+++ b/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
@@ -132,19 +132,19 @@ In the AI SDK, the `resumeToolExecution` method will return a tool status object
 
 ## Example: In-app approval flow
 
-In this guide we show you how to setup an approval flow that sends an in-app notification to a notification feed requesting approval when the agent wishes to invoke a particular tool.
+In this tutorial we show you how to set up an approval flow that sends an in-app notification to a notification feed requesting approval when the agent wishes to invoke a particular tool.
 
 <Steps>
   <Step title="Setting up a workflow to power approvals">
     To start, you'll want to setup a Knock workflow with a single, in-app feed channel step that sends an approval message to an in-app feed. You can find a workflow template for this in the [workflow templates repository](https://github.com/knocklabs/workflow-templates/tree/main/approve-tool-call).
   </Step>
   <Step title="Rendering the feed">
-    Next, you'll need to render the in-app feed in your application. You can find a guide on how to do this in the [building in-app feed guide](/in-app-ui/react/feed). By default, your in-app feed will handle the interaction on the "Approve" and "Reject" buttons and send the `message.interacted` event to Knock.
+    Next, you'll need to render the in-app feed in your application. You can find a tutorial on how to do this in the [building in-app feed documentation](/in-app-ui/react/feed). By default, your in-app feed will handle the interaction on the "Approve" and "Reject" buttons and send the `message.interacted` event to Knock.
   </Step>
   <Step title="Setting up an outbound webhook in Knock">
     A human-in-the-loop interaction is inherently an asynchronous action, and therefore requires that we might need to handle the approval at some later point. Knock uses [outbound webhooks](/developer-tools/outbound-webhooks/overview) to forward your events to your application, helping to implement this asynchronous behavior.
 
-    To set up an outbound webhook, you'll need to create a new webhook under **Platform** > **Webhooks** in the Knock dashboard. Add a URL for your service and select the `message.interacted` event. You can read more about the available [event types in our guide](/developer-tools/outbound-webhooks/event-types).
+    To set up an outbound webhook, you'll need to create a new webhook under **Platform** > **Webhooks** in the Knock dashboard. Add a URL for your service and select the `message.interacted` event. You can read more about the available [event types in our documentation](/developer-tools/outbound-webhooks/event-types).
 
   </Step>
   <Step title="Wrapping a tool as requiring human input">

--- a/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
+++ b/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
@@ -132,14 +132,14 @@ In the AI SDK, the `resumeToolExecution` method will return a tool status object
 
 ## Example: In-app approval flow
 
-In this tutorial we show you how to set up an approval flow that sends an in-app notification to a notification feed requesting approval when the agent wishes to invoke a particular tool.
+This example shows you how to set up an approval flow that sends an in-app notification to a notification feed requesting approval when the agent wishes to invoke a particular tool.
 
 <Steps>
   <Step title="Setting up a workflow to power approvals">
     To start, you'll want to setup a Knock workflow with a single, in-app feed channel step that sends an approval message to an in-app feed. You can find a workflow template for this in the [workflow templates repository](https://github.com/knocklabs/workflow-templates/tree/main/approve-tool-call).
   </Step>
   <Step title="Rendering the feed">
-    Next, you'll need to render the in-app feed in your application. You can find a tutorial on how to do this in the [building in-app feed documentation](/in-app-ui/react/feed). By default, your in-app feed will handle the interaction on the "Approve" and "Reject" buttons and send the `message.interacted` event to Knock.
+    Next, you'll need to render the in-app feed in your application. You can find documentation on how to do this in the [building in-app feed documentation](/in-app-ui/react/feed). By default, your in-app feed will handle the interaction on the "Approve" and "Reject" buttons and send the `message.interacted` event to Knock.
   </Step>
   <Step title="Setting up an outbound webhook in Knock">
     A human-in-the-loop interaction is inherently an asynchronous action, and therefore requires that we might need to handle the approval at some later point. Knock uses [outbound webhooks](/developer-tools/outbound-webhooks/overview) to forward your events to your application, helping to implement this asynchronous behavior.

--- a/content/developer-tools/agent-toolkit/overview.mdx
+++ b/content/developer-tools/agent-toolkit/overview.mdx
@@ -82,7 +82,7 @@ const classifyToolRequiringInput = toolkit.requireHumanInput(classifyWork, {
 });
 ```
 
-You can read more about [powering human-in-the-loop flows in the guide](/developer-tools/agent-toolkit/human-in-the-loop-flows).
+You can read more about [powering human-in-the-loop flows in the documentation](/developer-tools/agent-toolkit/human-in-the-loop-flows).
 
 ## Creating Knock resources
 

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -17,7 +17,7 @@ section: Developer Tools
 
 With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, Partials, and Translations between [environments](/concepts/environments) during testing and deployment.
 
-This guide assumes that you have [created](/concepts/environments#create-additional-environments) a “Staging” environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli/overview/installation) on your local machine.
+This tutorial assumes that you have [created](/concepts/environments#create-additional-environments) a "Staging" environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli/overview/installation) on your local machine.
 
 ## Local development
 

--- a/content/developer-tools/integrating-into-cicd.mdx
+++ b/content/developer-tools/integrating-into-cicd.mdx
@@ -17,7 +17,7 @@ section: Developer Tools
 
 With the [Knock CLI](/developer-tools/knock-cli), you can add Knock directly into your existing CI/CD pipeline in order to automate the promotion of changes to Workflows, Layouts, Partials, and Translations between [environments](/concepts/environments) during testing and deployment.
 
-This tutorial assumes that you have [created](/concepts/environments#create-additional-environments) a "Staging" environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli/overview/installation) on your local machine.
+This documentation assumes that you have [created](/concepts/environments#create-additional-environments) a "Staging" environment in Knock in addition to the Development and Production environments that are provided by default. It also assumes that you have [installed the Knock CLI](/cli/overview/installation) on your local machine.
 
 ## Local development
 

--- a/content/developer-tools/knock-and-postman.md
+++ b/content/developer-tools/knock-and-postman.md
@@ -7,7 +7,7 @@ section: Getting started
 
 Our Postman collection is a good way to get familiar with the Knock API. Here's how to get started.
 
-In this tutorial you'll fork the Knock collection into your Postman workspace and create Postman environments that map to your environments in Knock.
+This page walks through forking the Knock collection into your Postman workspace and creating Postman environments that map to your environments in Knock.
 
 ## For the Knock Postman collection
 

--- a/content/developer-tools/knock-and-postman.md
+++ b/content/developer-tools/knock-and-postman.md
@@ -7,7 +7,7 @@ section: Getting started
 
 Our Postman collection is a good way to get familiar with the Knock API. Here's how to get started.
 
-In this guide you'll fork the Knock collection into your Postman workspace and create Postman environments that map to your environments in Knock.
+In this tutorial you'll fork the Knock collection into your Postman workspace and create Postman environments that map to your environments in Knock.
 
 ## For the Knock Postman collection
 

--- a/content/developer-tools/knock-cli.mdx
+++ b/content/developer-tools/knock-cli.mdx
@@ -18,7 +18,7 @@ You can install the Knock CLI using `npm`, a node package manager, with the foll
 npm install -g @knocklabs/cli
 ```
 
-Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via Homebrew for macOS. See [the installation guide](/cli/overview/installation).
+Once the CLI is installed, you can call it by using the `knock` command in your terminal. The CLI is also available via Homebrew for macOS. See [the installation documentation](/cli/overview/installation).
 
 ## Authenticating the CLI
 

--- a/content/getting-started/quick-start.mdx
+++ b/content/getting-started/quick-start.mdx
@@ -5,7 +5,7 @@ tags: ["getting started"]
 section: Getting started
 ---
 
-In this guide, you'll integrate Knock with your backend web application and send your first notification using Knock.
+In this tutorial, you'll integrate Knock with your backend web application and send your first notification using Knock.
 
 <Steps titleSize="h2">
   <Step title="Create a Knock account">
@@ -58,7 +58,7 @@ In this guide, you'll integrate Knock with your backend web application and send
         Click the back arrow in the top-left corner of the workflow canvas to get back to the workflow overview page, where you can commit your changes.
       </Accordion>
     </AccordionGroup>
-    Now we're ready to trigger our workflow via the Knock API. You can also learn more about workflows and channels in Knock via our [guide on designing workflows](/send-notifications/designing-workflows).
+    Now we're ready to trigger our workflow via the Knock API. You can also learn more about workflows and channels in Knock via our [documentation on designing workflows](/send-notifications/designing-workflows).
 
   </Step>
   <Step title="Trigger your workflow">

--- a/content/getting-started/quick-start.mdx
+++ b/content/getting-started/quick-start.mdx
@@ -5,7 +5,7 @@ tags: ["getting started"]
 section: Getting started
 ---
 
-In this tutorial, you'll integrate Knock with your backend web application and send your first notification using Knock.
+This page will help you integrate Knock with your backend web application and send your first notification using Knock.
 
 <Steps titleSize="h2">
   <Step title="Create a Knock account">

--- a/content/in-app-ui/android/overview.mdx
+++ b/content/in-app-ui/android/overview.mdx
@@ -52,7 +52,7 @@ dependencies {
 }
 ```
 
-[Read more in the quick start guide ->](/in-app-ui/android/sdk/quick-start)
+[Read more in the quick start documentation ->](/in-app-ui/android/sdk/quick-start)
 
 ## Links
 

--- a/content/in-app-ui/android/sdk/deep-links.mdx
+++ b/content/in-app-ui/android/sdk/deep-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Handling deep links
-description: Follow this guide to get started with deep linking in the Knock Android SDK.
+description: Follow this documentation to get started with deep linking in the Knock Android SDK.
 section: SDKs
 ---
 

--- a/content/in-app-ui/android/sdk/overview.mdx
+++ b/content/in-app-ui/android/sdk/overview.mdx
@@ -9,7 +9,7 @@ The Knock Kotlin SDK is a client-side SDK for interacting with the Knock API and
 **Quick links**
 
 - [SDK on GitHub](https://github.com/knocklabs/knock-android)
-- [Full reference guide](/in-app-ui/android/sdk/reference)
+- [Full reference documentation](/in-app-ui/android/sdk/reference)
 
 ## Example app
 

--- a/content/in-app-ui/android/sdk/push-notifications.mdx
+++ b/content/in-app-ui/android/sdk/push-notifications.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Handling Android push notifications"
-description: "Usage guides to help you get started with the Push Notifications in the Android Knock SDK."
+description: "Documentation to help you get started with the Push Notifications in the Android Knock SDK."
 section: SDKs
 ---
 
@@ -8,7 +8,7 @@ section: SDKs
 
 ## Prerequisites
 
-- Before proceeding, ensure you've configured push notifications within your Knock account. For guidance on this initial setup, refer to our [Push Notification Configuration Guide](/integrations/push/overview).
+- Before proceeding, ensure you've configured push notifications within your Knock account. For guidance on this initial setup, refer to our [push notification documentation](/integrations/push/overview).
 - Review Firebase's [documentation](https://firebase.google.com/docs/cloud-messaging) for advanced features and updated practices.
 
 ## 1. Create a Firebase project

--- a/content/in-app-ui/expo/sdk/push-notifications.mdx
+++ b/content/in-app-ui/expo/sdk/push-notifications.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Handling Push Notifications with React Native and Expo"
-description: A guide on integrating Expo push notifications with the Knock SDK in your React Native application.
+description: Documentation on integrating Expo push notifications with the Knock SDK in your React Native application.
 section: SDKs
 ---
 
-**Note:** This guide assumes you're utilizing our `KnockExpoPushNotificationProvider` for a streamlined push notification setup within your React Native and Expo environment.
+**Note:** This documentation assumes you're utilizing our `KnockExpoPushNotificationProvider` for a streamlined push notification setup within your React Native and Expo environment.
 
 ## Prerequisites
 
-Before diving into the integration process, ensure your Knock account is set up for push notifications. For initial setup instructions, please visit our [Push Notification Configuration Guide](/integrations/push/overview).
+Before diving into the integration process, ensure your Knock account is set up for push notifications. For initial setup instructions, please visit our [push notification documentation](/integrations/push/overview).
 
 <Steps titleSize="h2">
 

--- a/content/in-app-ui/feeds-vs-guides.mdx
+++ b/content/in-app-ui/feeds-vs-guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Feeds v. guides
 description: An overview of the differences between feeds and guides.
-tags: []
+tags: [feed, guides]
 section: Building in-app UI
 ---
 

--- a/content/in-app-ui/feeds/filtering-in-app-feeds.mdx
+++ b/content/in-app-ui/feeds/filtering-in-app-feeds.mdx
@@ -12,7 +12,7 @@ When building an in-app notifications UI, you can filter notifications to increa
 - Separating notifications by engagement status (unread, read, seen, archived)
 - Separating notifications by a custom property (e.g. `priority: "high"`, `status: "incomplete"`)
 
-In this guide, we'll explore how to filter the feed API using `defaultFeedOptions`. These filters apply to all feed results, including real-time updates and badge counts for unseen or unread notifications.
+This page covers how to filter the feed API using `defaultFeedOptions`. These filters apply to all feed results, including real-time updates and badge counts for unseen or unread notifications.
 
 <Callout
   emoji="💡"
@@ -20,8 +20,8 @@ In this guide, we'll explore how to filter the feed API using `defaultFeedOption
   text={
     <>
       The feed client accepts default options that apply to both the initial
-      feed fetch and real-time updates. This guide demonstrates how to set these
-      defaults. You can also override these values when calling the{" "}
+      feed fetch and real-time updates. This documentation demonstrates how to
+      set these defaults. You can also override these values when calling the{" "}
       <code>fetch</code> function.
     </>
   }

--- a/content/in-app-ui/feeds/handling-interactivity.mdx
+++ b/content/in-app-ui/feeds/handling-interactivity.mdx
@@ -5,7 +5,7 @@ section: Building in-app UI > Feeds
 tags: ["interactivity", "routing", "clicking", "interaction"]
 ---
 
-Knock enables you to build engaging in-app feed experiences with a rich set of interactivity features across all supported platforms (Web, iOS, Android, and React Native). This guide covers the various ways you can handle user interactions with your feed components.
+Knock enables you to build engaging in-app feed experiences with a rich set of interactivity features across all supported platforms (Web, iOS, Android, and React Native). This documentation covers the various ways you can handle user interactions with your feed components.
 
 <Callout
   emoji="💡"

--- a/content/in-app-ui/feeds/styling.mdx
+++ b/content/in-app-ui/feeds/styling.mdx
@@ -5,7 +5,7 @@ tags: ["styling", "ui", "css", "theme"]
 section: Building in-app UI > Feeds
 ---
 
-Knock provides extensive styling capabilities for feed-based components across all supported platforms (Web, iOS, Android, and React Native). This guide covers the various ways you can customize the appearance of your in-app feeds to match your application's design system.
+Knock provides extensive styling capabilities for feed-based components across all supported platforms (Web, iOS, Android, and React Native). This page covers the various ways you can customize the appearance of your in-app feeds to match your application's design system.
 
 ## Styling our pre-built components
 
@@ -45,7 +45,7 @@ For iOS applications, Knock provides the `InAppFeedTheme` class for comprehensiv
    - `unreadNotificationCircleColor`: Customize unread indicators
    - Customizable action button styles for primary, secondary, and tertiary actions
 
-For more detailed information about iOS customization, see our [iOS customization guide](/in-app-ui/ios/customization).
+For more detailed information about iOS customization, see our [iOS customization documentation](/in-app-ui/ios/customization).
 
 ### Android
 
@@ -68,7 +68,7 @@ For Android applications, Knock provides similar theming capabilities through th
    - Customizable action button styles
    - Swipe action configurations for mark as read/unread and archive/unarchive
 
-For more detailed information about Android customization, see our [Android customization guide](/in-app-ui/android/customization).
+For more detailed information about Android customization, see our [Android customization documentation](/in-app-ui/android/customization).
 
 ### React Native
 
@@ -95,10 +95,10 @@ For React Native applications, Knock provides style customization through severa
 4. **Avatar view style**:
    - Customize container, image, and text styles for avatars
 
-For more detailed information about React Native customization, see our [React Native customization guide](/in-app-ui/react-native/customization).
+For more detailed information about React Native customization, see our [React Native customization documentation](/in-app-ui/react-native/customization).
 
 ## Building your own UI components
 
 You can build your own UI components and use them with Knock in a headless way. This approach allows you to leverage Knock's powerful in-app messaging infrastructure while maintaining full control over your UI design.
 
-For more information, see our [custom UI guide](/in-app-ui/feeds/custom-ui).
+For more information, see our [custom UI documentation](/in-app-ui/feeds/custom-ui).

--- a/content/in-app-ui/flutter/overview.mdx
+++ b/content/in-app-ui/flutter/overview.mdx
@@ -30,7 +30,7 @@ The Knock Flutter SDK is a low-level set of methods for interacting with the Kno
 flutter pub add knock_flutter
 ```
 
-[Read more in the quick start guide ->](/in-app-ui/flutter/sdk/quick-start)
+[Read more in the quick start documentation ->](/in-app-ui/flutter/sdk/quick-start)
 
 ## Links
 

--- a/content/in-app-ui/flutter/sdk/quick-start.mdx
+++ b/content/in-app-ui/flutter/sdk/quick-start.mdx
@@ -4,12 +4,12 @@ description: Get started with the Knock Flutter SDK to build in-app notification
 section: SDKs
 ---
 
-The Knock Flutter SDK is a client-side SDK for interacting with the Knock API and for building in-app notification experiences for Flutter applications. In this guide, we'll show some of the main ways you can interact with the SDK.
+The Knock Flutter SDK is a client-side SDK for interacting with the Knock API and for building in-app notification experiences for Flutter applications. This documentation shows some of the ways you can interact with the SDK.
 
 ## Quick links
 
 - [SDK on GitHub](https://github.com/knocklabs/knock-flutter)
-- [Full reference guide](/in-app-ui/flutter/sdk/reference)
+- [Full reference documentation](/in-app-ui/flutter/sdk/reference)
 - [Example application](https://github.com/knocklabs/knock-flutter/tree/main/example)
 
 ## Installation

--- a/content/in-app-ui/ios/sdk/deep-links.mdx
+++ b/content/in-app-ui/ios/sdk/deep-links.mdx
@@ -1,6 +1,6 @@
 ---
 title: Handling deep/universal links
-description: Follow this guide to get started with deep/universal linking in the Knock iOS SDK.
+description: Follow this documentation to get started with deep/universal linking in the Knock iOS SDK.
 section: SDKs
 ---
 

--- a/content/in-app-ui/ios/sdk/overview.mdx
+++ b/content/in-app-ui/ios/sdk/overview.mdx
@@ -9,7 +9,7 @@ The Knock Swift SDK is a client-side SDK for interacting with the Knock API and 
 **Quick links**
 
 - [SDK on GitHub](https://github.com/knocklabs/knock-swift)
-- [Full reference guide](/in-app-ui/ios/sdk/reference)
+- [Full reference documentation](/in-app-ui/ios/sdk/reference)
 
 ## Example app
 

--- a/content/in-app-ui/javascript/sdk/overview.mdx
+++ b/content/in-app-ui/javascript/sdk/overview.mdx
@@ -22,7 +22,7 @@ The `@knocklabs/client` library is a low-level JavaScript SDK for interacting wi
 
 - [`@knocklabs/client` on npm](https://www.npmjs.com/package/@knocklabs/client)
 - [Package on GitHub](https://github.com/knocklabs/javascript/tree/main/packages/client)
-- [Full reference guide](/in-app-ui/javascript/sdk/reference)
+- [Full reference documentation](/in-app-ui/javascript/sdk/reference)
 
 ## Need help?
 

--- a/content/in-app-ui/javascript/sdk/quick-start.mdx
+++ b/content/in-app-ui/javascript/sdk/quick-start.mdx
@@ -4,7 +4,7 @@ description: Get started with our Javascript SDK to build notification feed, toa
 section: SDKs
 ---
 
-The `@knocklabs/client` library is a low-level JavaScript SDK for interacting with Knock from the client side of your JS application. This documentation shows some of the main ways you can interact with the SDK:
+The `@knocklabs/client` library is a low-level JavaScript SDK for interacting with Knock from the client side of your JS application. This documentation shows some of the ways you can interact with the SDK:
 
 **Quick links**
 

--- a/content/in-app-ui/javascript/sdk/quick-start.mdx
+++ b/content/in-app-ui/javascript/sdk/quick-start.mdx
@@ -4,13 +4,13 @@ description: Get started with our Javascript SDK to build notification feed, toa
 section: SDKs
 ---
 
-The `@knocklabs/client` library is a low-level JavaScript SDK for interacting with Knock from the client side of your JS application. In this guide we'll show some of the main ways you can interact with the SDK:
+The `@knocklabs/client` library is a low-level JavaScript SDK for interacting with Knock from the client side of your JS application. This documentation shows some of the main ways you can interact with the SDK:
 
 **Quick links**
 
 - [`@knocklabs/client` on npm](https://www.npmjs.com/package/@knocklabs/client)
 - [Package on GitHub](https://github.com/knocklabs/javascript/tree/main/packages/client)
-- [Full reference guide](/in-app-ui/javascript/sdk/reference)
+- [Full reference documentation](/in-app-ui/javascript/sdk/reference)
 
 ## Getting started
 

--- a/content/in-app-ui/overview.mdx
+++ b/content/in-app-ui/overview.mdx
@@ -55,7 +55,7 @@ We have the following SDKs available to use to build in-app notification experie
 - [Kotlin (Android)](/in-app-ui/android/overview)
 - [Flutter (Android/iOS)](/in-app-ui/flutter/overview)
 
-Under each client SDK, you'll find tutorials and references to help you get started.
+Under each client SDK, you'll find documentation to help you get started.
 
 ## Going to production
 

--- a/content/in-app-ui/overview.mdx
+++ b/content/in-app-ui/overview.mdx
@@ -42,7 +42,7 @@ You can learn more about the difference between feeds and guides in our [feeds v
 - **Build holistic experiences.** Use the Knock workflow builder to create cross-channel notification experiences to power cases like "send to the in-app feed, if they don't see the feed message within 5 minutes then fallback to sending an email."
 - **Complete APIs that are easy to use.** We take all of the heavy lifting out of building APIs to support common in-app notification experiences, like preferences and feeds.
 - **Drop-in components.** We have components ready to help you get started with building in-app notification experiences in React.
-- **Fully customizable.** Whether you want to build a feed, toasts, a full-page inbox experience, or notifications that match your style guide, it's easy to customize the experience by overriding styles, or components, or building your own headless UI using our lower-level primitives.
+- **Fully customizable.** It's easy to customize the experience by overriding styles, or components, or building your own headless UI using our lower-level primitives.
 
 ## Client SDKs available
 
@@ -59,4 +59,4 @@ Under each client SDK, you'll find tutorials and references to help you get star
 
 ## Going to production
 
-You'll need to follow our checklist on [going to production](/guides/implementation-guide#going-to-production) for any in-app notifications using Knock. Most importantly you'll need to [secure your requests to the Knock API for each user](/in-app-ui/security-and-authentication).
+You'll need to follow our checklist on [going to production](/tutorials/implementation-guide#going-to-production) for any in-app notifications using Knock. Most importantly you'll need to [secure your requests to the Knock API for each user](/in-app-ui/security-and-authentication).

--- a/content/in-app-ui/react-native/feed.mdx
+++ b/content/in-app-ui/react-native/feed.mdx
@@ -5,7 +5,7 @@ tags: ["inbox", "feeds", "toasts"]
 section: Building in-app UI
 ---
 
-In this guide, you'll find common recipes to help you build in-app feed experiences within your React Native applications. The SDK handles all aspects of managing the data surrounding notifications on your behalf, including managing unread badge counts.
+This page provides common recipes to help you build in-app feed experiences within your React Native applications. The SDK handles all aspects of managing the data surrounding notifications on your behalf, including managing unread badge counts.
 
 <Callout
   emoji="🌠"
@@ -49,7 +49,7 @@ npm install @knocklabs/react-native
       enable enhanced security mode in your Knock dashboard and pass a signed
       {" "}<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
-      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>
+      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication documentation</a>
       for client-side applications.
     </>}
 
@@ -114,4 +114,4 @@ export default App;
 
 A feed can be scoped by any of the parameters that are accepted on the [feed endpoint](/api-reference/users/feeds/list_items) via the `FeedClientOptions` set in the `defaultFeedOptions` for the `KnockFeedProvider` component, or via the `useNotifications` hook.
 
-You can read more in this [guide on feed filtering](/in-app-ui/react/filtering-in-app-feeds).
+You can read more in this [documentation on feed filtering](/in-app-ui/react/filtering-in-app-feeds).

--- a/content/in-app-ui/react-native/headless/feed.mdx
+++ b/content/in-app-ui/react-native/headless/feed.mdx
@@ -7,7 +7,7 @@ tags: ["hooks", "headless", "useNotifications", "useAuthenticatedKnockClient"]
 
 Using our `@knocklabs/react-native` and `@knocklabs/client` libraries, you can create fully custom notification UIs that are backed by the Knock Feed API and real-time service.
 
-In this guide, we'll take a look at creating a completely custom notifications UI in our application in a headless way using Knock's hooks.
+This page shows how to create a completely custom notification UI in your application in a headless way using Knock's hooks.
 
 ## Getting started
 
@@ -140,4 +140,4 @@ const NotificationFeed = ({ user }) => {
 
 A feed can be scoped by any of the parameters that are accepted on the [feed endpoint](/api-reference/users/feeds/list_items) via the `FeedClientOptions` set in the `defaultFeedOptions` for the `KnockFeedProvider` component, or via the `useNotifications` hook.
 
-You can read more in this [guide on feed filtering](/in-app-ui/react/filtering-in-app-feeds).
+You can read more in this [documentation on feed filtering](/in-app-ui/react/filtering-in-app-feeds).

--- a/content/in-app-ui/react-native/sdk/push-notifications.mdx
+++ b/content/in-app-ui/react-native/sdk/push-notifications.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Handling Push Notifications with React Native and Firebase Cloud Messaging"
-description: A guide on integrating FCM push notifications with the Knock SDK in your React Native application.
+description: Documentation on integrating FCM push notifications with the Knock SDK in your React Native application.
 section: SDKs
 ---
 
@@ -12,7 +12,7 @@ section: SDKs
     <>
       See our{" "}
       <a href="/in-app-ui/expo/sdk/push-notifications">
-        guide to handling push notifications using our Expo SDK
+        documentation about handling push notifications using our Expo SDK
       </a>
       .
     </>
@@ -23,7 +23,7 @@ section: SDKs
 
 <Step title="Set up a Firebase Cloud Messaging channel in Knock">
 
-If you haven't already, create a new Firebase Cloud Messaging channel in the **Integrations** page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification guide](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
+If you haven't already, create a new Firebase Cloud Messaging channel in the **Integrations** page of your Knock dashboard. Follow our [Firebase Cloud Messaging push notification documentation](/integrations/push/firebase) to configure FCM with Knock using your Service Account JSON file.
 
 </Step>
 

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -5,7 +5,7 @@ tags: ["inbox", "feeds", "toasts", "action_url"]
 section: Building in-app UI
 ---
 
-Our `@knocklabs/react` library comes pre-built with a real-time feed component that you can drop into your application. In this guide, you'll find common recipes to help you work with the pre-built Knock feed UI element.
+Our `@knocklabs/react` library comes pre-built with a real-time feed component that you can drop into your application. This page provides common recipes to help you work with the pre-built Knock feed UI element.
 
 [See a live demo of our pre-built in-app feed UI element ->](https://in-app-demo.knock.app/)
 
@@ -59,7 +59,7 @@ To add a real-time notifications feed to your product, you can use the out-of-th
       enable enhanced security mode in your Knock dashboard and pass a signed
       {" "}<code>userToken</code> as a prop to the <code>KnockFeedProvider</code> component.
 
-      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication guide</a>{" "}
+      For more information, visit <a href="/in-app-ui/security-and-authentication">the security & authentication documentation</a>{" "}
       for client-side applications.
     </>
 
@@ -315,7 +315,7 @@ import { NotificationFeed, FilterStatus } from "@knocklabs/react";
 
 The component manages its filter state internally and provides a default header with status filtering controls. If you need to customize the status filtering behavior, you can provide a custom header using the `renderHeader` prop.
 
-You can read more in this [guide on feed filtering](/in-app-ui/react/filtering-in-app-feeds).
+You can read more in this [documentation on feed filtering](/in-app-ui/react/filtering-in-app-feeds).
 
 ## Related links
 

--- a/content/in-app-ui/react/headless/feed.mdx
+++ b/content/in-app-ui/react/headless/feed.mdx
@@ -7,7 +7,7 @@ tags: ["hooks", "headless", "useNotifications", "useAuthenticatedKnockClient"]
 
 Using our `@knocklabs/react` and `@knocklabs/client` libraries, you can create fully custom notification UIs that are backed by the Knock Feed API and real-time service.
 
-In this guide, we'll take a look at creating a completely custom notifications UI in our application in a headless way using Knock's hooks.
+In this documentation, we'll take a look at creating a completely custom notifications UI in our application in a headless way using Knock's hooks.
 
 ## Getting started
 

--- a/content/in-app-ui/react/headless/preferences.mdx
+++ b/content/in-app-ui/react/headless/preferences.mdx
@@ -7,7 +7,7 @@ tags: ["hooks", "headless", "usePreferences", "preferences"]
 
 Using our `@knocklabs/react` library, you can create custom notification preference interfaces that are backed by Knock's preferences API. The `usePreferences` hook enables you to fetch and update user preferences with real-time caching, making it easy to build responsive preference centers.
 
-In this guide, we'll walk through creating a custom preferences interface in your application using the `usePreferences` hook.
+In this documentation, we'll walk through creating a custom preferences interface in your application using the `usePreferences` hook.
 
 ## Getting started
 

--- a/content/in-app-ui/react/inbox.mdx
+++ b/content/in-app-ui/react/inbox.mdx
@@ -4,7 +4,7 @@ description: How to build a notification inbox powered by Knock and React.
 section: Building in-app UI
 ---
 
-Our `@knocklabs/react` library can be used to build full-page inbox experiences, too. In this guide we'll show you how to have a basic inbox ready for your users in a few minutes.
+Our `@knocklabs/react` library can be used to build full-page inbox experiences, too. This page covers how to create a basic inbox for your users in just a few minutes.
 
 ## Getting started
 

--- a/content/in-app-ui/react/modal.mdx
+++ b/content/in-app-ui/react/modal.mdx
@@ -38,7 +38,7 @@ The modal component enables you to display important notifications, announcement
 To use the modal component, you'll need:
 
 - [An account on Knock](https://dashboard.knock.app)
-- A guide channel set up in your Knock dashboard
+- An in-app guides channel set up in your Knock dashboard
 - A guide created using the "Modal" [message type](/in-app-ui/message-types)
 
 <Callout

--- a/content/in-app-ui/react/overview.mdx
+++ b/content/in-app-ui/react/overview.mdx
@@ -15,7 +15,7 @@ Our [`@knocklabs/react`](https://github.com/knocklabs/javascript/tree/main/packa
       If you're currently using <code>@knocklabs/react-notification-feed</code>,
       check out our{" "}
       <a href="/in-app-ui/react/sdk/migrating-from-react-notification-feed">
-        migration guide
+        migration documentation
       </a>{" "}
       to learn how to use our new React library.
     </>
@@ -46,7 +46,7 @@ The Knock React SDK ships the following pre-built UI elements:
 
 If you don't want to use the pre-built UI components, you can also use this library in a headless way and bring your own UI. The Knock React SDK includes a complete set of React hooks that you can use to build your own UI on top of.
 
-## Guides
+## Tutorials
 
 - [Integrating the `NotificationFeedPopover`](/in-app-ui/react/feed)
 - [Real-time notification toasts](/in-app-ui/react/toasts)

--- a/content/in-app-ui/react/overview.mdx
+++ b/content/in-app-ui/react/overview.mdx
@@ -46,7 +46,7 @@ The Knock React SDK ships the following pre-built UI elements:
 
 If you don't want to use the pre-built UI components, you can also use this library in a headless way and bring your own UI. The Knock React SDK includes a complete set of React hooks that you can use to build your own UI on top of.
 
-## Tutorials
+## Documentation
 
 - [Integrating the `NotificationFeedPopover`](/in-app-ui/react/feed)
 - [Real-time notification toasts](/in-app-ui/react/toasts)

--- a/content/in-app-ui/react/preferences.mdx
+++ b/content/in-app-ui/react/preferences.mdx
@@ -4,7 +4,7 @@ description: How to build a complete notification preference center, powered by 
 section: Building in-app UI
 ---
 
-In this guide we'll build a `PreferenceCenter` React component with Knock's preference APIs. This component should be flexible enough to handle most of your needs and can easily be customized or extended for more specific use cases. If you want to reference a TypeScript example, you can find one in the [Notion feed example](https://github.com/knocklabs/notion-feed-example/blob/main/components/PreferenceCenter.tsx).
+This page covers how to build a `PreferenceCenter` React component with Knock's preference APIs. This component should be flexible enough to handle most of your needs and can easily be customized or extended for more specific use cases. If you want to reference a TypeScript example, you can find one in the [Notion feed example](https://github.com/knocklabs/notion-feed-example/blob/main/components/PreferenceCenter.tsx).
 
 <SdkCard
   title="Video walkthrough"

--- a/content/in-app-ui/react/preferences.mdx
+++ b/content/in-app-ui/react/preferences.mdx
@@ -15,7 +15,7 @@ This page covers how to build a `PreferenceCenter` React component with Knock's 
 />
 ## Getting started
 
-Before beginning this tutorial, we'd recommend reading the [preferences overview docs](/preferences/overview) and creating a [default `PreferenceSet`](/preferences/overview#create-a-default-preferenceset) for your environment. The [API reference for preferences](/api-reference/recipients/preferences) can also be helpful, but is not required for this tutorial.
+Before you get started, we recommend reading the [preferences overview docs](/preferences/overview) and creating a [default `PreferenceSet`](/preferences/overview#create-a-default-preferenceset) for your environment. The [API reference for preferences](/api-reference/recipients/preferences) can also be helpful.
 
 <Callout
   emoji="💡"

--- a/content/in-app-ui/react/sdk/migrating-from-react-notification-feed.mdx
+++ b/content/in-app-ui/react/sdk/migrating-from-react-notification-feed.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Migrating from @knocklabs/react-notification-feed"
-description: This guide will help you migrate to the new Knock React library
+description: This documentation will help you migrate to the new Knock React library
 section: Building in-app UI
 ---
 
-This guide will walk you through the steps of replacing `@knocklabs/react-notification-feed` with `@knocklabs/react`.
+This documentation will walk you through the steps of replacing `@knocklabs/react-notification-feed` with `@knocklabs/react`.
 
 Please [report any issues](https://github.com/knocklabs/javascript/issues/new) you encounter while upgrading.
 

--- a/content/in-app-ui/react/sdk/overview.mdx
+++ b/content/in-app-ui/react/sdk/overview.mdx
@@ -15,7 +15,7 @@ Our [`@knocklabs/react`](https://github.com/knocklabs/javascript/tree/main/packa
       If you're currently using <code>@knocklabs/react-notification-feed</code>,
       check out our{" "}
       <a href="/in-app-ui/react/sdk/migrating-from-react-notification-feed">
-        migration tutorial
+        migration documentation
       </a>{" "}
       to learn how to use our new React library.
     </>

--- a/content/in-app-ui/react/sdk/overview.mdx
+++ b/content/in-app-ui/react/sdk/overview.mdx
@@ -15,7 +15,7 @@ Our [`@knocklabs/react`](https://github.com/knocklabs/javascript/tree/main/packa
       If you're currently using <code>@knocklabs/react-notification-feed</code>,
       check out our{" "}
       <a href="/in-app-ui/react/sdk/migrating-from-react-notification-feed">
-        migration guide
+        migration tutorial
       </a>{" "}
       to learn how to use our new React library.
     </>

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -224,7 +224,7 @@ SlackKit exposes three levels of support: React hooks, client functions, and API
 
 You can use the [Slack React hooks](/in-app-ui/react/sdk/reference#slack-hooks) under the hood to access and set Slack integration data with your own components. All of them are available from the `@knocklabs/react-core` package. All of them must still be nested under the `KnockSlackProvider` to work.
 
-To use a hook in your component, all you need to to is import it and pass it the necessary params, and then you can use the data and functions returned in each to pass to your own component UI.
+To use a hook in your component, all you need to do is import it and pass it the necessary params, and then you can use the data and functions returned in each to pass to your own component UI.
 
 For example, you may want to provide your users a list of the connected channels outside of the `SlackChannelCombobox`. Let's look at how you can combine two hooks to accomplish that.
 

--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -10,7 +10,7 @@ Our `@knocklabs/react` library comes with pre-built components for allowing your
 
 To get started you'll need a [Knock account](https://dashboard.knock.app), a [Slack channel connected to a Slack app](/in-app-ui/react/slack-kit), and a workflow with a Slack channel step.
 
-Depending on your use case, you can follow one of these guides for step-by-step instructions on how to set up your Slack integration:
+Follow step-by-step instructions for your use case:
 
 - [Sending messages to public and private](/integrations/chat/slack/sending-a-message-to-channels) channels in your customer's Slack workspace
 - [Sending direct messages](/integrations/chat/slack/sending-a-direct-message) to users in your customer's Slack workspace
@@ -332,7 +332,7 @@ await signUserToken("user-1", {
       [Grants.ChannelDataRead, Grants.ChannelDataWrite],
     ),
     buildUserTokenGrant(
-      { type: "object", id: "raptor-feeding-guide", collection: "videos" },
+      { type: "object", id: "raptor-feeding-info", collection: "videos" },
       [Grants.ChannelDataRead, Grants.ChannelDataWrite],
     ),
   ],

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -10,7 +10,7 @@ Our `@knocklabs/react` library comes with pre-built components for allowing your
 
 To get started you'll need a [Knock account](https://dashboard.knock.app), a [Microsoft Teams channel connected to a Microsoft Teams bot](/integrations/chat/microsoft-teams/overview), a [Graph API-enabled application](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra), and a workflow with a Microsoft Teams channel step.
 
-Depending on your use case, you can follow one of these guides for step-by-step instructions on how to set up your Microsoft Teams integration:
+Follow step-by-step instructions for your use case:
 
 - [Sending messages to public channels](/integrations/chat/microsoft-teams/sending-a-message-to-channels) in your customers' Microsoft Teams instances
 - [Sending direct messages](/integrations/chat/microsoft-teams/sending-a-direct-message) to users in your customers' Microsoft Teams instances
@@ -317,7 +317,7 @@ await signUserToken("user-1", {
       [Grants.ChannelDataRead, Grants.ChannelDataWrite],
     ),
     buildUserTokenGrant(
-      { type: "object", id: "raptor-feeding-guide", collection: "videos" },
+      { type: "object", id: "raptor-feeding-info", collection: "videos" },
       [Grants.ChannelDataRead, Grants.ChannelDataWrite],
     ),
   ],

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -258,7 +258,7 @@ TeamsKit exposes three levels of support: React hooks, client functions, and API
 
 You can use the [Microsoft Teams React hooks](/in-app-ui/react/sdk/reference#microsoft-teams-hooks) under the hood to access and set Microsoft Teams integration data with your own components. All of them are available from the `@knocklabs/react-core` package. All of them must still be nested under the `KnockMsTeamsProvider` to work.
 
-To use a hook in your component, all you need to to is import it and pass it the necessary params, and then you can use the data and functions returned in each to pass to your own component UI.
+To use a hook in your component, all you need to do is import it and pass it the necessary params, and then you can use the data and functions returned in each to pass to your own component UI.
 
 ### Client functions
 

--- a/content/in-app-ui/react/toasts.mdx
+++ b/content/in-app-ui/react/toasts.mdx
@@ -4,7 +4,7 @@ description: How to build in-app toasts powered by Knock and React.
 section: Building in-app UI
 ---
 
-While there are no out-of-the-box toast components in the `@knocklabs/react` library, it's easy to build toasts on top of the primitives exposed. In this guide, we'll show you just how to do that using the `react-hot-toasts` library as our "toaster."
+While there are no out-of-the-box toast components in the `@knocklabs/react` library, it's easy to build toasts on top of the primitives exposed. This page covers how to do that using the `react-hot-toasts` library as our "toaster."
 
 [See a live demo](https://in-app-demo.knock.app/)
 

--- a/content/in-app-ui/security-and-authentication.mdx
+++ b/content/in-app-ui/security-and-authentication.mdx
@@ -17,13 +17,13 @@ tags:
   title="Note:"
   text={
     <>
-      This integration guide references examples from our{" "}
+      This documentation references examples from our{" "}
       <a href="https://github.com/knocklabs/javascript/tree/main/packages/client">
         client-side JS SDK
       </a>
-      . You only need to add the authentication outlined in this guide if you're
-      integrating Knock on the client-side of your applications to use Knock feeds
-      and guides, or the Knock preferences model.
+      . You only need to add the authentication outlined here if you're integrating
+      Knock on the client-side of your applications to use Knock feeds and guides,
+      or the Knock preferences model.
     </>
   }
 />

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -6,9 +6,9 @@ section: Integrations
 layout: integrations
 ---
 
-In this tutorial you'll learn how to use Knock to send notifications to Discord.
+This page covers how to use Knock to send notifications to Discord.
 
-We’ll cover:
+Topics covered:
 
 - Methods for sending notifications to Discord
 - Incoming webhooks configuration

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send Discord notifications with Knock
-description: Setup tutorial with examples to show you how to send Discord notifications with Knock.
+description: Get started sending Discord notifications with Knock.
 tags: ["discord", "chat"]
 section: Integrations
 layout: integrations

--- a/content/integrations/chat/discord.mdx
+++ b/content/integrations/chat/discord.mdx
@@ -1,12 +1,12 @@
 ---
 title: How to send Discord notifications with Knock
-description: Setup guide with examples to show you how to send Discord notifications with Knock.
+description: Setup tutorial with examples to show you how to send Discord notifications with Knock.
 tags: ["discord", "chat"]
 section: Integrations
 layout: integrations
 ---
 
-In this guide you’ll learn how to use Knock to send notifications to Discord.
+In this tutorial you'll learn how to use Knock to send notifications to Discord.
 
 We’ll cover:
 

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -6,9 +6,9 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this tutorial you'll learn how to use Knock to send notifications to Microsoft Teams. Depending on your use case, there are a few different ways to approach this integration. This tutorial serves as a starting point and will cover the basics of setting up a Microsoft Teams integration with Knock regardless of your use case.
+This page covers how to use Knock to send notifications to Microsoft Teams. Depending on your use case, there are a few different ways to approach this integration. This documentation serves as a starting point and will cover the basics of setting up a Microsoft Teams integration with Knock regardless of your use case.
 
-Here's what we'll cover in this tutorial:
+Topics covered:
 
 - The different methods of sending notifications to Microsoft Teams
 - How to add a Microsoft Teams channel to your Knock instance
@@ -103,7 +103,7 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
 
 Next, navigate to a workflow in Knock that you want to notify Teams and add a chat channel step. Select the Teams channel you just configured and create a notification template for the channel.
 
-You can learn more about how to write basic and advanced templates for Teams in the [designing notifications templates section](#designing-notification-templates-for-teams) of this tutorial.
+You can learn more about how to write basic and advanced templates for Teams in the [designing notifications templates section](#designing-notification-templates-for-teams) below.
 
 ### Trigger the workflow
 

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -6,9 +6,9 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this guide you'll learn how to use Knock to send notifications to Microsoft Teams. Depending on your use case, there are a few different ways to approach this integration. This guide serves as a starting point and will cover the basics of setting up a Microsoft Teams integration with Knock regardless of your use case.
+In this tutorial you'll learn how to use Knock to send notifications to Microsoft Teams. Depending on your use case, there are a few different ways to approach this integration. This tutorial serves as a starting point and will cover the basics of setting up a Microsoft Teams integration with Knock regardless of your use case.
 
-Here's what we'll cover in this guide.
+Here's what we'll cover in this tutorial:
 
 - The different methods of sending notifications to Microsoft Teams
 - How to add a Microsoft Teams channel to your Knock instance
@@ -103,7 +103,7 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
 
 Next, navigate to a workflow in Knock that you want to notify Teams and add a chat channel step. Select the Teams channel you just configured and create a notification template for the channel.
 
-You can learn more about how to write basic and advanced templates for Teams in the [designing notifications templates section](#designing-notification-templates-for-teams) of this guide.
+You can learn more about how to write basic and advanced templates for Teams in the [designing notifications templates section](#designing-notification-templates-for-teams) of this tutorial.
 
 ### Trigger the workflow
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -6,17 +6,9 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this tutorial, we'll cover how to update a Microsoft Teams bot to send direct messages to Teams users using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) tutorial.
+This page covers how to update a Microsoft Teams bot to send direct messages to Teams users using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview).
 
 In this implementation, your application's users will connect their Microsoft Entra tenant to Knock and be able to send messages to individual users via direct message. To make this easier to implement, we'll use Knock's [TeamsKit components](/in-app-ui/react/teams-kit) to facilitate the OAuth flow.
-
-Here's what we'll cover in this tutorial:
-
-- Modeling a multi-tenant application in Knock using `Tenants`
-- Adding required scopes to your Microsoft Teams app's manifest
-- Implementing a Microsoft OAuth flow using Knock's `MsTeamsAuthButton` component
-- Setting required User channel data when a Microsoft Teams bot is installed in a user's personal scope
-- Triggering a workflow with a user recipient to send a direct message to a Teams user
 
 ## Prerequisites
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -6,11 +6,11 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this guide, we'll cover how to update a Microsoft Teams bot to send direct messages to Teams users using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) guide.
+In this tutorial, we'll cover how to update a Microsoft Teams bot to send direct messages to Teams users using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) tutorial.
 
 In this implementation, your application's users will connect their Microsoft Entra tenant to Knock and be able to send messages to individual users via direct message. To make this easier to implement, we'll use Knock's [TeamsKit components](/in-app-ui/react/teams-kit) to facilitate the OAuth flow.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover in this tutorial:
 
 - Modeling a multi-tenant application in Knock using `Tenants`
 - Adding required scopes to your Microsoft Teams app's manifest

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -6,11 +6,11 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this guide, we'll cover how to update a Microsoft Teams bot to send messages to channels in Microsoft Teams using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) guide.
+In this tutorial, we'll cover how to update a Microsoft Teams bot to send messages to channels in Microsoft Teams using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) tutorial.
 
 In this implementation, your application's users will connect their Microsoft Entra tenant to Knock and be able to send messages to public channels. To make this easier to implement, we'll use Knock's [TeamsKit components](/in-app-ui/react/teams-kit) to facilitate the OAuth flow and channel selection process.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover in this tutorial:
 
 - Modeling a multi-tenant application in Knock using `Tenants`
 - Adding required scopes to your Microsoft Teams app's manifest

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -6,11 +6,11 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this tutorial, we'll cover how to update a Microsoft Teams bot to send messages to channels in Microsoft Teams using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) tutorial.
+This page covers how to update a Microsoft Teams bot to send messages to channels in Microsoft Teams using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview).
 
 In this implementation, your application's users will connect their Microsoft Entra tenant to Knock and be able to send messages to public channels. To make this easier to implement, we'll use Knock's [TeamsKit components](/in-app-ui/react/teams-kit) to facilitate the OAuth flow and channel selection process.
 
-Here's what we'll cover in this tutorial:
+Topics covered:
 
 - Modeling a multi-tenant application in Knock using `Tenants`
 - Adding required scopes to your Microsoft Teams app's manifest

--- a/content/integrations/chat/microsoft-teams/sending-an-internal-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-an-internal-message.mdx
@@ -6,9 +6,9 @@ section: Integrations > Microsoft Teams
 layout: integrations
 ---
 
-In this guide we'll cover how to send a message to an internal Microsoft Teams workspace using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration overview](/integrations/chat/microsoft-teams/overview) guide.
+In this documentation we'll cover how to send a message to an internal Microsoft Teams workspace using Knock. It assumes that you have already created a Microsoft Teams channel in Knock as outlined in the [Microsoft Teams integration](/integrations/chat/microsoft-teams/overview) documentation.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover:
 
 - Retrieving an incoming webhook URL from Microsoft Teams
 - Setting channel data for an `Object` in Knock

--- a/content/integrations/chat/overview.mdx
+++ b/content/integrations/chat/overview.mdx
@@ -12,7 +12,7 @@ We make it effortless to send notifications to chat providers like Slack, Micros
 - **Markdown template builder**: use our markdown editor to create templates for each platform and let us take care of sending the platform-specific markup.
 - **Use JSON to build interactive messages**: if you need to, it's easy to go to a fully customizable JSON template to power your chat notifications.
 - **Cross-provider, single template**: you can send the same chat templated message across all chat providers to reduce the amount of templates to maintain.
-- **Link tracking**: capture link-click events right within your Knock account. For more details, see the [Knock link tracking guide](/send-notifications/tracking).
+- **Link tracking**: capture link-click events right within your Knock account. For more details, see the [Knock link tracking documentation](/send-notifications/tracking).
 
 ## Supported providers
 

--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -5,9 +5,9 @@ section: Integrations > Slack
 layout: integrations
 ---
 
-In this guide you'll learn how to use Knock to send notifications to Slack. Depending on your use case, there are a few different ways to approach this integration. This guide serves as a starting point and will cover the basics of setting up a Slack integration with Knock regardless of your use case.
+This page covers how to use Knock to send notifications to Slack. Depending on your use case, there are a few different ways to approach this integration. This documentation serves as a starting point and will cover the basics of setting up a Slack integration with Knock regardless of your use case.
 
-Here's what we'll cover in this guide.
+Here's what we'll cover:
 
 - Building a Slack app for your integration
 - How to store Slack connection data in Knock using channel data
@@ -84,7 +84,7 @@ In this section we'll complete the steps for setting up your Knock account and S
           content="https://api.knock.app/providers/slack/authenticate"
         />
 
-        If you are building your own OAuth flow, you'll need to use a URL in your frontend application. You can reference this guide on [building a Slack OAuth flow](https://knock.app/blog/how-to-authenticate-users-in-slack-using-oauth) from scratch.
+        If you're building your own OAuth flow, you'll need to use a URL in your frontend application. You can reference this tutorial on [building a Slack OAuth flow](https://knock.app/blog/how-to-authenticate-users-in-slack-using-oauth) from scratch.
       </Accordion>
       <Accordion title="Set up public distribution">
         Under **Manage Distribution**, click the "Distribute app" button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for "Remove hard coded information."
@@ -171,7 +171,7 @@ Here's an overview of the data requirements for [setting recipient channel data]
 | connections | `SlackConnection[]` | One or more connections to Slack |
 
     A `SlackConnection` can have one of two schemas, depending on whether you're using standard Slack OAuth scopes or an incoming webhook.
-    We cover Slack app scopes in detail in our [Slack scopes guide](/integrations/chat/slack-diy/slack-apps-and-scopes).
+    We cover Slack app scopes in detail in our [Slack scopes documentation](/integrations/chat/slack-diy/slack-apps-and-scopes).
 
 <AccordionGroup>
   <Accordion title="SlackConnection with an access token" description="For self-serve customer integrations">
@@ -260,7 +260,7 @@ Depending on the Slack integration you build into your product, you’ll store t
 
     The [`SlackChannelCombobox`](/in-app-ui/react/slack-kit#slackchannelcombobox) component of Knock's SlackKit can help you with this.
 
-    You can learn more about the Knock object model and see an example how to use it to power Slack notifications in our [Objects concept guide](/concepts/objects).
+    You can learn more about the Knock object model and see an example how to use it to power Slack notifications in our [Objects documentation](/concepts/objects).
 
   </Accordion>
 </AccordionGroup>
@@ -307,7 +307,7 @@ There are {{ total_activities }} comments left on {{ page_name }}.
 [**View page**]({{vars.base_url}}/{{account_id}}/pages/{{ page_id }})
 ```
 
-In the example above we're using [Liquid's for-loop tag](https://shopify.github.io/liquid/tags/iteration/) to iterate over the activities array produced by a Knock batch function. You can learn more about Knock batch functions and the state they produce in our [batch function guide](/send-notifications/designing-workflows/batch-function).
+In the example above we're using [Liquid's for-loop tag](https://shopify.github.io/liquid/tags/iteration/) to iterate over the activities array produced by a Knock batch function. You can learn more about Knock batch functions and the state they produce in our [batch function documentation](/send-notifications/designing-workflows/batch-function).
 
 ### Block-based templates
 

--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -84,7 +84,7 @@ In this section we'll complete the steps for setting up your Knock account and S
           content="https://api.knock.app/providers/slack/authenticate"
         />
 
-        If you're building your own OAuth flow, you'll need to use a URL in your frontend application. You can reference this tutorial on [building a Slack OAuth flow](https://knock.app/blog/how-to-authenticate-users-in-slack-using-oauth) from scratch.
+        If you're building your own OAuth flow, you'll need to use a URL in your frontend application. You can reference this documentation on [building a Slack OAuth flow](https://knock.app/blog/how-to-authenticate-users-in-slack-using-oauth) from scratch.
       </Accordion>
       <Accordion title="Set up public distribution">
         Under **Manage Distribution**, click the "Distribute app" button which will show you a list of items to complete to activate public distribution. If you've built the app from scratch and completed the previous steps, you should see all of these complete except for "Remove hard coded information."

--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -337,7 +337,7 @@ Once you've designed your Slack template, copy the JSON from the block kit build
 
 #### Knock's JSON template editor
 
-You can use liquid in the Knock JSON template editor just as you would in the markdown editor. This is helpful for both injecting variables into the text of your Slack UI blocks, as well as for for using liquid control tags to control when certain blocks should be displayed and for iterating through an array and mapping its items into a list of Slack blocks.
+You can use liquid in the Knock JSON template editor just as you would in the markdown editor. This is helpful for both injecting variables into the text of your Slack UI blocks, as well as for using liquid control tags to control when certain blocks should be displayed and for iterating through an array and mapping its items into a list of Slack blocks.
 
 Here's an example of a block kit UI template with liquid syntax added to iterate through a list of items.
 

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -6,11 +6,11 @@ section: Integrations > Slack
 layout: integrations
 ---
 
-In this guide we'll cover how to create a self-serve Slack integration for a multi-tenant application using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration overview](/integrations/chat/slack/overview) guide.
+This page covers how to create a self-serve Slack integration for a multi-tenant application using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration overview](/integrations/chat/slack/overview).
 
 In this implementation, your application's users will connect their Slack workspace to Knock and be able to send messages to individual users via DM. To make this easier to implement, we'll use Knock's [SlackKit components](/in-app-ui/react/slack-kit) to facilitate the OAuth flow.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover:
 
 - Modeling a multi-tenant application in Knock using `Tenants`
 - Implementing a Slack OAuth flow using Knock's `SlackAuthButton` component

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -244,7 +244,7 @@ export async function fetchUserId(email: string): Promise<string> {
       'knocklabs',
       process.env.NEXT_PUBLIC_KNOCK_SLACK_CHANNEL_ID as string,
     );
-  // Next, use that access to to make a request to the Slack API
+  // Next, use that access to make a request to the Slack API
   const response = await fetch(
     `https://slack.com/api/users.lookupByEmail?email=${email}`,
     {

--- a/content/integrations/chat/slack/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/slack/sending-a-message-to-channels.mdx
@@ -6,11 +6,11 @@ section: Integrations > Slack
 layout: integrations
 ---
 
-In this guide we'll cover how to create a self-serve Slack integration for a multi-tenant application using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration overview](/integrations/chat/slack/overview) guide.
+In this documentation we'll cover how to create a self-serve Slack integration for a multi-tenant application using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration](/integrations/chat/slack/overview) documentation.
 
 In this implementation, your application's users will connect their Slack workspace to Knock and be able to send messages to public and private channels. To make this easier to implement, we'll use Knock's [SlackKit components](/in-app-ui/react/slack-kit) to facilitate the OAuth flow and channel selection process.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover:
 
 - Modeling a multi-tenant application in Knock using `Tenants` and `Objects`
 - Implementing a Slack OAuth flow using Knock's `SlackAuthButton` component

--- a/content/integrations/chat/slack/sending-an-internal-message.mdx
+++ b/content/integrations/chat/slack/sending-an-internal-message.mdx
@@ -6,9 +6,9 @@ section: Integrations > Slack
 layout: integrations
 ---
 
-In this guide we'll cover how to send a message to an internal Slack workspace using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration overview](/integrations/chat/slack/overview) guide.
+In this documentation we'll cover how to send a message to an internal Slack workspace using Knock. It assumes that you have already created a Slack app and created a Slack channel in Knock as outlined in the [Slack integration](/integrations/chat/slack/overview) documentation.
 
-Here's what we'll cover in this guide:
+Here's what we'll cover:
 
 - Retrieving an incoming webhook URL from your Slack app
 - Setting channel data for an `Object` in Knock

--- a/content/integrations/chat/whatsapp.mdx
+++ b/content/integrations/chat/whatsapp.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send WhatsApp notifications with Knock
-description: Setup tutorial for sending notifications with WhatsApp and Knock.
+description: Get started sending WhatsApp notifications with Knock.
 section: Integrations > Chat
 layout: integrations
 ---

--- a/content/integrations/chat/whatsapp.mdx
+++ b/content/integrations/chat/whatsapp.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send WhatsApp notifications with Knock
-description: Setup guide for sending notifications with WhatsApp and Knock.
+description: Setup tutorial for sending notifications with WhatsApp and Knock.
 section: Integrations > Chat
 layout: integrations
 ---

--- a/content/integrations/email/aws-ses.mdx
+++ b/content/integrations/email/aws-ses.mdx
@@ -6,9 +6,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://aws.amazon.com/ses/" target="_blank">AWS Simple Email Service (SES)</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with SES through Knock. We also cover provider configuration and additional data you can pass through to SES.
+Knock integrates with <a href="https://aws.amazon.com/ses/" target="_blank">AWS Simple Email Service (SES)</a> to send email notifications to your users. This page walks through how to get started with SES, including provider configurations and additional data you can pass through to SES.
 
 ## Features
 

--- a/content/integrations/email/aws-ses.mdx
+++ b/content/integrations/email/aws-ses.mdx
@@ -21,7 +21,7 @@ You can create a new AWS SES channel in the dashboard under the **Integrations**
 
 <Steps titleSize="h3">
   <Step title='Verify a "From" address within AWS SES'>
-    You'll need to verify the **"From" email address** you plan on using to send emails with AWS if you haven't already. To do so, follow the steps outlined in AWS's guide to <a href="https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure" target="_blank">creating and verifying an email address identity</a>.
+    You'll need to verify the **"From" email address** you plan on using to send emails with AWS if you haven't already. To do so, follow the steps outlined in AWS's documentation on <a href="https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html#verify-email-addresses-procedure" target="_blank">creating and verifying an email address identity</a>.
   </Step>
   <Step title="Choose an AWS Authentication Scheme">
     Knock supports two authentication schemes with AWS SES:

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -17,10 +17,6 @@ tags:
   ]
 ---
 
-In this guide we cover how to use email layouts and templates in Knock to send great looking notifications to your users.
-
-## An intro to email layouts and templates in Knock
-
 When you use Knock to power your email notifications, you use two main concepts to build the notifications that will be sent to your users: layouts and templates.
 
 The **layout** typically includes the header and footer of your email, as well as any other HTML or CSS that will be used across all (or multiple) templates. You can think of your email layout as the "frame" of your email notifications, where you define the shared structure and styles once for all your email notifications so they can look and feel consistently without having to repeat them in every template.
@@ -50,7 +46,7 @@ Your Knock account starts with a pre-built default layout. If you navigate to **
 
 Click on the "Default" layout in your layouts list to enter the layout editor. You'll start by looking at the pre-built layout that Knock gives you out of the box. You'll find a footer design option in this visual builder where you can add footer links to this pre-built layout for HTML emails. You can update the logo, icon, and brand color of your email layout by going to **Settings** > **Branding** and updating these attributes.
 
-If you'd rather create your own layout from scratch, you can click "Edit in code editor" in the top right corner of the layout editor to enter our custom layout editor. You can learn more about custom layouts in the [custom layouts and styling section](/integrations/email/layouts#custom-layouts-and-styling) of this guide.
+If you'd rather create your own layout from scratch, you can click "Edit in code editor" in the top right corner of the layout editor to enter our [custom layout](/integrations/email/layouts#custom-layouts-and-styling) editor.
 
 Every layout includes the text layout for plaintext emails, and the concept works the same as the HTML layout where the text content of your email template will be injected into the `{{content}}` variable. Click the "Text" tab to switch to the text layout, and edit it as you see fit.
 

--- a/content/integrations/email/mailersend.mdx
+++ b/content/integrations/email/mailersend.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://mailersend.com/" target="_blank">MailerSend</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with MailerSend through Knock.
+Knock integrates with <a href="https://mailersend.com/" target="_blank">MailerSend</a> to send email notifications to your users. This page describes how to get started with MailerSend in Knock, including necessary provider configurations and additional data you can pass through to MailerSend.
 
 ## Features
 

--- a/content/integrations/email/mailgun.mdx
+++ b/content/integrations/email/mailgun.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://mailgun.com/" target="_blank">Mailgun</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with Mailgun through Knock. We also cover provider configuration and additional data you can pass through to Mailgun.
+Knock integrates with <a href="https://mailgun.com/" target="_blank">Mailgun</a> to send email notifications to your users. This page describes how to get started with Mailgun in Knock, including necessary provider configurations and additional data you can pass through to Mailgun.
 
 ## Features
 

--- a/content/integrations/email/mailjet.mdx
+++ b/content/integrations/email/mailjet.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://mailjet.com/" target="_blank">Mailjet</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with Mailjet through Knock. We also cover provider configuration and additional data you can pass through to Mailjet.
+Knock integrates with <a href="https://mailjet.com/" target="_blank">Mailjet</a> to send email notifications to your users. This page describes how to get started with Mailjet in Knock, including necessary provider configurations and additional data you can pass through to Mailjet.
 
 ## Features
 

--- a/content/integrations/email/mailtrap.mdx
+++ b/content/integrations/email/mailtrap.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://mailtrap.io/" target="_blank">Mailtrap</a> to send email notifications to your users.
-
-In this guide, you'll learn how to get started sending transactional email notifications with Mailtrap through Knock. We also cover provider configuration and additional data you can pass through to Mailtrap.
+Knock integrates with <a href="https://mailtrap.io/" target="_blank">Mailtrap</a> to send email notifications to your users. This page describes how to get started with Mailtrap in Knock, including necessary provider configurations and additional data you can pass through to Mailtrap.
 
 ## Features
 

--- a/content/integrations/email/mandrill.mdx
+++ b/content/integrations/email/mandrill.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://mandrillapp.com/" target="_blank">Mandrill</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with Mandrill through Knock. We also cover provider configuration and additional data you can pass through to Mandrill.
+Knock integrates with <a href="https://mandrillapp.com/" target="_blank">Mandrill</a> to send email notifications to your users. This page describes how to get started with Mandrill in Knock, including necessary provider configurations and additional data you can pass through to Mandrill.
 
 ## Features
 

--- a/content/integrations/email/overview.mdx
+++ b/content/integrations/email/overview.mdx
@@ -16,7 +16,7 @@ Effortlessly design and deliver email notifications to downstream providers, wit
 - **Text generation**: We'll automatically generate a text version of your emails, so you never need to write both HTML and text templates.
 - **Multiple layouts**: We support any number of emails layouts that can "wrap" your email templates and provide styles and shared elements like headers and footers.
 - **Attachments support**: It's easy to send attachments alongside your emails, just pass through some Base64 encoded data along with your `workflow.trigger` call and you're done!
-- **Link and open tracking**: Capture link-click and email-open events right within your Knock account. For more details, see the [Knock link and open tracking guide](/send-notifications/tracking).
+- **Link and open tracking**: Capture link-click and email-open events right within your Knock account. For more details, see the [Knock link and open tracking documentation](/send-notifications/tracking).
 
 ## Supported providers
 

--- a/content/integrations/email/postmark.mdx
+++ b/content/integrations/email/postmark.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://postmarkapp.com/" target="_blank">Postmark</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with Postmark through Knock. We also cover provider configuration and additional data you can pass through to Postmark.
+Knock integrates with <a href="https://postmarkapp.com/" target="_blank">Postmark</a> to send email notifications to your users. This page describes how to get started with Postmark in Knock, including necessary provider configurations and additional data you can pass through to Postmark.
 
 ## Features
 

--- a/content/integrations/email/resend.mdx
+++ b/content/integrations/email/resend.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://resend.com/" target="_blank">Resend</a> to send email notifications to your users. Note: you will need an existing Resend account to set up this integration.
-
-In this guide you'll learn how to get started sending transactional email notifications with Resend through Knock. We also cover provider configuration details.
+Knock integrates with <a href="https://resend.com/" target="_blank">Resend</a> to send email notifications to your users. This page describes how to get started with Resend in Knock, including necessary provider configurations and additional data you can pass through to Resend.
 
 ## Features
 

--- a/content/integrations/email/sendgrid.mdx
+++ b/content/integrations/email/sendgrid.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://sendgrid.com" target="_blank">SendGrid</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with SendGrid through Knock. We also cover provider configuration and additional data you can pass through to SendGrid.
+Knock integrates with <a href="https://sendgrid.com" target="_blank">SendGrid</a> to send email notifications to your users. This page describes how to get started with SendGrid in Knock, including necessary provider configurations and additional data you can pass through to SendGrid.
 
 ## Features
 

--- a/content/integrations/email/smtp.mdx
+++ b/content/integrations/email/smtp.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock supports sending email notifications to your users via the Simple Mail Transfer Protocol (SMTP). In this configuration, Knock will act as an SMTP client and send email notifications to a specified SMTP server.
-
-In this guide, we'll cover how to get started sending email notifications using SMTP with Knock.
+Knock supports sending email notifications to your users via the Simple Mail Transfer Protocol (SMTP). In this configuration, Knock acts as an SMTP client and sends email notifications to a specified SMTP server. This page describes how to get started sending email notifications using SMTP with Knock.
 
 ## Features
 

--- a/content/integrations/email/sparkpost.mdx
+++ b/content/integrations/email/sparkpost.mdx
@@ -5,9 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock integrates with <a href="https://support.sparkpost.com/docs/getting-started/getting-started-sparkpost" target="_blank">SparkPost</a> to send email notifications to your users.
-
-In this guide you'll learn how to get started sending transactional email notifications with SparkPost through Knock. We also cover provider configuration and additional data you can pass through to SparkPost.
+Knock integrates with <a href="https://support.sparkpost.com/docs/getting-started/getting-started-sparkpost" target="_blank">SparkPost</a> to send email notifications to your users. This page describes how to get started with SparkPost in Knock, including necessary provider configurations and additional data you can pass through to SparkPost.
 
 ## Features
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -23,7 +23,7 @@ You can bring your notification analytics from Knock into your own data warehous
 
 Please [contact our support team](mailto:support@knock.app) to get started with the warehouse connection process. Your message should include the [destination type](#supported-destinations) of the warehouse that you'd like to connect, as well as which of the tables you'd like to sync from the [available data](#available-data) listed below.
 
-We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard that will guide you through the remainder of the setup process.
+We will ask you for additional information according to the destination type that you'd like to connect. Once we have the required details, Knock will provide you with a magic link to a step-by-step wizard for completing the setup process.
 
 Upon successful connection, your first data sync will include a backfill of historical data. You will receive up-to-date data once every 24 hours after the initial backfill.
 
@@ -144,7 +144,7 @@ Below is a description of the columns included in the table and the data type of
           "combined_trigger_data",
           "json",
           <div key="combined_trigger_data_body">
-            Combined and truncated trigger data for the workflow run that generated the message, at the time the message was created. See the <a target="_blank" rel="noreferrer" href="/api-reference/overview/trigger-data-filtering">trigger data filtering guide</a> for more info.
+            Combined and truncated trigger data for the workflow run that generated the message, at the time the message was created. See the <a target="_blank" rel="noreferrer" href="/api-reference/overview/trigger-data-filtering">trigger data filtering documentation</a> for more info.
           </div>
         ],
         [

--- a/content/integrations/extensions/heap.mdx
+++ b/content/integrations/extensions/heap.mdx
@@ -6,7 +6,7 @@ tags: ["heap", "extensions", "analytics"]
 section: Integrations > Extensions
 ---
 
-This guide covers how to use our Heap extension to send Knock's normalized notification data into [Heap](https://heap.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
+This documentation covers how to use our Heap extension to send Knock's normalized notification data into [Heap](https://heap.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
 
 Once the extension is enabled, Knock automatically passes a stream of `track` events to Heap (e.g. `Notification delivered`, `Notification seen`, `Notification read`) which you can then use in your downstream tools.
 

--- a/content/integrations/extensions/segment.mdx
+++ b/content/integrations/extensions/segment.mdx
@@ -6,7 +6,7 @@ tags: ["segment", "extensions", "analytics"]
 section: Integrations > Extensions
 ---
 
-This guide covers how to use our Segment extension to send Knock's normalized notification data into [Segment](https://segment.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
+This documentation covers how to use our Segment extension to send Knock's normalized notification data into [Segment](https://segment.io) to forward on to your data warehouse or other tools where you run data analysis, such as Amplitude or Mixpanel.
 
 Once the extension is enabled, Knock automatically passes a stream of `track` events to Segment (e.g. `Notification delivered`, `Notification seen`, `Notification read`) which you can then use in your downstream tools.
 

--- a/content/integrations/in-app/overview.mdx
+++ b/content/integrations/in-app/overview.mdx
@@ -10,7 +10,7 @@ In addition to delivering to out-of-app channels such as email, push, SMS, and c
 
 You can use our in-app feed channel to build stateful, in-app notifications experiences like floating feeds, inboxes, toasts and banners, and you can use our preferences API to build powerful user-facing preference controls. You can also use [Knock link tracking](/send-notifications/tracking) to capture link-click events right within your Knock account.
 
-For a complete guide on powering in-app notifications with Knock, see our [building in-app UI docs](/in-app-ui/overview).
+For more information about powering in-app notifications with Knock, see our [building in-app UI documentation](/in-app-ui/overview).
 
 [See a live demo ->](https://in-app-demo.knock.app/)
 

--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this tutorial we'll walk through how to configure an Apple Push Notifications service (APNs) provider in Knock to send iOS push notifications. This tutorial assumes that you've already created an APNs channel in the Knock dashboard.
+This page walks through how to configure an Apple Push Notifications service (APNs) provider in Knock to send iOS push notifications. You'll need an APNs channel in your Knock dashboard to follow along.
 
 ## How to configure Apple Push Notifications service with Knock
 

--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this guide we'll walk through how to configure an Apple Push Notifications service (APNs) provider in Knock to send iOS push notifications. This guide assumes that you've already created an APNs channel in the Knock dashboard.
+In this tutorial we'll walk through how to configure an Apple Push Notifications service (APNs) provider in Knock to send iOS push notifications. This tutorial assumes that you've already created an APNs channel in the Knock dashboard.
 
 ## How to configure Apple Push Notifications service with Knock
 
@@ -35,7 +35,7 @@ Both of these values should be converted according to the instructions [here](ht
 
 In order to use APNs with Knock you'll need to synchronize your users device tokens retrieved from the APNs SDK to Knock by [setting channel data](/managing-recipients/setting-channel-data) for your recipient.
 
-You can follow the [quickstart guide](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) on APNs to see how to get the device token.
+You can follow the [quickstart tutorial](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) on APNs to see how to get the device token.
 
 <MultiLangCodeBlock
   snippet="users.setChannelData-push"
@@ -79,7 +79,7 @@ Overrides are merged into the notification payload sent to APNs. See the <a href
 
 ## Channel data requirements
 
-In order to use a configured APNs channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the guide on the [Apple developer documentation](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns).
+In order to use a configured APNs channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the tutorial in the [Apple developer documentation](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns).
 
 | Property | Type     | Description               |
 | -------- | -------- | ------------------------- |

--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -35,7 +35,7 @@ Both of these values should be converted according to the instructions [here](ht
 
 In order to use APNs with Knock you'll need to synchronize your users device tokens retrieved from the APNs SDK to Knock by [setting channel data](/managing-recipients/setting-channel-data) for your recipient.
 
-You can follow the [quickstart tutorial](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) on APNs to see how to get the device token.
+You can follow the [quickstart documentation](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) on APNs to see how to get the device token.
 
 <MultiLangCodeBlock
   snippet="users.setChannelData-push"

--- a/content/integrations/push/apns.mdx
+++ b/content/integrations/push/apns.mdx
@@ -48,7 +48,7 @@ By default, Knock makes no assumptions about managing your device tokens. This m
 
 However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
 
-You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration documentation](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to APNs
 

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this tutorial we'll walk through how to configure an Expo provider in Knock to send push notifications. This tutorial assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
+This page walks through how to configure an Expo provider in Knock to send push notifications. This documentation assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
 
 If you're new to setting up push in your Expo enabled React Native project, you can follow <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">Expo's push notification overview</a>.
 

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -33,7 +33,7 @@ By default, Knock makes no assumptions about managing your device tokens. This m
 
 However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
 
-You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration documentation](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to Expo
 

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -6,9 +6,9 @@ section: Integrations
 layout: integrations
 ---
 
-In this guide we'll walk through how to configure an Expo provider in Knock to send push notifications. This guide assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
+In this tutorial we'll walk through how to configure an Expo provider in Knock to send push notifications. This tutorial assumes that you've already created an Expo channel in the Knock dashboard and that your React Native application is already setup to support Push notifications.
 
-If you're new to setting up push in your Expo enabled React Native project, you can follow the <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">excellent setup guide in the Expo documentation</a>.
+If you're new to setting up push in your Expo enabled React Native project, you can follow <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">Expo's push notification overview</a>.
 
 ## How to configure Expo with Knock
 
@@ -20,7 +20,7 @@ You can get both of these by logging into the <a href="https://expo.dev/" target
 
 In order to use Expo with Knock you'll need to synchronize your users device tokens retrieved from the Expo SDK in either Android, iOS, or on the Web to Knock by [setting channel data](/managing-recipients/setting-channel-data) for your recipient.
 
-You can follow the appropriate <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">quickstart guide for your platform</a> on Expo to see how to get the device token.
+You can follow the appropriate <a href="https://docs.expo.dev/push-notifications/overview/" target="_blank">quickstart tutorial for your platform</a> on Expo to see how to get the device token.
 
 <MultiLangCodeBlock
   snippet="users.setChannelData-push"
@@ -58,7 +58,7 @@ Overrides are merged into the notification payload sent to Expo. See the <a href
 
 ## Channel data requirements
 
-In order to use a configured Expo channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the guide on the <a href="https://docs.expo.dev/push-notifications/push-notifications-setup/" target="_blank">Expo developer documentation</a>.
+In order to use a configured Expo channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the tutorial in the <a href="https://docs.expo.dev/push-notifications/push-notifications-setup/" target="_blank">Expo developer documentation</a>.
 
 | Property | Type     | Description               |
 | -------- | -------- | ------------------------- |

--- a/content/integrations/push/firebase.mdx
+++ b/content/integrations/push/firebase.mdx
@@ -48,7 +48,7 @@ By default, Knock makes no assumptions about managing your device tokens. This m
 
 However, Knock does provide an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. When enabled, Knock will automatically remove invalid or expired tokens upon receiving a bounce event from the provider.
 
-You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration documentation](/integrations/push/token-deregistration) for more details on enabling and working with this feature.
 
 ## Data passed to FCM
 

--- a/content/integrations/push/firebase.mdx
+++ b/content/integrations/push/firebase.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this guide we'll walk through how to configure a Firebase Cloud Messaging (FCM) provider in Knock to send mobile or web push notifications. This guide assumes that you've already created an FCM channel in the Knock dashboard.
+In this tutorial we'll walk through how to configure a Firebase Cloud Messaging (FCM) provider in Knock to send mobile or web push notifications. This tutorial assumes that you've already created an FCM channel in the Knock dashboard.
 
 ## How to configure FCM with Knock
 
@@ -33,7 +33,7 @@ You can get both of these by logging into the [Firebase console](https://console
 
 In order to use FCM with Knock you'll need to synchronize your users device tokens retrieved from the FCM SDK in either Android, iOS, or Web to Knock by [setting channel data](/managing-recipients/setting-channel-data) for your recipient.
 
-You can follow the appropriate quickstart guide for either [iOS](https://firebase.google.com/docs/cloud-messaging/ios/client), [Android](https://firebase.google.com/docs/cloud-messaging/android/client), or [Web](https://firebase.google.com/docs/cloud-messaging/js/client) on FCM to see how to get the device token.
+You can follow the appropriate quickstart tutorial for either [iOS](https://firebase.google.com/docs/cloud-messaging/ios/client), [Android](https://firebase.google.com/docs/cloud-messaging/android/client), or [Web](https://firebase.google.com/docs/cloud-messaging/js/client) on FCM to see how to get the device token.
 
 Once you have the device token, you can use the Knock SDK to set the channel data for your recipient. In the case of web push, you can send the token to your app server and use the corresponding Knock SDK to set the channel data:
 

--- a/content/integrations/push/firebase.mdx
+++ b/content/integrations/push/firebase.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this tutorial we'll walk through how to configure a Firebase Cloud Messaging (FCM) provider in Knock to send mobile or web push notifications. This tutorial assumes that you've already created an FCM channel in the Knock dashboard.
+This page walks through how to configure a Firebase Cloud Messaging (FCM) provider in Knock to send mobile or web push notifications. You'll need an FCM channel in your Knock dashboard to follow along.
 
 ## How to configure FCM with Knock
 

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this guide we'll walk through how to configure a OneSignal provider in Knock to send push notifications. This guide assumes that you've already created a OneSignal channel in the Knock dashboard.
+In this tutorial we'll walk through how to configure a OneSignal provider in Knock to send push notifications. This tutorial assumes that you've already created a OneSignal channel in the Knock dashboard.
 
 Your OneSignal channel expects that you are using Knock to author Push notification templates. Those templates are then passed to OneSignal as content.
 
@@ -17,7 +17,7 @@ Your OneSignal channel expects that you are using Knock to author Push notificat
   title="Note:"
   text={
     <>
-      this guide assumes that you have already setup OneSignal with push
+      this tutorial assumes that you have already setup OneSignal with push
       certificates and everything needed in order to start sending push
       notifications. You should also have already integrated the OneSignal SDK
       within your application.

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -73,7 +73,7 @@ By default, Knock makes no assumptions about managing your device tokens. This m
 
 When using `player_id` mode, Knock provides an opt-in token deregistration feature that automatically removes invalid tokens from a recipient's channel data when a message bounces. This feature is not available when using `external_id` mode since Knock doesn't directly manage any tokens in this case.
 
-You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration guide](/integrations/push/token-deregistration) for more details.
+You can configure token deregistration on a per-environment basis in your channel's environment configurations. See our [token deregistration documentation](/integrations/push/token-deregistration) for more details.
 
 ## Channel data requirements
 

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -6,7 +6,7 @@ section: Integrations
 layout: integrations
 ---
 
-In this tutorial we'll walk through how to configure a OneSignal provider in Knock to send push notifications. This tutorial assumes that you've already created a OneSignal channel in the Knock dashboard.
+This page walks through how to configure a OneSignal provider in Knock to send push notifications. You'll need a OneSignal channel in your Knock dashboard to follow along.
 
 Your OneSignal channel expects that you are using Knock to author Push notification templates. Those templates are then passed to OneSignal as content.
 

--- a/content/integrations/push/one-signal.mdx
+++ b/content/integrations/push/one-signal.mdx
@@ -17,7 +17,7 @@ Your OneSignal channel expects that you are using Knock to author Push notificat
   title="Note:"
   text={
     <>
-      this tutorial assumes that you have already setup OneSignal with push
+      This documentation assumes that you have already setup OneSignal with push
       certificates and everything needed in order to start sending push
       notifications. You should also have already integrated the OneSignal SDK
       within your application.

--- a/content/integrations/push/token-deregistration.mdx
+++ b/content/integrations/push/token-deregistration.mdx
@@ -44,4 +44,4 @@ Knock will remove the invalid token from the list of tokens present in the recip
 
 ### Outbound webhooks
 
-If you use Knock's outbound webhooks, you can view the invalid token in the `message.bounced` events captured. If token deregistration is `ON`, no further intervention is needed for token removal. See the [outbound webhooks guide](/developer-tools/outbound-webhooks/overview) for more details.
+If you use Knock's outbound webhooks, you can view the invalid token in the `message.bounced` events captured. If token deregistration is `ON`, no further intervention is needed for token removal. See the [outbound webhooks documentation](/developer-tools/outbound-webhooks/overview) for more details.

--- a/content/integrations/sms/africas-talking.mdx
+++ b/content/integrations/sms/africas-talking.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Africa's Talking
-description: Setup guide for SMS notifications with Africa's Talking and Knock.
+description: Setup tutorial for SMS notifications with Africa's Talking and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/africas-talking.mdx
+++ b/content/integrations/sms/africas-talking.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Africa's Talking
-description: Setup tutorial for SMS notifications with Africa's Talking and Knock.
+description: Get started sending SMS notifications with Africa's Talking and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/aws-sns.mdx
+++ b/content/integrations/sms/aws-sns.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with AWS SNS
-description: Setup tutorial for SMS notifications with AWS SNS and Knock.
+description: Get started sending SMS notifications with AWS SNS and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/aws-sns.mdx
+++ b/content/integrations/sms/aws-sns.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with AWS SNS
-description: Setup guide for SMS notifications with AWS SNS and Knock.
+description: Setup tutorial for SMS notifications with AWS SNS and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/mailersend.mdx
+++ b/content/integrations/sms/mailersend.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with MailerSend
-description: Setup tutorial for SMS notifications with MailerSend and Knock.
+description: Get started sending SMS notifications with MailerSend and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/mailersend.mdx
+++ b/content/integrations/sms/mailersend.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with MailerSend
-description: Setup guide for SMS notifications with MailerSend and Knock.
+description: Setup tutorial for SMS notifications with MailerSend and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/messagebird.mdx
+++ b/content/integrations/sms/messagebird.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with MessageBird
-description: Setup guide for SMS notifications with MessageBird and Knock.
+description: Setup tutorial for SMS notifications with MessageBird and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/messagebird.mdx
+++ b/content/integrations/sms/messagebird.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with MessageBird
-description: Setup tutorial for SMS notifications with MessageBird and Knock.
+description: Get started sending SMS notifications with MessageBird and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/overview.mdx
+++ b/content/integrations/sms/overview.mdx
@@ -10,7 +10,7 @@ Effortlessly design and deliver SMS notifications to downstream providers. Let K
 ## Features
 
 - **Easy templating**: it's easy to create and maintain SMS notification templates in Knock's editor.
-- **Link tracking**: capture link-click events right within your Knock account. For more details, see the [Knock link tracking guide](/send-notifications/tracking).
+- **Link tracking**: capture link-click events right within your Knock account. For more details, see the [Knock link tracking documentation](/send-notifications/tracking).
 
 ## Supported providers
 

--- a/content/integrations/sms/plivo.mdx
+++ b/content/integrations/sms/plivo.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Plivo
-description: Setup guide for SMS notifications with Plivo and Knock.
+description: Setup tutorial for SMS notifications with Plivo and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/plivo.mdx
+++ b/content/integrations/sms/plivo.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Plivo
-description: Setup tutorial for SMS notifications with Plivo and Knock.
+description: Get started sending SMS notifications with Plivo and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/sinch-message-media.mdx
+++ b/content/integrations/sms/sinch-message-media.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Sinch MessageMedia
-description: Setup guide for SMS notifications with Sinch MessageMedia and Knock.
+description: Setup tutorial for SMS notifications with Sinch MessageMedia and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/sinch-message-media.mdx
+++ b/content/integrations/sms/sinch-message-media.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Sinch MessageMedia
-description: Setup tutorial for SMS notifications with Sinch MessageMedia and Knock.
+description: Get started sending SMS notifications with Sinch MessageMedia and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/sinch.mdx
+++ b/content/integrations/sms/sinch.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Sinch
-description: Setup tutorial for SMS notifications with Sinch and Knock.
+description: Get started sending SMS notifications with Sinch and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/sinch.mdx
+++ b/content/integrations/sms/sinch.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Sinch
-description: Setup guide for SMS notifications with Sinch and Knock.
+description: Setup tutorial for SMS notifications with Sinch and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/telnyx.mdx
+++ b/content/integrations/sms/telnyx.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Telnyx
-description: Setup guide for SMS notifications with Telnyx and Knock.
+description: Setup tutorial for SMS notifications with Telnyx and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/telnyx.mdx
+++ b/content/integrations/sms/telnyx.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Telnyx
-description: Setup tutorial for SMS notifications with Telnyx and Knock.
+description: Get started sending SMS notifications with Telnyx and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/twilio.mdx
+++ b/content/integrations/sms/twilio.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Twilio
-description: Setup guide for SMS notifications with Twilio and Knock.
+description: Setup tutorial for SMS notifications with Twilio and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/twilio.mdx
+++ b/content/integrations/sms/twilio.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Twilio
-description: Setup tutorial for SMS notifications with Twilio and Knock.
+description: Get started sending SMS notifications with Twilio and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/vonage.mdx
+++ b/content/integrations/sms/vonage.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Vonage
-description: Setup tutorial for SMS notifications with Vonage and Knock.
+description: Get started sending SMS notifications with Vonage and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sms/vonage.mdx
+++ b/content/integrations/sms/vonage.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to send SMS messages with Vonage
-description: Setup guide for SMS notifications with Vonage and Knock.
+description: Setup tutorial for SMS notifications with Vonage and Knock.
 section: Integrations > SMS
 layout: integrations
 ---

--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -181,7 +181,7 @@ To ensure that the user is notified, we'd change the id reference in `recipients
 }
 ```
 
-You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
+You can learn more about inline identification in [our documentation on identifying recipients](/managing-recipients/identifying-recipients).
 
 ## Event idempotency
 

--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -162,7 +162,7 @@ To ensure that the user is notified, we'd change the id reference in `recipients
 }
 ```
 
-You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
+You can learn more about inline identification in [our documentation on identifying recipients](/managing-recipients/identifying-recipients).
 
 ## Video walkthrough
 

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -5,7 +5,7 @@ section: Integrations > Sources
 layout: integrations
 ---
 
-This guide covers using Segment as a [Knock source](/integrations/sources/overview) to bring track and identify event data from Segment into Knock to power your notifications.
+Knock's Segment integration enables you to use Segment as a [Knock source](/integrations/sources/overview) to power your notifications with track and identify events.
 
 Knock also provides a separate [Segment extension](/integrations/extensions/segment) for sending Knock notification data into Segment for use in your downstream tools.
 
@@ -203,7 +203,7 @@ To ensure the user is notified, we'd change the id reference in `recipients` to 
 }
 ```
 
-You can learn more about inline identification in [our guide on identifying recipients](/managing-recipients/identifying-recipients).
+You can learn more about inline identification in [our identifying recipients documentation](/managing-recipients/identifying-recipients).
 
 ## Video walkthrough
 

--- a/content/integrations/webhook/overview.mdx
+++ b/content/integrations/webhook/overview.mdx
@@ -140,6 +140,6 @@ To test that the payload sent has not been compromised, you can recreate the sig
 
   </Accordion>
   <Accordion title="Can I use the Knock webhook channel to power customer-facing webhooks in my own product?">
-    Yes! We cover this in more detail in our guide on [building customer configurable webhooks](/tutorials/customer-webhooks).
+    Yes! We cover this in more detail in our tutorial on [building customer configurable webhooks](/tutorials/customer-webhooks).
   </Accordion>
 </AccordionGroup>

--- a/content/manage-your-account/directory-sync.mdx
+++ b/content/manage-your-account/directory-sync.mdx
@@ -31,10 +31,10 @@ Any users that are assigned in the Knock application in your identity provider w
 To set up directory sync for your account:
 
 1. Contact the [Knock support team](mailto:support@knock.app).
-2. Our team will provide you with a customized link to guide you through the Directory Sync setup process for your specific identity provider.
-3. Follow the step-by-step instructions in the guide provided at the link in order to complete the configuration.
+2. Our team will provide you with a custom link to your identity provider's Directory Sync setup process.
+3. From that link, follow the step-by-step instructions to complete the configuration.
 
-We support many common identity providers. For detailed, provider-specific setup guides, please refer to the following:
+We support many common identity providers. For detailed, provider-specific setup documentation, please refer to the following:
 
 - [CyberArk](https://workos.com/docs/integrations/cyberark-scim/2-select-or-create-your-cyberark-application)
 - [Entra ID (formerly Azure AD)](https://workos.com/docs/integrations/entra-id-scim/2-select-or-create-your-azure-application)

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -50,7 +50,7 @@ There are three ways of setting channel data for a given recipient:
       title="Set channel data for an Object"
     />
 
-    You can learn more about objects in our [concept guide](/concepts/objects) and [API reference](/api-reference/objects).
+    You can learn more about objects in our [the objects concept overview](/concepts/objects) and [API reference](/api-reference/objects).
 
   </Accordion>
   <Accordion title="Setting channel data inline">
@@ -110,7 +110,7 @@ Any previously set channel data can be cleared by issuing an `unsetChannelData` 
       recipient's channel data when messages bounce. Learn more about this
       opt-in feature in our{" "}
       <a href="/integrations/push/token-deregistration">
-        token deregistration guide
+        token deregistration documentation
       </a>
       .
     </>
@@ -174,7 +174,7 @@ Channel data requirements for each provider are listed below. Typically `channel
     | connections | `SlackConnection[]` | One or more connections to Slack |
 
     A `SlackConnection` can have one of two schemas, depending on whether you're using standard Slack OAuth scopes or an incoming webhook.
-    We cover Slack app scopes in detail in our [Slack scopes guide](/in-app-ui/react/slack-kit).
+    We cover Slack app scopes in detail in our [Slack scopes documentation](/in-app-ui/react/slack-kit).
 
     If you're using standard Slack OAuth with access token scopes, your `SlackConnection` schema looks like this. You'll use
     either a `channel_id` or `user_id` depending on whether you're storing connection data to message a channel or user in Slack:

--- a/content/preferences/object-preferences.mdx
+++ b/content/preferences/object-preferences.mdx
@@ -1,6 +1,6 @@
 ---
 title: Object preferences
-description: A guide to storing preferences on objects.
+description: Documentation about to storing preferences on objects.
 tags: ["object preferences", "preferences"]
 section: Preferences
 ---

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -160,7 +160,7 @@ There are four steps to building a preference center with Knock:
 
     Once you have loaded a user's preference, you'll need to render an interface in your application so they can update their notification preferences. Typically you encapsulate all of the getting and setting of preferences in a single component.
 
-    You can see an example of this below, but our [quickstart tutorial on building preferences UI](/in-app-ui/react/preferences) provides an in-depth walkthrough of how to build a functional `PreferenceCenter` component.
+    You can see an example of this below, but our [quickstart documentation on building preferences UI](/in-app-ui/react/preferences) provides an in-depth walkthrough of how to build a functional `PreferenceCenter` component.
 
 ```jsx title="A basic preference center"
 <PreferenceCenter />

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -160,7 +160,7 @@ There are four steps to building a preference center with Knock:
 
     Once you have loaded a user's preference, you'll need to render an interface in your application so they can update their notification preferences. Typically you encapsulate all of the getting and setting of preferences in a single component.
 
-    You can see an example of this below, but our [quickstart guide on building preferences UI](/in-app-ui/react/preferences) provides an in-depth walkthrough of how to build a functional `PreferenceCenter` component.
+    You can see an example of this below, but our [quickstart tutorial on building preferences UI](/in-app-ui/react/preferences) provides an in-depth walkthrough of how to build a functional `PreferenceCenter` component.
 
 ```jsx title="A basic preference center"
 <PreferenceCenter />
@@ -354,7 +354,7 @@ You can update the preferences of up to 1000 users in a single batch by using th
 ## Advanced concepts
 
 - [Per-tenant preferences](/preferences/tenant-preferences). In multi-tenant B2B applications, an advanced use case is customer admins who want to set the tenant-level default `PreferenceSet` for new users within their tenant.
-- [Object preferences](/preferences/object-preferences). In the guide above, we referred to user preferences. You can also set preferences for objects.
+- [Object preferences](/preferences/object-preferences). Just as you can for users, you can set preferences for objects.
 - [Preference conditions](/preferences/preference-conditions). You can build advanced conditions and store them on Knock’s preference model to power use cases such as per-resource muting (example: mute notifications about this task) or threshold alerts (example: only notify me if my account balance is below $5).
 - Merge strategy. It's possible to configure the merge strategy on specific preferences within a `PreferenceSet`. This allows you to override the default merge hierarchy when preferences are evaluated. See the [Frequently asked questions](#frequently-asked-questions) section below for more details and use cases.
 - Workflow overrides. If you need to override a recipient's notification preferences to send notifications like a password reset email, you can override the preferences model. To do this, go to your workflow, click "Manage workflow," and enable "Override recipient preferences." You will need to commit this change for it to take effect. When enabled, the workflow will send to all of its channels, regardless of the recipient's preferences.

--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -86,7 +86,7 @@ Here's how to set preference conditions for a user.
 
   </Accordion>
   <Accordion title="How do I debug preference conditions?">
-    Knock will capture conditions evaluation details for all preference conditions resolved while executing your workflows. See the [guide on debugging conditions](/concepts/conditions#debugging-conditions) for more info.
+    Knock will capture conditions evaluation details for all preference conditions resolved while executing your workflows. See the [documentation on debugging conditions](/concepts/conditions#debugging-conditions) for more info.
   </Accordion>
   <Accordion title="Can I use multiple conditions on a single preference?">
     Yes. You can use multiple conditions within a single preference `conditions` array. Note that all conditions in the array must evaluate to `true` in order for the notification to be sent; this is a logical `AND` operation.

--- a/content/preferences/tenant-preferences.mdx
+++ b/content/preferences/tenant-preferences.mdx
@@ -34,9 +34,9 @@ If you're a B2B application or a multi-tenant SaaS product, you can use tenant p
   title="Terminology callout."
   text={
     <>
-      This guide assumes you know about tenants in Knock and what they do. If
-      you're new to tenants, we recommend reading our concept guide on{" "}
-      <a href="/concepts/tenants">tenants</a> before continuing.
+      This documentation assumes you know about tenants in Knock and what they
+      do. If you're new to tenants, we familiarizing yourself with the concept
+      of <a href="/concepts/tenants">tenants</a> before continuing.
     </>
   }
 />

--- a/content/send-notifications/canceling-workflows.mdx
+++ b/content/send-notifications/canceling-workflows.mdx
@@ -17,7 +17,7 @@ Only workflows with a step that can pause the run can be canceled, since otherwi
 
 To perform a cancellation, you first need to provide a `cancellation_key` in the [workflow trigger](/send-notifications/triggering-workflows) request. Knock will use this key to uniquely identify the triggered workflow for cancellation.
 
-You can read about generating workflow cancellation keys and some best practices in the [triggering workflows guide](/send-notifications/triggering-workflows/api#generating-a-cancellation-key).
+You can read about generating workflow cancellation keys and some best practices in the [triggering workflows documentation](/send-notifications/triggering-workflows/api#generating-a-cancellation-key).
 
 <MultiLangCodeBlock
   snippet="workflows.cancel"

--- a/content/send-notifications/message-statuses.mdx
+++ b/content/send-notifications/message-statuses.mdx
@@ -85,7 +85,7 @@ On a per-channel level, `delivered` means that:
 - **Email** — Your message was successfully delivered to the recipient's email service provider.
 - **In-app** — Your message was successfully delivered to the recipient's feed.
 - **Push** — We do not support delivery tracking for push channels, so push channel messages will never have a delivery status greater than `sent`. However, you can introduce a handler into your mobile app to update a given message's [engagement status](#engagement-status) when the message has successfully made it to your recipient's device, using the `knock_message_id` from the push notification payload.
-- **SMS** — Your message was successfully sent to the recipient's SMS provider. Note that not all SMS delivery providers support delivery tracking. See the [Knock integration guides for SMS providers](/integrations/sms/overview) for more information.
+- **SMS** — Your message was successfully sent to the recipient's SMS provider. Note that not all SMS delivery providers support delivery tracking. See the [Knock integration documentation for SMS providers](/integrations/sms/overview) for more information.
 - **Chat** — Delivery tracking is not available for chat platforms, so chat channel messages will never have a delivery status greater than `sent`. In most cases, a `sent` status will also mean that the message has been delivered to the recipient.
 - **Webhook** — Your message was successfully delivered to your webhook endpoint.
 
@@ -169,4 +169,4 @@ The message has been archived by the recipient. The timestamp represents the tim
 
 ## Message events
 
-Knock records each change in message status, whether delivery or engagement, as a message event. You can view these events in chronological order of occurrence in the message timeline view in the Knock dashboard. Knock also uses these message events to power webhooks. See our [guide on outbound webhooks](/developer-tools/outbound-webhooks/overview) to learn more about how you can hook into the Knock message status lifecycle.
+Knock records each change in message status, whether delivery or engagement, as a message event. You can view these events in chronological order of occurrence in the message timeline view in the Knock dashboard. Knock also uses these message events to power webhooks. See our [documentation on outbound webhooks](/developer-tools/outbound-webhooks/overview) to learn more about how you can hook into the Knock message status lifecycle.

--- a/content/send-notifications/message-statuses.mdx
+++ b/content/send-notifications/message-statuses.mdx
@@ -41,19 +41,19 @@ Below we break down each status in detail (including any channel-specific limita
 
 We attempted to deliver your message, we encountered an error, and _we will not retry delivery_. Your message has not made it from Knock to your provider.
 
-You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our guide on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
+You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our documentation on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
 
 ### 2) Bounced
 
 Your message was successfully sent to the downstream provider, but the message was dropped by your provider due to bad recipient data, resulting in a bounce, and _we will not retry delivery_.
 
-You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our guide on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
+You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our documentation on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
 
 ### 3) Delivery attempted
 
 We attempted to deliver your message, but we encountered an error. If we deem the error retryable and we have not hit our retry limit, we will re-enqueue the message for another delivery attempt.
 
-You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our guide on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
+You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our documentation on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
 
 ### 4) Queued
 

--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -90,7 +90,7 @@ You'll need the following information ready to enable custom tracking domains.
    - **Name:** Your chosen subdomain (e.g., `links`)
    - **Value:** `cname.knock.app`
 
-Once you contact our support team, they'll guide you through the setup process and handle the technical configuration on our end.
+Once you contact our support team, they'll help you with the setup process and handle the technical configuration on our end.
 
 ### Step-level overrides
 
@@ -123,11 +123,11 @@ When link tracking is enabled, Knock will capture link-click actions as `message
 
 When link tracking is enabled for your channel, you can stitch link-click events into your workflows as a step condition. For example, you can require that at least one link in a previous channel step has been clicked for the current step to execute.
 
-See the [step conditions guide](/designing-workflows/step-conditions) for more details.
+See the [step conditions documentation](/designing-workflows/step-conditions) for more details.
 
 ### Knock Webhooks
 
-If you use Knock's outbound webhooks, you can hook into the `message.read` and `message.link_clicked` events captured via Knock tracking. See the [outbound webhooks guide](/developer-tools/outbound-webhooks/overview) for more details.
+If you use Knock's outbound webhooks, you can hook into the `message.read` and `message.link_clicked` events captured via Knock tracking. See the [outbound webhooks documentation](/developer-tools/outbound-webhooks/overview) for more details.
 
 ## How it works
 

--- a/content/send-notifications/triggering-workflows/api.mdx
+++ b/content/send-notifications/triggering-workflows/api.mdx
@@ -70,7 +70,7 @@ The workflow builder determines which data keys are required.
   text={
     <>
       For more information on validating trigger data and working with JSON
-      schemas, see our tutorial on{" "}
+      schemas, see our documentation on{" "}
       <a href="/developer-tools/validating-trigger-data">
         validating trigger data
       </a>
@@ -99,7 +99,7 @@ Calling a workflow trigger with an actor:
 
 Include a `cancellation_key` in your `trigger` call to enable workflow cancellation.
 
-You can read more about canceling workflows [in our tutorial](/send-notifications/canceling-workflows).
+You can read more about canceling workflows [in our documentation](/send-notifications/canceling-workflows).
 
 The key should uniquely identify the workflow run you want to cancel. We recommend using:
 
@@ -205,7 +205,7 @@ You can optionally pass a `tenant` to your `trigger` call. If you are a product 
 you'll want to pass a `tenant` to Knock in your trigger calls so that you can make sure a given user's in-app feed is scoped to the
 tenants to which they belong in your product.
 
-You can read more about [supporting multi-tenancy in our tutorial](/concepts/tenants).
+You can read more about [supporting multi-tenancy in our documentation](/concepts/tenants).
 
 ## Frequently asked questions
 

--- a/content/send-notifications/triggering-workflows/events.mdx
+++ b/content/send-notifications/triggering-workflows/events.mdx
@@ -30,7 +30,7 @@ From the Trigger step sidebar, if you have events connected to Knock you'll see 
   <Accordion title="Can I cancel a workflow run triggered by an event?">
     Yes, you can cancel any workflow that contains a pause step (batch, delay,
     or fetch function). The ability to cancel depends on the workflow structure,
-    not how it was triggered. See our guide on [canceling
+    not how it was triggered. See our documentation on [canceling
     workflows](/send-notifications/canceling-workflows) for details.
   </Accordion>
 </AccordionGroup>

--- a/content/tutorials/alerting.mdx
+++ b/content/tutorials/alerting.mdx
@@ -5,7 +5,7 @@ tags: ["alert", "alerts", "alerting"]
 section: Tutorials
 ---
 
-In this guide, we’ll cover some best practices in creating alerting-style workflows in Knock. Alerts are common in many types of infrastructure tools, like Datadog or Honeycomb, as well as in product management and data tools like Amplitude or Mixpanel.
+In this documentation, we’ll cover some best practices in creating alerting-style workflows in Knock. Alerts are common in many types of infrastructure tools, like Datadog or Honeycomb, as well as in product management and data tools like Amplitude or Mixpanel.
 
 <Callout
   emoji="👩‍💻"
@@ -23,7 +23,7 @@ In this guide, we’ll cover some best practices in creating alerting-style work
   }
 />
 Here are some assumptions we’ll make about configurable alerts for the purposes of
-this guide:
+this tutorial:
 
 1. The user should be able to pick the channels (like email, SMS, and in-app) that the workflow will use to notify recipients.
 2. The user can define the list of recipients who will receive these notifications.
@@ -65,7 +65,7 @@ await knock.workflows.trigger("alert", {
 
 When you look at this code sample, you’ll see that there’s nothing fundamentally different about triggering an alert than triggering any other type of notification. You pass in data to be used in the workflow itself as well as all of the recipient references. You can then use the data in individual channel and function steps to drive the logic of your workflow.
 
-In the next step of this guide, we’ll explore how you can offload more of this modeling to Knock, but it’s worth discussing the pros and cons of these two approaches.
+In the next step of this documentation, we’ll explore how you can offload more of this modeling to Knock, but it’s worth discussing the pros and cons of these two approaches.
 
 ### Benefits of modeling in your system
 

--- a/content/tutorials/building-recurring-digests.mdx
+++ b/content/tutorials/building-recurring-digests.mdx
@@ -5,7 +5,7 @@ tags: ["weekly", "daily", "monthly", "recurrence"]
 section: Tutorials
 ---
 
-In this guide, we'll create a simple recurring digest notification for our customers that will execute a digest every Monday at 9am to summarize information that the users might have missed in the past week.
+In this tutorial, we'll create a simple recurring digest notification for our customers that will execute a digest every Monday at 9am to summarize information that the users might have missed in the past week.
 
 To do so, we'll use the [schedules API](/concepts/schedules) and the [fetch function](/designing-workflows/fetch-function) to build a powerful, flexible notification workflow that is driven by dynamic data from your service.
 

--- a/content/tutorials/customer-webhooks.mdx
+++ b/content/tutorials/customer-webhooks.mdx
@@ -5,7 +5,7 @@ tags: ["webhooks", "webhooks as a service"]
 section: Tutorials
 ---
 
-In this guide, we’ll walk through how Knock can be used to send per-customer configurable webhooks as part of your notification workflows.
+In this tutorial, we'll walk through how Knock can be used to send per-customer configurable webhooks as part of your notification workflows.
 
 <Callout
   emoji="👩‍💻"

--- a/content/tutorials/implementation-guide.mdx
+++ b/content/tutorials/implementation-guide.mdx
@@ -1,11 +1,11 @@
 ---
-title: Knock implementation guide
+title: Implementing Knock
 description: Learn how to plan and execute your Knock integration from start to finish.
 tags: ["migrate", "migration", "implementation", "building", "planning"]
 section: Tutorials
 ---
 
-Knock’s APIs and developer tools make it easy to migrate your notification templates, delivery logic, recipient data, and user preferences into Knock. In this guide, we will walk you through planning and executing your Knock integration from start to finish.
+Knock’s APIs and developer tools make it easy to migrate your notification templates, delivery logic, recipient data, and user preferences into Knock. In this tutorial, we will walk you through planning and executing your Knock integration from start to finish.
 
 If you’re new to Knock, we recommend taking a look at our [What is Knock?](/getting-started/what-is-knock) page to learn more about our product and how it can be used. You may also want to take a closer look at various [Concepts](/concepts/overview) as you familiarize yourself with the product.
 
@@ -96,7 +96,7 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
 
     The [User](/concepts/users) object in Knock has a number of (optional) reserved attributes like `name`, `email`, and `phone_number`, but it can also store any number of custom properties which can be used in the logic and templates of your workflow; for example, you might want to deliver different messages based on a user’s `role`. These attributes can be updated at any time with subsequent upserts.
 
-    We offer a variety of ways to identify your users to Knock, so you’ll want to look over our guide on [identifying recipients](/managing-recipients/identifying-recipients) before you solidify your migration plan. If you’re planning to send notifications to [push](/integrations/push/overview) or [chat](/integrations/chat/overview) channels, you’ll also need to review our guide on [setting channel data](/managing-recipients/setting-channel-data) to ensure that we can deliver your messages to the right place.
+    We offer a variety of ways to identify your users to Knock, so you'll want to look over our documentation on [identifying recipients](/managing-recipients/identifying-recipients) before you solidify your migration plan. If you're planning to send notifications to [push](/integrations/push/overview) or [chat](/integrations/chat/overview) channels, you'll also need to review our documentation on [setting channel data](/managing-recipients/setting-channel-data) to ensure that we can deliver your messages to the right place.
 
     Remember, the Knock environment model means that you’ll need to identify production users directly into your Knock Production environment.
 
@@ -213,7 +213,7 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
   </Step>
 </Steps>
 
-For more information and in-depth guidance on specific use cases, please take a look at our [example apps](/getting-started/example-apps) and the following guides:
+For more information and in-depth guidance on specific use cases, please take a look at our [example apps](/getting-started/example-apps) and the following tutorials:
 
 - [Alerting](/tutorials/alerting)
 - [Customer-facing webhooks](/tutorials/customer-webhooks)
@@ -234,7 +234,7 @@ Here are some use cases that will require additional client-side planning:
 
 Testing your notifications and insight into any errors that occur are a key part of developing and deploying your Knock integration. Knock offers many tools and resources to help you ensure that your users are receiving the right messages at the right time:
 
-- Guides on tools for [testing](/send-notifications/testing-workflows) and [debugging](/send-notifications/debugging-workflows) workflows.
+- Documentation on tools for [testing](/send-notifications/testing-workflows) and [debugging](/send-notifications/debugging-workflows) workflows.
 - A [Postman collection](/developer-tools/knock-and-postman) to test against our API.
 - An optional [sandbox mode](/integrations/overview#sandbox-mode) on each of your channels that allows you to generate and preview messages without sending them to your downstream provider for delivery.
 - [Delivery and engagement statuses](/send-notifications/message-statuses) for all of the notifications sent through Knock.

--- a/content/tutorials/migrate-from-courier.mdx
+++ b/content/tutorials/migrate-from-courier.mdx
@@ -5,7 +5,7 @@ tags: ["migrate", "courier", "migration"]
 section: Tutorials
 ---
 
-Knock’s APIs and developer tools make it easy to migrate your notification templates and user data from other notifications platforms into Knock. In this guide, we will walk you through planning and executing a migration from Courier into Knock.
+Knock’s APIs and developer tools make it easy to migrate your notification templates and user data from other notifications platforms into Knock. In this tutorial, we will walk you through planning and executing a migration from Courier into Knock.
 
 ## Mapping Courier concepts to Knock concepts
 

--- a/content/tutorials/modeling-users-objects-and-tenants.mdx
+++ b/content/tutorials/modeling-users-objects-and-tenants.mdx
@@ -4,7 +4,7 @@ description: Learn how to map your application's data model into Knock.
 section: Tutorials
 ---
 
-In this guide, we’ll cover some best practices in modeling users, tenants, and objects in Knock. Since Knock is a set of flexible abstractions, there are many possible ways to map these concepts in Knock to entities in your own application, but this guide will use examples to help you with this decision-making process.
+In this tutorial, we'll cover some best practices in modeling users, tenants, and objects in Knock. Since Knock is a set of flexible abstractions, there are many possible ways to map these concepts in Knock to entities in your own application, but this tutorial will use examples to help you with this decision-making process.
 
 To do this, we’ll use an example collaboration app called Collab.io that consists of users, workspaces, projects, and alerts.
 
@@ -18,7 +18,7 @@ To do this, we’ll use an example collaboration app called Collab.io that consi
 
 ## Users in Knock
 
-Users in Knock are the most straightforward concept to explain in this guide because users in your application will map directly to users in Knock. Users in Knock are identified with a unique `id`, which in most cases should be the same `id` that you use to identify them in your application.
+Users in your application will map directly to users in Knock. Users in Knock are [identified](/managing-recipients/identifying-recipients) with a unique `id`, which in most cases should be the same `id` that you use to identify them in your application.
 
 <Image
   src="/images/tutorials/modeling-users-objects-and-tenants/user-modeled-new.png"
@@ -88,7 +88,7 @@ Since an Object can store any number of custom properties, you can also include 
 }
 ```
 
-When you trigger a workflow with this object as a recipient, you can use the `url` and `signingKey` properties to generate a secure webhook request. Using the `events` array, you can store event subscriptions directly on the Object and filter out webhook events using a [step condition](https://docs.knock.app/designing-workflows/step-conditions). To learn more about using Objects and webhooks, you can read [our guide on creating customer facing webhooks](https://docs.knock.app/tutorials/customer-webhooks).
+When you trigger a workflow with this object as a recipient, you can use the `url` and `signingKey` properties to generate a secure webhook request. Using the `events` array, you can store event subscriptions directly on the Object and filter out webhook events using a [step condition](https://docs.knock.app/designing-workflows/step-conditions). To learn more about using Objects and webhooks, you can read [our tutorial on creating customer facing webhooks](https://docs.knock.app/tutorials/customer-webhooks).
 
 #### A Slack integration
 

--- a/content/tutorials/overview.mdx
+++ b/content/tutorials/overview.mdx
@@ -1,13 +1,22 @@
 ---
 title: Tutorials
-description: Guides for using Knock
-tags: ["alert", "alerts", "alerting"]
+description: Tutorials for using Knock
+tags:
+  [
+    "alert",
+    "alerts",
+    "alerting",
+    "tutorial",
+    "quickstart",
+    "implementation guide",
+    "how to",
+  ]
 section: Tutorials
 ---
 
 <ResponsiveThreeColumn>
   <ContentCard
-    title="Knock implementation guide"
+    title="Implementing Knock"
     description="A complete walkthrough of implementing Knock in your product."
     href="/tutorials/implementation-guide"
     icon={"BookUp"}

--- a/data/sidebars/developerToolsSidebar.ts
+++ b/data/sidebars/developerToolsSidebar.ts
@@ -32,7 +32,7 @@ export const DEVELOPER_TOOLS_SIDEBAR_CONTENT: SidebarContent[] = [
   },
   {
     slug: `${baseSlug}/migration-guides`,
-    title: "Migration guides",
+    title: "Migration manuals",
     pages: [
       { slug: "/node", title: "Node.js 1.0" },
       { slug: "/python", title: "Python 1.0" },

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -4,7 +4,7 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
   {
     title: "Getting started",
     slug: "/getting-started",
-    desc: "A technical and non-technical introduction to the basics of Knock, and a step-by-step guide to get you going in minutes.",
+    desc: "An introduction to the basics of Knock.",
     pages: [
       { slug: "/what-is-knock", title: "What is Knock?" },
       { slug: "/quick-start", title: "Quick start" },

--- a/data/sidebars/tutorialsSidebar.ts
+++ b/data/sidebars/tutorialsSidebar.ts
@@ -14,7 +14,7 @@ export const TUTORIALS_SIDEBAR: SidebarContent[] = [
   },
   {
     slug: `${baseSlug}/implementation-guide`,
-    title: "Knock implementation guide",
+    title: "Implementing Knock",
   },
   {
     slug: `${baseSlug}/alerting`,


### PR DESCRIPTION
## Update terminology where "guides" is used in documentation

This PR updates the documentation to use alternative copy where we previously used the words guide and guides, aligning with our style guide that reserves those terms for the specific Knock feature. Reserved the word "tutorial" for referencing our tutorials section explicitly.

### Changes:
- Updated terminology throughout documentation files to protect "guides" and "tutorial"
- Updated sidebar navigation names as needed
- Aligned email provider introduction sections
- Fixed various typos discovered during the update
- Simplified language in some places while updating old copy

### Note: 
- There are few places where "guide" is still used to reference external resources named as such.
- Renamed the SDK "migration guides" to "migration manuals" but didn't update URL slugs as I was concerned about breaking links we've shared.