### PR TITLE
chore: clarify that per-recipient batching w/ timezone awareness is not currently available

### DIFF
--- a/content/designing-workflows/batch-function.mdx
+++ b/content/designing-workflows/batch-function.mdx
@@ -376,7 +376,7 @@ If you want to remove an item from a batch (example: a user deletes a comment), 
     You can think about batching as a per-recipient, per-workflow summary of notifications that should be sent together. Many of our Knock customers use batching as a form of digest to reduce the number of notifications that their users receive. If you have more advance digesting needs that aren't covered by our current batching implementation, [please get in touch](mailto:support@knock.app).
   </Accordion>
   <Accordion title="Do you support per-recipient batch windows and timezones?">
-    We're currently working on this feature! If you'd like early access, please [get in touch with us](mailto:support@knock.app?subject=Per%20recipient%20batch%20windows).
+    No, this is not currently supported. If this is a blocker for your use case, please [get in touch with us](mailto:support@knock.app?subject=Per%20recipient%20batch%20windows).
   </Accordion>
   <Accordion title="How can I query for messages or feed items that were generated from activities with given workflow trigger call data?">
     When messages are generated from a batch step, the workflow trigger call data for the first (or last) 10 activities of the batch will be combined into one single entity at batch closing time.


### PR DESCRIPTION
### Description

Updates the FAQ under the batch function to clarify that per-recipient timezone-aware batching is not currently available for early access.
