### PR TITLE
chore(kno-8921): Clarify naming guidelines for workflow categories

### DIFF
--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -74,9 +74,8 @@ To set a `category` for a given workflow, go to that workflow's page in the dash
   style={{ alignItems: "center" }}
   text={
     <>
-      Workflow categories are <strong>case sensitive</strong> and can contain
-      special characters and spaces. They do not need to follow slug
-      conventions.
+      Workflow categories are <strong>case sensitive</strong> and may contain
+      special characters and spaces.
     </>
   }
 />

--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -74,7 +74,9 @@ To set a `category` for a given workflow, go to that workflow's page in the dash
   style={{ alignItems: "center" }}
   text={
     <>
-      workflow categories are <strong>case sensitive</strong>.
+      Workflow categories are <strong>case sensitive</strong> and can contain
+      special characters and spaces. They do not need to follow slug
+      conventions.
     </>
   }
 />


### PR DESCRIPTION
### Description

Updates the callout for workflow categories to clarify naming guidelines. 

### Tasks

[KNO-8921](https://linear.app/knock/issue/KNO-8921/docs-update-workflow-categories-description)

### Screenshots
https://docs-git-rt-kno-8921-workflow-categories-knocklabs.vercel.app/concepts/workflows#workflow-categories

<img width="748" height="304" alt="Screenshot 2025-10-03 at 4 53 53 PM" src="https://github.com/user-attachments/assets/c3e9bad0-f7e3-4cd7-9794-ea4dc31d0d6f" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies workflows docs to note categories are case sensitive and can include spaces and special characters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a5e9a4317e6fab2755df40f1d6df17cae671cd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->