### PR TITLE
chore(kno-9687): clarify schedule fanout limitations

### DIFF
--- a/content/concepts/schedules.mdx
+++ b/content/concepts/schedules.mdx
@@ -85,19 +85,6 @@ const schedules = await client.schedules.create({
 });
 ```
 
-### Schedule properties
-
-| Variable       | Type                  | Description                                                                                                                                                                 |
-| -------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `recipients`   | RecipientIdentifier[] | One or more recipient identifiers, or complete recipients to be upserted.                                                                                                   |
-| `workflow`     | string                | The workflow to trigger.                                                                                                                                                    |
-| `repeats`      | ScheduleRepeat[]      | A list of one or more repeats (see below). Required if you're creating a recurring schedule.                                                                                |
-| `data`         | map                   | Custom data to pass to every workflow trigger.                                                                                                                              |
-| `tenant`       | string                | A tenant to pass to the workflow trigger.                                                                                                                                   |
-| `actor`        | RecipientIdentifier   | An identifier of an actor, or a complete actor to be upserted.                                                                                                              |
-| `scheduled_at` | utc_datetime          | A UTC datetime in ISO-8601 format representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule.          |
-| `ending_at`    | utc_datetime          | A UTC datetime in ISO-8601 format that indicates when the schedule should end. Once the current schedule time passes `ending_at`, no further occurrences will be scheduled. |
-
 <Callout
   emoji="🚨"
   title="Note:"
@@ -112,6 +99,19 @@ const schedules = await client.schedules.create({
     </>
   }
 />
+
+### Schedule properties
+
+| Variable       | Type                  | Description                                                                                                                                                                 |
+| -------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `recipients`   | RecipientIdentifier[] | One or more recipient identifiers, or complete recipients to be upserted.                                                                                                   |
+| `workflow`     | string                | The workflow to trigger.                                                                                                                                                    |
+| `repeats`      | ScheduleRepeat[]      | A list of one or more repeats (see below). Required if you're creating a recurring schedule.                                                                                |
+| `data`         | map                   | Custom data to pass to every workflow trigger.                                                                                                                              |
+| `tenant`       | string                | A tenant to pass to the workflow trigger.                                                                                                                                   |
+| `actor`        | RecipientIdentifier   | An identifier of an actor, or a complete actor to be upserted.                                                                                                              |
+| `scheduled_at` | utc_datetime          | A UTC datetime in ISO-8601 format representing the start moment for the recurring schedule, or the exact and only execution moment for the non-recurring schedule.          |
+| `ending_at`    | utc_datetime          | A UTC datetime in ISO-8601 format that indicates when the schedule should end. Once the current schedule time passes `ending_at`, no further occurrences will be scheduled. |
 
 ### ScheduleRepeat properties
 
@@ -288,6 +288,12 @@ Knock supports a `timezone` property on the recipient that automatically makes a
 ## Frequently asked questions
 
 <AccordionGroup>
+  <Accordion title="Can I create a schedule to notify subscribers of an object?">
+    No, currently we do not support creating schedules to notify subscribers of
+    an object. Each individual subscriber will need to be added as a recipient
+    when creating the workflow schedule; a schedule for an object recipient will
+    only generate a workflow run for that object.
+  </Accordion>
   <Accordion title="How can I start my repeating schedule at a particular time?">
     You can use the `scheduled_at` attribute to start your schedule at a
     particular time in the future.

--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -205,10 +205,11 @@ Knock always deduplicates recipients when executing a notification fan out, incl
     No, currently the `actor` is **always** excluded from being a recipient in a
     workflow trigger if they are a subscriber to an Object recipient.
   </Accordion>
-  <Accordion title="Can I create a schedule for subscribers of an object?">
-    No, currently we do not support [creating schedules](/concepts/schedules)
-    for subscribers of an object. Each individual subscriber will need to be
-    added as a recipient when creating the workflow schedule.
+  <Accordion title="Can I create a schedule to notify subscribers of an object?">
+    No, currently we do not support [creating schedules](/concepts/schedules) to
+    notify subscribers of an object. Each individual subscriber will need to be
+    added as a recipient when creating the workflow schedule; a schedule for an
+    object recipient will only generate a workflow run for that object.
   </Accordion>
   <Accordion title="Can I cancel a workflow run for a specific recipient if they were notified via an object subscription?">
     Yes, you can. [Workflow


### PR DESCRIPTION
### Description

This PR aims to surface the limitation of schedules for object subscribers a bit more-clearly. It slightly updates the wording of the FAQ we already had on the subscriptions concept page, moves the location of the callout about this topic on the schedules page, and adds an FAQ to the schedules page as well in case someone skips straight to that section or misses the callout.

https://docs-kcejpx969-knocklabs.vercel.app/concepts/schedules
https://docs-kcejpx969-knocklabs.vercel.app/concepts/subscriptions
