### PR TITLE
fix(KNO-8935): preserve input and trigger AI search on no-results Enter key press

### DIFF
--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -491,8 +491,8 @@ const Autocomplete = () => {
   });
 
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
     if (autocompleteState?.query && !hasResults) {
+      e.preventDefault();
       handleOpenAiChat(autocompleteState.query);
       return;
     }

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -490,11 +490,16 @@ const Autocomplete = () => {
     inputElement: inputRef.current,
   });
 
+  const originalOnSubmit = (formProps as FormProps).onSubmit;
+
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     if (autocompleteState?.query && !hasResults) {
       e.preventDefault();
       handleOpenAiChat(autocompleteState.query);
       return;
+    }
+    if (originalOnSubmit) {
+      originalOnSubmit(e);
     }
   };
 

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -412,16 +412,13 @@ const Autocomplete = () => {
         },
         navigator: {
           navigate({ itemUrl, item, state }) {
-            // Check if this is our Ask AI item
             if ((item as any).__isAskAiItem) {
               handleOpenAiChat(state.query);
               return;
             }
 
-            // Handle regular navigation
             router.push(`/${itemUrl}`);
 
-            // Clear the query when navigating
             if (state.query) {
               autocomplete.setQuery("");
             }
@@ -484,9 +481,22 @@ const Autocomplete = () => {
     onReset: (e: React.FormEvent<HTMLFormElement>) => void;
   };
 
+  const hasResults =
+    autocompleteState?.collections?.some(
+      (collection) => collection.items.length > 1,
+    ) ?? false;
+
   const formProps: unknown = autocomplete.getFormProps({
     inputElement: inputRef.current,
   });
+
+  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (autocompleteState?.query && !hasResults) {
+      handleOpenAiChat(autocompleteState.query);
+      return;
+    }
+  };
 
   const inputProps: unknown = autocomplete.getInputProps({
     inputElement: inputRef.current,
@@ -495,7 +505,12 @@ const Autocomplete = () => {
 
   return (
     <Box {...autocomplete.getRootProps()} w="full" tgphRef={rootRef}>
-      <Box as="form" className="aa-Form" {...(formProps as FormProps)}>
+      <Box
+        as="form"
+        className="aa-Form"
+        {...(formProps as FormProps)}
+        onSubmit={handleFormSubmit}
+      >
         <Input
           tgphRef={inputRef}
           placeholder="Search the docs.."


### PR DESCRIPTION
### Description

When hitting enter in the search box, it will try to enter AI chat if there are no results. If there are results, it'll navigate to the first item


---

Fixes a UX issue where searching for something with no results and pressing Enter would clear the search input instead of preserving the query and offering AI search as a fallback.

**Changes made:**
- Added `hasResults` helper to detect when search results exist beyond the "Ask AI" item
- Implemented custom `handleFormSubmit` to override default Algolia form behavior when no results are found
- Modified form to preserve search input and automatically trigger AI search on Enter key press when no results exist
- Removed redundant comments in navigator function

**How it works:**
When a user types a query that returns no Algolia results and presses Enter, instead of clearing the input (previous behavior), the search input is preserved and the AI chat modal opens automatically with the query pre-populated.

### Tasks

[KNO-8935](https://linear.app/knock/issue/KNO-8935)

### Review Checklist

⚠️ **Critical testing required** - Local testing was blocked by Next.js environment issues, so these changes need thorough manual validation:

- [ ] Test no-results scenario: Search for something with no results → press Enter → verify input preserved AND AI chat opens with query
- [ ] Test normal results: Search for something with results → press Enter/click → verify input clears and navigation works as expected  
- [ ] Test manual "Ask AI": Click the "Ask AI" link → verify it still works correctly
- [ ] Verify `hasResults` logic correctly identifies when there are actual search results vs just the "Ask AI" item
- [ ] Ensure the AI search auto-trigger behaves the same as manual trigger

### Implementation Notes

The `hasResults` detection assumes that `collections` with `items.length > 1` indicates real results (since the first item is always "Ask AI"). This logic should be validated during testing.

---
**Requested by:** @MikeCarbone  
**Link to Devin run:** https://app.devin.ai/sessions/592f42d408bd4fcaacd5b929c725b44f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Intercepts Enter in the search form to open AI chat when no results; otherwise navigates to the first result, with updated handler types.
> 
> - **Search UX (`components/ui/Autocomplete.tsx`)**:
>   - Add `onKeyDown` handler on the form to intercept Enter:
>     - If query exists and no results (`hasResults`), open AI chat with the query.
>     - Otherwise navigate to the first non-"Ask AI" item.
>   - Introduce `hasResults` helper to detect real results beyond the "Ask AI" item.
>   - Broaden `handleSearchNavigation` event type to accept `React.KeyboardEvent<HTMLFormElement>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3da7c74aa76f7572b22a969bbd8084f4de0f50bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->