### PR TITLE
fix: correct trigger workflow idempotency key example

### DIFF
--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -142,7 +142,7 @@ result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTri
 	Actor:           param.New("3"),
 	CancellationKey: param.New("cancel_123"),
 	Tenant:          param.New("jurassic_world_employees"),
-}, option.WithIdempotencyKey("123"))
+}, option.WithHeader("Idempotency-Key", "123"))
 `,
   java: `
 import app.knock.api.client.KnockClient;


### PR DESCRIPTION
### Description
Fixes the snippet to show the correct way to specify the idempotency key header. Confirmed via the next-example-app. 

<img width="1157" height="733" alt="CleanShot 2025-09-19 at 09 56 44" src="https://github.com/user-attachments/assets/329eba05-3d09-44cd-a8d9-caaae38a88d5" />
