### PR TITLE
chore(kno-9926): add max file size for csv

### DIFF
--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -102,6 +102,8 @@ The API is designed for batch processing and accepts payloads of up to 1,000 mem
 
 You can upload a CSV of users to an audience. After uploading your CSV, you can map the CSV fields to the corresponding user fields in Knock. Knock will upsert the users as they are added to the audience and skip any users with malformed or missing IDs.
 
+Note: The maximum size of a CSV upload is capped at 10MB.
+
 ### Manually
 
 You can manually add existing users to an audience.

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -155,4 +155,7 @@ Knock also supports [commercial unsubscribe](/preferences/commercial-unsubscribe
     broadcast. When you upload a CSV of users to a broadcast, Knock will
     automatically identify the users.
   </Accordion>
+  <Accordion title="What's the maximum size of a CSV upload for a broadcast?">
+    The maximum size of a CSV upload is capped at 10MB.
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

Adds the max file size we allow for csv uploads.





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents a 10MB maximum CSV upload size for audience and broadcast uploads.
> 
> - **Docs (Concepts)**:
>   - `content/concepts/audiences.mdx`: Add note that CSV uploads are capped at 10MB.
>   - `content/concepts/broadcasts.mdx`: Add FAQ accordion specifying CSV upload maximum size is 10MB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a1c9d4b5739a4ac0a78092304ce2830e97bd85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->