### PR TITLE
chore(KNO-9901): update idempotency code example for Go SDK

### DIFF
--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -140,7 +140,7 @@ result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTri
 	Actor:           param.New("3"),
 	CancellationKey: param.New("cancel_123"),
 	Tenant:          param.New("jurassic_world_employees"),
-}, option.WithHeader("Idempotency-Key", "123"))
+}, option.WithIdempotencyKey("123"))
 `,
   java: `
 import app.knock.api.client.KnockClient;


### PR DESCRIPTION
### Description

[v1.18.0 of our Go SDK](https://github.com/knocklabs/knock-go/releases/tag/v1.18.0) includes a `WithIdempotencyKey` function. This PR updates the idempotency code example for the Go SDK to make use of `WithIdempotencyKey`.

### Tasks

[KNO-9901](https://linear.app/knock/issue/KNO-9901/docs-add-withidempotencykey-to-go-sdk-idempotency-example)

### Screenshots

<img width="520" height="462" alt="Screenshot 2025-09-26 at 6 00 12 PM" src="https://github.com/user-attachments/assets/c30cb74a-88f4-4633-b1b7-8d53a41b71c2" />
