### PR TITLE
fix(kno-8851): include shared resources in API references

### DIFF
--- a/data/sidebars/apiOverviewSidebar.ts
+++ b/data/sidebars/apiOverviewSidebar.ts
@@ -12,7 +12,7 @@ export const RESOURCE_ORDER = [
   "audiences",
   "bulk_operations",
   "providers",
-  "shared",
+  "$shared",
 ];
 
 export const API_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [

--- a/data/sidebars/mapiOverviewSidebar.ts
+++ b/data/sidebars/mapiOverviewSidebar.ts
@@ -13,6 +13,7 @@ export const RESOURCE_ORDER = [
   "message_types",
   "guides",
   "api_keys",
+  "$shared",
 ];
 
 export const MAPI_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [

--- a/data/specs/api/customizations.yml
+++ b/data/specs/api/customizations.yml
@@ -117,7 +117,7 @@ resources:
         name: Microsoft Teams
         description: |-
           A Microsoft Teams provider is a channel-specific configuration that determines how a message is delivered to a recipient via Microsoft Teams.
-  shared:
+  $shared:
     name: Shared
     description: |-
       Resources that are shared across the API.

--- a/data/specs/api/stainless.yml
+++ b/data/specs/api/stainless.yml
@@ -8,7 +8,7 @@ organization:
   github_org: knocklabs
   upload_spec: true
 resources:
-  shared:
+  $shared:
     models:
       condition: '#/components/schemas/Condition'
       page_info: '#/components/schemas/PageInfo'
@@ -317,18 +317,29 @@ targets:
   java:
     reverse_domain: app.knock.api
     production_repo: knocklabs/knock-java
+    skip: true
     publish:
       maven:
         sonatype_platform: portal
-    skip: false
   ruby:
     gem_name: knockapi
     production_repo: knocklabs/knock-ruby
     publish:
       rubygems: false
+  php:
+    skip: true
+    package_name: knock
+    composer_package_name: 'knocklabs/knock'
+  csharp:
+    skip: true
+    package_name: knock
+    publish:
+      nuget: false
 settings:
   license: Apache-2.0
 client_settings:
+  idempotency:
+    header: 'Idempotency-Key'
   opts:
     api_key:
       type: string

--- a/data/specs/mapi/customizations.yml
+++ b/data/specs/mapi/customizations.yml
@@ -64,3 +64,7 @@ resources:
     name: Guides
     description: |-
       Guides let you define in-app messaging for your users, powered by your own components.
+  $shared:
+    name: Shared
+    description: |-
+      Resources that are shared across the API.


### PR DESCRIPTION
### Description

Previously, there were two issues:
- no shared resource section on mapi
- shared resource section on api used wrong key in stainless spec `shared` instead of the correct [Stainless-specific](https://www.stainless.com/docs/guides/configure#shared-models) `$shared`

Step one of this fix was making sure we use the $shared key in Stainless config. This will update our SDKs so `shared` is not an accessible resource.

This PR adds the new stainless config ^ so API reference is updated and _adds_ the shared section to mAPI

Example:
This URL doesnt work on live docs: https://docs.knock.app/mapi-reference/$shared/schemas/page_info
and now it works!

https://linear.app/knock/issue/KNO-8851/docs-404s-on-shared-schemas-within-mapi