### PR TITLE
KNO-9567: Fix CLS issue in search bar by matching icon sizes

### DIFF
--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -92,7 +92,7 @@ const StaticSearch = () => {
         size="2"
         className="aa-Input"
         LeadingComponent={
-          <Icon icon={Search} alt="Search" color="gray" mr="2" />
+          <Icon icon={Search} alt="Search" color="gray" size="1" mr="2" />
         }
         TrailingComponent={
           <Stack


### PR DESCRIPTION
### Description

Fixes a Cumulative Layout Shift (CLS) issue in the documentation search bar by adding an explicit `size="1"` prop to the Search icon in the `StaticSearch` component.

**Problem:** During SSR, the `StaticSearch` component renders with a Search icon using the default size (16px), but after hydration, the active `Autocomplete` component uses an explicit `size="1"` prop (14px). This 2px difference causes a visible layout shift when the page loads.

**Solution:** Add `size="1"` prop to the Search icon in `StaticSearch` to match the active search component, eliminating the size mismatch and CLS.

The change is minimal - just adding one prop to ensure visual consistency between the static and interactive search states.

### Tasks

[KNO-9567](https://linear.app/knock/issue/KNO-9567)

### Screenshots

*Note: Local testing was blocked by a Next.js dev environment issue (`react/jsx-runtime not in cache`), so visual verification will need to be done via CI/deployed preview.*

---

**Link to Devin run:** https://app.devin.ai/sessions/8df2375b69e348a684511fafb67548e7  
**Requested by:** @MikeCarbone