### PR TITLE
chore(kno-11556): Update Step component to add h4 support and heading size alignment

### DIFF
--- a/components/ui/Step.tsx
+++ b/components/ui/Step.tsx
@@ -28,7 +28,7 @@ function TitleTag({ size, title }) {
           id={id}
           color="default"
           weight="semi-bold"
-          size="3"
+          size="4"
           mb="2"
         >
           {title}
@@ -49,8 +49,33 @@ function TitleTag({ size, title }) {
         </Heading>
       );
     }
+    case "h4": {
+      return (
+        <Heading
+          as="h4"
+          id={id}
+          color="default"
+          weight="semi-bold"
+          size="2"
+          mb="2"
+        >
+          {title}
+        </Heading>
+      );
+    }
     default:
-      return null;
+      return (
+        <Heading
+          as="h2"
+          id={id}
+          color="default"
+          weight="semi-bold"
+          size="2"
+          mb="2"
+        >
+          {title}
+        </Heading>
+      );
   }
 }
 

--- a/components/ui/Step.tsx
+++ b/components/ui/Step.tsx
@@ -70,7 +70,7 @@ function TitleTag({ size, title }) {
           id={id}
           color="default"
           weight="semi-bold"
-          size="2"
+          size="4"
           mb="2"
         >
           {title}

--- a/components/ui/Step.tsx
+++ b/components/ui/Step.tsx
@@ -4,7 +4,13 @@ import { Text, Heading } from "@telegraph/typography";
 
 type TitleSize = "p" | "h2" | "h3" | "h4";
 
-const Steps = ({ titleSize = "p", children }: { titleSize?: TitleSize; children: React.ReactElement<any> | React.ReactElement<any>[] }) => (
+const Steps = ({
+  titleSize = "p",
+  children,
+}: {
+  titleSize?: TitleSize;
+  children: React.ReactElement<any> | React.ReactElement<any>[];
+}) => (
   <Box role="list" ml="4" mt="10" mb="6">
     {React.Children.map(children, (child, i) =>
       React.cloneElement(child, { titleSize, stepNumber: i + 1 }),
@@ -71,7 +77,17 @@ function TitleTag({ size, title }: { size: TitleSize; title: string }) {
   }
 }
 
-const Step = ({ titleSize = "p", title, children, stepNumber }: { titleSize?: TitleSize; title: string; children: React.ReactNode; stepNumber?: number }) => (
+const Step = ({
+  titleSize = "p",
+  title,
+  children,
+  stepNumber,
+}: {
+  titleSize?: TitleSize;
+  title: string;
+  children: React.ReactNode;
+  stepNumber?: number;
+}) => (
   <Stack position="relative" alignItems="flex-start" pb="4" role="listitem">
     <Box
       position="absolute"

--- a/components/ui/Step.tsx
+++ b/components/ui/Step.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { Box, Stack } from "@telegraph/layout";
 import { Text, Heading } from "@telegraph/typography";
 
-const Steps = ({ titleSize = "p", children }) => (
+type TitleSize = "p" | "h2" | "h3" | "h4";
+
+const Steps = ({ titleSize = "p", children }: { titleSize?: TitleSize; children: React.ReactElement<any> | React.ReactElement<any>[] }) => (
   <Box role="list" ml="4" mt="10" mb="6">
     {React.Children.map(children, (child, i) =>
       React.cloneElement(child, { titleSize, stepNumber: i + 1 }),
@@ -10,7 +12,7 @@ const Steps = ({ titleSize = "p", children }) => (
   </Box>
 );
 
-function TitleTag({ size, title }) {
+function TitleTag({ size, title }: { size: TitleSize; title: string }) {
   const id = title.toLowerCase().replaceAll(" ", "-");
 
   switch (size) {
@@ -64,22 +66,12 @@ function TitleTag({ size, title }) {
       );
     }
     default:
-      return (
-        <Heading
-          as="h2"
-          id={id}
-          color="default"
-          weight="semi-bold"
-          size="4"
-          mb="2"
-        >
-          {title}
-        </Heading>
-      );
+      // Unreachable when titleSize is typed correctly; intentionally returns null
+      return null;
   }
 }
 
-const Step = ({ titleSize = "p", title, children, stepNumber }) => (
+const Step = ({ titleSize = "p", title, children, stepNumber }: { titleSize?: TitleSize; title: string; children: React.ReactNode; stepNumber?: number }) => (
   <Stack position="relative" alignItems="flex-start" pb="4" role="listitem">
     <Box
       position="absolute"

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -286,7 +286,7 @@ export async function fetchUserId(email: string): Promise<string> {
 We'll break this function down step-by-step:
 
 <Steps titleSize="h4">
-  <Step title="Get the `access_token` stored in Knock for the user's tenant">
+  <Step title="Get the access_token stored in Knock for the user's tenant">
     Since your users have already connected their Slack workspace to Knock, you can use the `knockClient.objects.getChannelData` method to get the `access_token` for the user's tenant. Tenants in Knock are stored in a system-reserved object collection called `$tenants`.
 
     ```javascript

--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -286,7 +286,7 @@ export async function fetchUserId(email: string): Promise<string> {
 We'll break this function down step-by-step:
 
 <Steps titleSize="h4">
-  <Step title="Get the access_token stored in Knock for the user's tenant">
+  <Step title="Get the access token stored in Knock for the user's tenant">
     Since your users have already connected their Slack workspace to Knock, you can use the `knockClient.objects.getChannelData` method to get the `access_token` for the user's tenant. Tenants in Knock are stored in a system-reserved object collection called `$tenants`.
 
     ```javascript


### PR DESCRIPTION
### Description

I noticed that step headings weren't appearing in [this section](https://docs.knock.app/integrations/chat/slack/sending-a-direct-message) of the docs, and after digging in realized that this was because the `titleSize` was set to `h4` and the `Step` component was returning `null` in this case. To have better support moving forward, I've added the following changes:
1. Explicitly added support for `titleSize="h4"` (previously there was only support for `"p"`, `"h2"` and `"h3"`
2. Added a `TitleSize` union type (`"p" | "h2" | "h3" | "h4"`) and typed all component props accordingly so that passing an invalid `titleSize` is now a compile-time error rather than a silent runtime failure
3. I kept `default: null` (which is reverted from the previous version of this PR) as it looks like this was intentional original behavior since `Steps` defaults `titleSize` to `"p"` at the prop level, meaning `default` was never meant to be reached. With the `TitleSize` type now enforced, it genuinely can't be reached, and a comment has been added to reflect that
4. Updated the heading sizes to align with the markdown headings. Step titles now use the same Telegraph `Heading` size as `SectionHeading` (used for ##, ###, #### in MDX via [mdxComponents](https://github.com/knocklabs/docs/blob/main/lib/mdxComponents.tsx#L46-L48)) to help keep the step headings consistent with the rest of the docs.
5. I also removed backticks from the `access_token` step title in `sending-a-direct-message.mdx` as currently backticks don't render as inline code in the title prop and were displaying as literal characters. Worth us considering adding inline code parsing to the component, but this was the only use of backticks in a title in the docs, so I opted to just remove it from this one use case for now. 

### Tasks

[KNO-11556](https://linear.app/knock/issue/KNO-11556/docs-fix-step-titlesize-on-slack-dm-page)

### Screenshots

Before:
<img width="817" height="1097" alt="Screenshot 2026-02-04 at 4 58 01 PM" src="https://github.com/user-attachments/assets/1931090b-11cb-47c6-8024-153288b386b0" />

After:
Can be seen under [this section](https://docs-git-rt-kno-11556-fix-step-titlesize-knocklabs.vercel.app/integrations/chat/slack/sending-a-direct-message#manually-resolving-a-users-slack-id) after the "We'll break this function down step-by-step:"
<img width="813" height="1155" alt="Screenshot 2026-02-04 at 5 04 12 PM" src="https://github.com/user-attachments/assets/1dc879a3-ddfd-4034-9d07-61453b5060e4" />


<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> found 1 potential issue for commit <u>48a6f48</u></sup><!-- /BUGBOT_STATUS -->