### PR TITLE
chore: document new recipient.subscription.object reference

### DIFF
--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -119,7 +119,18 @@ When triggering a workflow for a recipient from a subscription, the `properties`
 
 As an example, if you have a property `role` under your subscription properties, you can access it as `recipient.subscription.role` in the workflow run scope.
 
-Note: If you're looking to reference the parent object that the recipient is subscribed to, you can side-load the parent object [using the `object` filter in liquid](/designing-workflows/template-editor/referencing-data).
+<Callout
+  emoji="💡"
+  bgColor="yellow"
+  title="Note:"
+  text={
+    <>
+      If you're looking to reference the parent object that the recipient is
+      subscribed to, you can use the <code>recipient.subscription.object</code>{" "}
+      property.
+    </>
+  }
+/>
 
 ## Modeling nested subscription hierarchies
 
@@ -198,8 +209,8 @@ Knock always deduplicates recipients when executing a notification fan out, incl
     team](mailto:support@knock.app).
   </Accordion>
   <Accordion title="Is the object that recipients are subscribed to exposed in the workflow run scope?">
-    No, currently we do not expose the object the subscription belongs to under
-    the workflow run scope.
+    Yes. You can access the object that the recipient is subscribed to using the
+    `recipient.subscription.object` property.
   </Accordion>
   <Accordion title="Will the actor included in the workflow trigger receive a notification if they are a subscriber?">
     No, currently the `actor` is **always** excluded from being a recipient in a

--- a/content/designing-workflows/template-editor/referencing-data.mdx
+++ b/content/designing-workflows/template-editor/referencing-data.mdx
@@ -41,6 +41,20 @@ Objects returned will have all custom properties available, as well as the `id`,
 {% assign project = data.project_id | object: "projects" %}
 ```
 
+<Callout
+  emoji="💡"
+  bgColor="yellow"
+  title="Note:"
+  text={
+    <>
+      If you're looking to reference the parent object that the recipient is
+      subscribed to when they are notified via a{" "}
+      <a href="/concepts/subscriptions">subscription</a>, you can use the{" "}
+      <code>recipient.subscription.object</code> property.
+    </>
+  }
+/>
+
 ## Referencing tenants via the `tenant` filter
 
 To reference a tenant, you can use the `tenant` filter. This will return a serialized `Tenant`, which you can then use to output data in your template.


### PR DESCRIPTION
### Description

This PR adds guidance on referencing the parent object in workflow runs when a recipient is notified via a subscription (with `recipient.subscription.object`).

### Todos

Note: This PR should not be merged until the FF has been rolled out to all users.