### PR TITLE
fix(search): KNO-8935 preserve input and trigger AI search when no results found on Enter

### DIFF
--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -499,10 +499,24 @@ const Autocomplete = () => {
     },
   };
 
-  const inputProps: unknown = autocomplete.getInputProps({
+  const defaultInputProps = autocomplete.getInputProps({
     inputElement: inputRef.current,
     placeholder: "Search the docs...",
   });
+
+  const inputProps = {
+    ...defaultInputProps,
+    onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && autocompleteState?.query && !hasResults) {
+        e.preventDefault();
+        handleOpenAiChat(autocompleteState.query);
+        return;
+      }
+      if ((defaultInputProps as any).onKeyDown) {
+        (defaultInputProps as any).onKeyDown(e);
+      }
+    },
+  };
 
   return (
     <Box {...autocomplete.getRootProps()} w="full" tgphRef={rootRef}>
@@ -511,10 +525,7 @@ const Autocomplete = () => {
           tgphRef={inputRef}
           placeholder="Search the docs.."
           className="aa-Input"
-          {...(inputProps as React.DetailedHTMLProps<
-            React.InputHTMLAttributes<HTMLInputElement>,
-            HTMLInputElement
-          >)}
+          {...(inputProps as any)}
           size="2"
           w="full"
           LeadingComponent={

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -476,17 +476,28 @@ const Autocomplete = () => {
     return <StaticSearch />;
   }
 
-  type FormProps = {
-    action: string;
-    noValidate: boolean;
-    role: string;
-    onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
-    onReset: (e: React.FormEvent<HTMLFormElement>) => void;
-  };
+  const hasResults =
+    autocompleteState?.collections?.some(
+      (collection) => collection.items.length > 1,
+    ) ?? false;
 
-  const formProps: unknown = autocomplete.getFormProps({
+  const defaultFormProps = autocomplete.getFormProps({
     inputElement: inputRef.current,
   });
+
+  const formProps = {
+    ...defaultFormProps,
+    onSubmit: (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (autocompleteState?.query && !hasResults) {
+        handleOpenAiChat(autocompleteState.query);
+        return;
+      }
+      if (defaultFormProps.onSubmit) {
+        defaultFormProps.onSubmit(e.nativeEvent);
+      }
+    },
+  };
 
   const inputProps: unknown = autocomplete.getInputProps({
     inputElement: inputRef.current,
@@ -495,7 +506,7 @@ const Autocomplete = () => {
 
   return (
     <Box {...autocomplete.getRootProps()} w="full" tgphRef={rootRef}>
-      <Box as="form" className="aa-Form" {...(formProps as FormProps)}>
+      <Box as="form" className="aa-Form" {...(formProps as any)}>
         <Input
           tgphRef={inputRef}
           placeholder="Search the docs.."


### PR DESCRIPTION
### Description

Fixes a UX issue in the documentation search where pressing Enter on a search query with no results would clear the input instead of preserving it or triggering AI search as a fallback.

**Changes:**
- Added custom form submission handler that detects when no search results exist
- Automatically triggers AI chat when Enter is pressed with a query but no results
- Preserves search input instead of clearing it in no-results scenarios  
- Maintains existing behavior for searches that return results

**Implementation details:**
- `hasResults` helper checks if any collections have more than 1 item (accounting for the always-present "Ask AI" item)
- Custom `onSubmit` handler intercepts form submission and calls existing `handleOpenAiChat()` function
- Falls back to default Algolia behavior when results exist
- Removed explicit `FormProps` typing in favor of type spreading to resolve TypeScript conflicts

### Todos

- [ ] **Manual testing required** - Verify search behavior works correctly (couldn't test locally due to dev server cache issues)
- [ ] Test that existing search functionality still works (searches with results + Enter)
- [ ] Test that manual "Ask AI" link clicks still work
- [ ] Verify AI chat opens with correct query pre-populated

### Tasks

[KNO-8935](https://linear.app/knock/issue/KNO-8935) - Fix search UX issue where Enter key clears input on no results

---

**Link to Devin run:** https://app.devin.ai/sessions/9389bdc06b5e4c5381fca3182ae26f5a  
**Requested by:** @MikeCarbone

**⚠️ Review focus areas:**
- Results detection logic: Is `collection.items.length > 1` reliable for detecting actual search results?
- Type safety: The `as any` casting removes type checking - ensure this doesn't introduce runtime issues
- Form submission flow: Verify the fallback to `defaultFormProps.onSubmit(e.nativeEvent)` works correctly