### PR TITLE
chore(kno-9950): Clarify Slack integration capabilities

### DIFF
--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -7,6 +7,12 @@ layout: integrations
 
 This page covers how to use Knock to send notifications to Slack. Depending on your use case, there are a few different ways to approach this integration. This documentation serves as a starting point and will cover the basics of setting up a Slack integration with Knock regardless of your use case.
 
+## What can I do with Knock's Slack integration?
+
+Knock's Slack integration enables you to send notifications to [Slack channels](https://docs.knock.app/integrations/chat/slack/sending-a-message-to-channels) and [direct messages](https://docs.knock.app/integrations/chat/slack/sending-a-direct-message) to users, or use [incoming webhooks for internal workspaces](https://docs.knock.app/integrations/chat/slack/sending-an-internal-message). You can create rich message templates using [markdown](#markdown-templates) or [Slack's block kit framework](http://localhost:3002/integrations/chat/slack/overview#block-based-templates), and build self-serve integrations where customers connect their own Slack workspaces.
+
+This integration does not support Slack modals, slash commands, shortcuts, or interactive dialogs.
+
 ## How to connect Slack to Knock
 
 Knock supports multiples ways to create a Slack integration depending on your technical requirements:


### PR DESCRIPTION
### Description

Adds a short section to the Slack integration overview page about what's possible with Knock's Slack integration and clarifies what is currently not supported.

### Tasks

[KNO-9950](https://linear.app/knock/issue/KNO-9950/docs-add-overview-of-what-integration-covers-to-slack-docs)

### Screenshots
<img width="761" height="548" alt="Screenshot 2025-10-02 at 2 12 49 PM" src="https://github.com/user-attachments/assets/09a858b7-3e48-4bd3-9a11-7fe7939431d7" />

