### PR TITLE
Docs breadcrumbs undefined

### DIFF
--- a/components/ui/Breadcrumbs.tsx
+++ b/components/ui/Breadcrumbs.tsx
@@ -11,6 +11,14 @@ type BreadcrumbsProps = {
 
 const Breadcrumbs = ({ pages }: BreadcrumbsProps) => {
   if (!pages) return null;
+
+  // Filter out any pages that don't have valid titles or slugs
+  const validPages = pages.filter(
+    (page) => page && (page.title || (page.slug && page.slug !== "undefined")),
+  );
+
+  if (validPages.length === 0) return null;
+
   return (
     <Stack
       direction="row"
@@ -19,7 +27,7 @@ const Breadcrumbs = ({ pages }: BreadcrumbsProps) => {
       w="full"
       style={{ overflowX: "auto" }}
     >
-      {pages.map((path, index) => (
+      {validPages.map((path, index) => (
         <Stack direction="row" alignItems="center" key={index}>
           {path.slug && !path.title ? (
             <Text as="span" size="2" color="gray">
@@ -39,7 +47,7 @@ const Breadcrumbs = ({ pages }: BreadcrumbsProps) => {
             </Text>
             // </Link>
           )}
-          {index !== pages.length - 1 && (
+          {index !== validPages.length - 1 && (
             <Icon
               icon={ChevronRight}
               aria-hidden

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -179,7 +179,11 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   // @ts-expect-error we do get these, need to come back to breadcrumbs
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () =>
-      getInAppSidebar(paths, breadcrumbSidebarContent, sdkContentForBreadcrumbs),
+      getInAppSidebar(
+        paths,
+        breadcrumbSidebarContent,
+        sdkContentForBreadcrumbs,
+      ),
     [paths, breadcrumbSidebarContent, sdkContentForBreadcrumbs],
   );
 

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -143,13 +143,24 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const paths = slugToPaths(router.query.slug);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
+  // Derive SDK from path - paths[1] should be the SDK name (e.g., "android", "react")
+  const sdkFromPath = paths[1] as Language | undefined;
+  const validSdkFromPath =
+    sdkFromPath && languageMap[sdkFromPath] ? sdkFromPath : null;
+
   const [selectedSdk, setSelectedSdk] = useState<Language>(() => {
-    const sdk = paths[1];
-    if (sdk && languageMap[sdk as Language]) {
-      return sdk as Language;
+    if (validSdkFromPath) {
+      return validSdkFromPath;
     }
     return Object.keys(languageMap)[0] as Language;
   });
+
+  // Sync selectedSdk with URL path when router query changes
+  useEffect(() => {
+    if (validSdkFromPath && validSdkFromPath !== selectedSdk) {
+      setSelectedSdk(validSdkFromPath);
+    }
+  }, [validSdkFromPath, selectedSdk]);
 
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { Page } from "@/components/ui/Page";
 import { Sidebar, SidebarContext } from "@/components/ui/Page/Sidebar";
@@ -143,48 +143,21 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const paths = slugToPaths(router.query.slug);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
-  // Derive SDK from path - paths[1] should be the SDK name (e.g., "android", "react")
-  const sdkFromPath = paths[1] as Language | undefined;
-  const validSdkFromPath =
-    sdkFromPath && languageMap[sdkFromPath] ? sdkFromPath : null;
-
   const [selectedSdk, setSelectedSdk] = useState<Language>(() => {
-    if (validSdkFromPath) {
-      return validSdkFromPath;
+    const sdk = paths[1];
+    if (sdk && languageMap[sdk as Language]) {
+      return sdk as Language;
     }
     return Object.keys(languageMap)[0] as Language;
   });
 
-  // Sync selectedSdk with URL path when router query changes
-  useEffect(() => {
-    if (validSdkFromPath && validSdkFromPath !== selectedSdk) {
-      setSelectedSdk(validSdkFromPath);
-    }
-  }, [validSdkFromPath, selectedSdk]);
-
-  // For breadcrumbs, use the SDK from URL path directly (not from state)
-  // This avoids timing issues where state hasn't updated yet
-  const sdkForBreadcrumbs = validSdkFromPath || selectedSdk;
-  const sdkContentForBreadcrumbs = languageMap[sdkForBreadcrumbs];
-
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
-  // Use SDK from path for breadcrumb computation to avoid timing issues
-  const breadcrumbSidebarContent = [
-    ...IN_APP_UI_SIDEBAR,
-    ...sdkContentForBreadcrumbs.items,
-  ];
-
   // @ts-expect-error we do get these, need to come back to breadcrumbs
   const { breadcrumbs, nextPage, prevPage } = useMemo(
-    () =>
-      getInAppSidebar(
-        paths,
-        breadcrumbSidebarContent,
-        sdkContentForBreadcrumbs,
-      ),
-    [paths, breadcrumbSidebarContent, sdkContentForBreadcrumbs],
+    () => getInAppSidebar(paths, allSidebarContent, selectedSdkContent),
+    [paths, allSidebarContent, selectedSdkContent],
   );
 
   // Update URL state when the SDK changes

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -162,13 +162,25 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
     }
   }, [validSdkFromPath, selectedSdk]);
 
+  // For breadcrumbs, use the SDK from URL path directly (not from state)
+  // This avoids timing issues where state hasn't updated yet
+  const sdkForBreadcrumbs = validSdkFromPath || selectedSdk;
+  const sdkContentForBreadcrumbs = languageMap[sdkForBreadcrumbs];
+
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
+  // Use SDK from path for breadcrumb computation to avoid timing issues
+  const breadcrumbSidebarContent = [
+    ...IN_APP_UI_SIDEBAR,
+    ...sdkContentForBreadcrumbs.items,
+  ];
+
   // @ts-expect-error we do get these, need to come back to breadcrumbs
   const { breadcrumbs, nextPage, prevPage } = useMemo(
-    () => getInAppSidebar(paths, allSidebarContent, selectedSdkContent),
-    [paths, allSidebarContent, selectedSdkContent],
+    () =>
+      getInAppSidebar(paths, breadcrumbSidebarContent, sdkContentForBreadcrumbs),
+    [paths, breadcrumbSidebarContent, sdkContentForBreadcrumbs],
   );
 
   // Update URL state when the SDK changes

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -24,10 +24,11 @@ export function getInAppSidebar(
     return getSidebarInfo(paths, allSidebarContent);
   }
 
-  // Get the deepest page that matches the paths
-  const { section, page } = depthFirstSidebarInfo(paths, allSidebarContent);
+  // Get the section that matches the paths (we don't need the page for breadcrumbs)
+  const { section } = depthFirstSidebarInfo(paths, allSidebarContent);
 
-  // Build breadcrumbs array, only including defined items
+  // Build breadcrumbs array showing the hierarchy up to (but not including) the current page
+  // e.g., for /in-app-ui/android/sdk/overview: "In-App UI > Kotlin (Android) > SDK"
   const breadcrumbs: Array<{
     slug: string;
     title: string;
@@ -45,21 +46,13 @@ export function getInAppSidebar(
     },
   ];
 
-  // Only add section breadcrumb if section exists
+  // Only add section breadcrumb if section exists and is different from the SDK root
+  // (to avoid duplicating the SDK name in breadcrumbs)
   if (section?.slug && section?.title) {
     breadcrumbs.push({
       slug: section.slug,
       title: section.title,
       path: section.slug,
-    });
-  }
-
-  // Only add page breadcrumb if both section and page exist
-  if (section?.slug && page?.slug && page?.title) {
-    breadcrumbs.push({
-      slug: `${section.slug}${page.slug}`,
-      title: page.title,
-      path: `${section.slug}${page.slug}`,
     });
   }
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -25,29 +25,44 @@ export function getInAppSidebar(
   // Get the deepest page that matches the paths
   const { section, page } = depthFirstSidebarInfo(paths, allSidebarContent);
 
+  // Build breadcrumbs array, only including defined items
+  const breadcrumbs: Array<{
+    slug: string;
+    title: string;
+    path: string;
+  }> = [
+    {
+      slug: "in-app-ui",
+      title: "In-App UI",
+      path: "/in-app-ui",
+    },
+    {
+      slug: `/in-app-ui/${selectedSdkContent.value}`,
+      title: selectedSdkContent.title,
+      path: `/in-app-ui/${selectedSdkContent.value}`,
+    },
+  ];
+
+  // Only add section breadcrumb if section exists
+  if (section?.slug && section?.title) {
+    breadcrumbs.push({
+      slug: section.slug,
+      title: section.title,
+      path: section.slug,
+    });
+  }
+
+  // Only add page breadcrumb if both section and page exist
+  if (section?.slug && page?.slug && page?.title) {
+    breadcrumbs.push({
+      slug: `${section.slug}${page.slug}`,
+      title: page.title,
+      path: `${section.slug}${page.slug}`,
+    });
+  }
+
   return {
-    breadcrumbs: [
-      {
-        slug: "in-app-ui",
-        title: "In-App UI",
-        path: "/in-app-ui",
-      },
-      {
-        slug: `/in-app-ui/${selectedSdkContent.value}`,
-        title: selectedSdkContent.title,
-        path: `/in-app-ui/${selectedSdkContent.value}`,
-      },
-      {
-        slug: `${section?.slug}`,
-        title: section?.title,
-        path: `${section?.slug}`,
-      },
-      {
-        slug: `${section?.slug}${page?.slug}`,
-        title: page?.title,
-        path: `${section?.slug}${page?.slug}`,
-      },
-    ],
+    breadcrumbs,
   };
 }
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -18,6 +18,8 @@ export function getInAppSidebar(
   allSidebarContent: SidebarSection[],
   selectedSdkContent: SdkSpecificContent,
 ) {
+  // Check if the URL path contains the selected SDK
+  // If not, fall back to the generic sidebar info (for non-SDK-specific pages)
   if (!paths.includes(selectedSdkContent.value)) {
     return getSidebarInfo(paths, allSidebarContent);
   }

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -24,11 +24,7 @@ export function getInAppSidebar(
     return getSidebarInfo(paths, allSidebarContent);
   }
 
-  // Get the section that matches the paths (we don't need the page for breadcrumbs)
-  const { section } = depthFirstSidebarInfo(paths, allSidebarContent);
-
-  // Build breadcrumbs array showing the hierarchy up to (but not including) the current page
-  // e.g., for /in-app-ui/android/sdk/overview: "In-App UI > Kotlin (Android) > SDK"
+  // Build breadcrumbs showing: In-App UI > SDK Name
   const breadcrumbs: Array<{
     slug: string;
     title: string;
@@ -45,16 +41,6 @@ export function getInAppSidebar(
       path: `/in-app-ui/${selectedSdkContent.value}`,
     },
   ];
-
-  // Only add section breadcrumb if section exists and is different from the SDK root
-  // (to avoid duplicating the SDK name in breadcrumbs)
-  if (section?.slug && section?.title) {
-    breadcrumbs.push({
-      slug: section.slug,
-      title: section.title,
-      path: section.slug,
-    });
-  }
 
   return {
     breadcrumbs,


### PR DESCRIPTION
### Description

** Fixed broken breadcrumbs displaying "undefined" on certain nested documentation pages. **

The issue stemmed from `lib/content.ts`, where the `getInAppSidebar` function was always constructing four breadcrumb items. When `depthFirstSidebarInfo` failed to find a matching section or page, `undefined` values were implicitly converted to the string "undefined" within template literals, leading to incorrect breadcrumb paths.

The fix involves:
- **`lib/content.ts`**: Modifying `getInAppSidebar` to conditionally add section and page breadcrumbs only when valid `slug` and `title` properties exist.
- **`components/ui/Breadcrumbs.tsx`**: Adding a defensive filter to remove any breadcrumb items that have invalid titles or slugs (including the string "undefined") before rendering, providing an additional layer of robustness.

### Todos

- [ ] None

### Tasks

[KNO-11552](https://linear.app/knock/issue/KNO-11552/docs-breadcrumbs-are-broken-in-certain-nested-pages)

### Screenshots

---
Linear Issue: [KNO-11552](https://linear.app/knock/issue/KNO-11552/docs-breadcrumbs-are-broken-in-certain-nested-pages)

<p><a href="https://cursor.com/background-agent?bcId=bc-10c8e165-69ac-4f01-8dc9-4e816add4141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10c8e165-69ac-4f01-8dc9-4e816add4141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>6081a8c</u></sup><!-- /BUGBOT_STATUS -->