### PR TITLE
chore(kno-9728): update node sdk readme links for token signing

### DIFF
--- a/content/in-app-ui/react/slack-kit.mdx
+++ b/content/in-app-ui/react/slack-kit.mdx
@@ -313,7 +313,7 @@ Example:
 - Recipient object collection: `videos`
 - Recipient object ID: `dinosaurs-loose`
 
-Using the above example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the above example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {

--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -298,7 +298,7 @@ Example:
 - Recipient object collection: `videos`
 - Recipient object ID: `dinosaurs-loose`
 
-Using the above example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the above example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {

--- a/content/in-app-ui/security-and-authentication.mdx
+++ b/content/in-app-ui/security-and-authentication.mdx
@@ -144,7 +144,7 @@ app.use(async (req, res, next) => {
 });
 ```
 
-You can see more details on the options for the `signUserToken` method [in the docs](https://github.com/knocklabs/knock-node#signing-jwts).
+You can see more details on the options for the `signUserToken` method <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">in the SDK docs</a>.
 
 ### 3. Send the JWT to the client
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -77,7 +77,7 @@ We've made it easy for you to tell Knock which resources your users should have 
 
 You'll need to generate a token for your user that includes access to the Knock tenant storing the Microsoft Entra tenant ID as well as any recipient objects storing Microsoft Teams channel data described in this reference on [TeamsKit resource access grants](/in-app-ui/react/teams-kit#resource-access-grants).
 
-Using the below example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the below example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -128,7 +128,7 @@ We've made it easy for you to tell Knock which resources your users should have 
 
 You'll need to generate a token for your user that includes access to the Knock tenant storing the Microsoft Entra tenant ID as well as any recipient objects storing Microsoft Teams channel data described in this reference on [TeamsKit resource access grants](/in-app-ui/react/teams-kit#resource-access-grants).
 
-Using the below example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the below example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -52,7 +52,7 @@ We've made it easy for you to tell Knock which resources your users should have 
 
 You'll need to generate a token for your user that includes access to the tenant storing the Slack access token as well as any recipient objects storing Slack channel data described in this reference on [SlackKit resource access grants](/in-app-ui/react/slack-kit#resources-access-grants).
 
-Using the below example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the below example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {

--- a/content/integrations/chat/slack/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/slack/sending-a-message-to-channels.mdx
@@ -90,7 +90,7 @@ We've made it easy for you to tell Knock which resources your users should have 
 
 You'll need to generate a token for your user that includes access to the tenant storing the Slack access token as well as any recipient objects storing Slack channel data described in this reference on [SlackKit resource access grants](/in-app-ui/react/slack-kit#resources-access-grants).
 
-Using the below example, you can quickly generate a token with the [Node SDK](https://github.com/knocklabs/knock-node#signing-jwts).
+Using the below example, you can quickly generate a token with the <a href="https://github.com/knocklabs/knock-node#jwt-token-signing" target="_blank">Node SDK</a>.
 
 ```javascript
 import {


### PR DESCRIPTION
### Description

This PR updates broken links to the Node SDK readme, where the header for JWT signing was renamed.
