### PR TITLE
fix(kno-11552): remove `undefined` breadcrumbs from docs

### DIFF
--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -151,7 +151,23 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
     return Object.keys(languageMap)[0] as Language;
   });
 
-  const selectedSdkContent = languageMap[selectedSdk];
+  // Sync selectedSdk when paths change (e.g., after hydration when router.query becomes available)
+  useEffect(() => {
+    const sdkFromPath = paths[1] as Language;
+    if (
+      sdkFromPath &&
+      languageMap[sdkFromPath] &&
+      sdkFromPath !== selectedSdk
+    ) {
+      setSelectedSdk(sdkFromPath);
+    }
+  }, [paths, selectedSdk]);
+
+  // Derive SDK from path for breadcrumb computation to avoid timing issues with state
+  const sdkFromPath = paths[1] as Language;
+  const effectiveSdk =
+    sdkFromPath && languageMap[sdkFromPath] ? sdkFromPath : selectedSdk;
+  const selectedSdkContent = languageMap[effectiveSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
   // @ts-expect-error we do get these, need to come back to breadcrumbs
@@ -179,7 +195,7 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
         mobileSidebar={
           <MobileSidebar>
             <InAppSidebar
-              selectedSdk={selectedSdk}
+              selectedSdk={effectiveSdk}
               selectedSdkContent={selectedSdkContent}
               handleSdkChange={handleSdkChange}
             />
@@ -192,7 +208,7 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
             <Sidebar.ScrollContainer scrollerRef={scrollerRef}>
               <Stack direction="column" gap="2">
                 <InAppSidebar
-                  selectedSdk={selectedSdk}
+                  selectedSdk={effectiveSdk}
                   selectedSdkContent={selectedSdkContent}
                   handleSdkChange={handleSdkChange}
                 />

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -25,30 +25,39 @@ export function getInAppSidebar(
   // Get the deepest page that matches the paths
   const { section, page } = depthFirstSidebarInfo(paths, allSidebarContent);
 
-  return {
-    breadcrumbs: [
-      {
-        slug: "in-app-ui",
-        title: "In-App UI",
-        path: "/in-app-ui",
-      },
-      {
-        slug: `/in-app-ui/${selectedSdkContent.value}`,
-        title: selectedSdkContent.title,
-        path: `/in-app-ui/${selectedSdkContent.value}`,
-      },
-      {
-        slug: `${section?.slug}`,
-        title: section?.title,
-        path: `${section?.slug}`,
-      },
-      {
-        slug: `${section?.slug}${page?.slug}`,
-        title: page?.title,
-        path: `${section?.slug}${page?.slug}`,
-      },
-    ],
-  };
+  // Build breadcrumbs array conditionally to avoid "undefined" strings
+  const breadcrumbs: Array<{ slug: string; title: string; path: string }> = [
+    {
+      slug: "in-app-ui",
+      title: "In-App UI",
+      path: "/in-app-ui",
+    },
+    {
+      slug: `/in-app-ui/${selectedSdkContent.value}`,
+      title: selectedSdkContent.title,
+      path: `/in-app-ui/${selectedSdkContent.value}`,
+    },
+  ];
+
+  // Only add section breadcrumb if section was found
+  if (section?.slug && section?.title) {
+    breadcrumbs.push({
+      slug: section.slug,
+      title: section.title,
+      path: section.slug,
+    });
+  }
+
+  // Only add page breadcrumb if both section and page were found
+  if (section?.slug && page?.slug && page?.title) {
+    breadcrumbs.push({
+      slug: `${section.slug}${page.slug}`,
+      title: page.title,
+      path: `${section.slug}${page.slug}`,
+    });
+  }
+
+  return { breadcrumbs };
 }
 
 export function depthFirstSidebarInfo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR resolves the issue of "undefined" appearing in breadcrumbs on certain nested documentation pages, particularly within the `/in-app-ui` section.

**Why:**
The problem stemmed from two main issues:
1.  **Incorrect Breadcrumb Generation:** The `getInAppSidebar` function in `lib/content.ts` was unconditionally generating breadcrumb items, leading to `undefined` values being converted to the string `"undefined"` when a matching section or page was not found.
2.  **State Synchronization Timing Issue:** In `layouts/InAppUILayout.tsx`, the `selectedSdk` React state was not reliably syncing with the Next.js router's path after client-side hydration. This caused the breadcrumb logic to use an outdated SDK context, resulting in failed lookups.

**How:**
1.  **`lib/content.ts`**: The `getInAppSidebar` function now conditionally adds breadcrumb items only when valid `slug` and `title` properties exist for the section or page.
2.  **`layouts/InAppUILayout.tsx`**:
    *   A `useEffect` hook was added to synchronize the `selectedSdk` state with the SDK value extracted from the URL path, ensuring the correct SDK context is always available.
    *   The breadcrumb computation logic was updated to prioritize the SDK derived directly from the URL path (`validSdkFromPath`) over the `selectedSdk` state, mitigating timing issues.
    *   The `InAppSidebar` component now uses an `effectiveSdk` prop to ensure the dropdown consistently reflects the current page's SDK.

### Todos

- None

### Tasks

- [KNO-11552](https://linear.app/knock/issue/KNO-11552/docs-breadcrumbs-are-broken-in-certain-nested-pages)

### Screenshots

Old: 
<img width="600" height="660" alt="image" src="https://github.com/user-attachments/assets/2426784b-a4ce-4c7b-ad0b-ee983eeb734b" />

New:
<img width="1128" height="660" alt="image" src="https://github.com/user-attachments/assets/89f21e0d-fc36-46e5-bf7d-2817a1910cfa" />


Linear Issue: [KNO-11552](https://linear.app/knock/issue/KNO-11552/docs-breadcrumbs-are-broken-in-certain-nested-pages)

<div><a href="https://cursor.com/agents/bc-6e4459e2-1936-4211-9e6f-ce447d14be68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e4459e2-1936-4211-9e6f-ce447d14be68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->