### PR TITLE
chore(KNO-9099): update idempotency code example for Node.js SDK

### DIFF
--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -30,9 +30,7 @@ await knock.workflows.trigger(
     tenant: "jurassic_world_employees",
   },
   {
-    headers: {
-      "Idempotency-Key": "123",
-    },
+    idempotencyKey: "123",
   },
 );
 `,


### PR DESCRIPTION
### Description

This PR updates the idempotency code example for our Node.js SDK to pass in the `idempotencyKey` option, reverting the change to the Node.js example made by #1125.

[`@knocklabs/node` v1.17.0](https://github.com/knocklabs/knock-node/releases/tag/v1.17.0) made it so that specifying the `idempotencyKey` option will automatically set the `Idempotency-Key` request header, whereas this was not the case with prior releases.

Our Go SDK doesn’t actually have a `WithIdempotencyKey` function, so I’ve kept the Go example using `WithHeader`.

### Tasks

[KNO-9099](https://linear.app/knock/issue/KNO-9099/node-sdk-improve-idempotency-key-handling)

### Screenshots

#### Before

<img width="521" height="466" alt="Screenshot 2025-09-24 at 11 25 36 AM" src="https://github.com/user-attachments/assets/1a2b4651-1594-47fe-9b96-40325bff5287" />

#### After

<img width="527" height="433" alt="Screenshot 2025-09-24 at 11 44 46 AM" src="https://github.com/user-attachments/assets/25f910ee-4cce-4a73-b1b0-e08de5826bad" />
