### PR TITLE
feat(kno-12274): add guides in vue.js tutorial

### DIFF
--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -28,6 +28,25 @@ const TYPE_CONFIG: Record<
   community: { emoji: "🤝", bgColor: "default" },
 };
 
+const COMMUNITY_CONTENT = {
+  title: "Community-sourced.",
+  text: (
+    <>
+      This tutorial is based on a real Knock implementation and may reflect
+      preferences of the original developer. If you spot something that could
+      be improved, we welcome{" "}
+      <a href="https://github.com/knocklabs/docs/" target="_blank">
+        contributions
+      </a>
+      . Join our{" "}
+      <a href="https://knock.app/join-slack" target="_blank">
+        community Slack
+      </a>{" "}
+      to discuss this implementation or share your own.
+    </>
+  ),
+};
+
 export const Callout = ({
   type,
   emoji: customEmoji,
@@ -61,6 +80,9 @@ export const Callout = ({
   const bgColor = effectiveType
     ? TYPE_CONFIG[effectiveType]?.bgColor ?? customBgColor ?? "default"
     : customBgColor || "default";
+
+  const effectiveTitle = title ?? (effectiveType === "community" ? COMMUNITY_CONTENT.title : undefined);
+  const effectiveText = text ?? (effectiveType === "community" ? COMMUNITY_CONTENT.text : undefined);
 
   // Ensure emoji is always a string
   const emojiString = typeof emoji === "string" ? emoji : String(emoji || "💡");
@@ -121,17 +143,17 @@ export const Callout = ({
         py="1"
         style={{ marginBottom: "0px", color: "var(--tgph-gray-12)" }}
       >
-        {title && (
+        {effectiveTitle && (
           <Text
             as="span"
             size="2"
             weight="semi-bold"
             style={{ color: "var(--tgph-gray-12)" }}
           >
-            {title}{" "}
+            {effectiveTitle}{" "}
           </Text>
         )}
-        {text && text}
+        {effectiveText && effectiveText}
       </Text>
     </Stack>
   );

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -10,7 +10,7 @@ type CalloutType =
   | "enterprise"
   | "beta"
   | "roadmap"
-  | "community";
+  | "community_sourced";
 
 const TYPE_CONFIG: Record<
   CalloutType,
@@ -25,16 +25,16 @@ const TYPE_CONFIG: Record<
   enterprise: { emoji: "🏢", bgColor: "blue" },
   beta: { emoji: "🚧", bgColor: "yellow" },
   roadmap: { emoji: "🛣", bgColor: "default" },
-  community: { emoji: "🤝", bgColor: "default" },
+  community_sourced: { emoji: "🤝", bgColor: "default" },
 };
 
-const COMMUNITY_CONTENT = {
+const COMMUNITY_SOURCED = {
   title: "Community-sourced.",
   text: (
     <>
       This tutorial is based on a real Knock implementation and may reflect
-      preferences of the original developer. If you spot something that could
-      be improved, we welcome{" "}
+      preferences of the original developer. If you spot something that could be
+      improved, we welcome{" "}
       <a href="https://github.com/knocklabs/docs/" target="_blank">
         contributions
       </a>
@@ -81,8 +81,16 @@ export const Callout = ({
     ? TYPE_CONFIG[effectiveType]?.bgColor ?? customBgColor ?? "default"
     : customBgColor || "default";
 
-  const effectiveTitle = title ?? (effectiveType === "community" ? COMMUNITY_CONTENT.title : undefined);
-  const effectiveText = text ?? (effectiveType === "community" ? COMMUNITY_CONTENT.text : undefined);
+  const effectiveTitle =
+    title ??
+    (effectiveType === "community_sourced"
+      ? COMMUNITY_SOURCED.title
+      : undefined);
+  const effectiveText =
+    text ??
+    (effectiveType === "community_sourced"
+      ? COMMUNITY_SOURCED.text
+      : undefined);
 
   // Ensure emoji is always a string
   const emojiString = typeof emoji === "string" ? emoji : String(emoji || "💡");

--- a/components/ui/Callout.tsx
+++ b/components/ui/Callout.tsx
@@ -9,7 +9,8 @@ type CalloutType =
   | "alert"
   | "enterprise"
   | "beta"
-  | "roadmap";
+  | "roadmap"
+  | "community";
 
 const TYPE_CONFIG: Record<
   CalloutType,
@@ -24,6 +25,7 @@ const TYPE_CONFIG: Record<
   enterprise: { emoji: "🏢", bgColor: "blue" },
   beta: { emoji: "🚧", bgColor: "yellow" },
   roadmap: { emoji: "🛣", bgColor: "default" },
+  community: { emoji: "🤝", bgColor: "default" },
 };
 
 export const Callout = ({

--- a/components/ui/CodeBlock.tsx
+++ b/components/ui/CodeBlock.tsx
@@ -47,6 +47,7 @@ SyntaxHighlighter.registerLanguage("swift", swift);
 SyntaxHighlighter.registerLanguage("kotlin", kotlin);
 SyntaxHighlighter.registerLanguage("xml", xml);
 SyntaxHighlighter.registerLanguage("mjml", xml);
+SyntaxHighlighter.registerLanguage("vue", xml);
 
 export type SupportedLanguage =
   | "javascript"

--- a/content/concepts/channels.mdx
+++ b/content/concepts/channels.mdx
@@ -10,7 +10,8 @@ A channel in Knock represents a configured provider to send notifications to you
 Within Knock, we split channels into different types, where each type has at least one provider associated that can be configured:
 
 - [Email](/integrations/email/overview) (such as Sendgrid, Postmark)
-- [In-app](/integrations/in-app/overview) (such as feeds, toasts, banners)
+- [In-app](/integrations/in-app/overview) (such as feeds and toasts)
+- [In-app guide](/in-app-ui/guides/overview) (such as banners, modals, and other in-product messaging)
 - [Push](/integrations/push/overview) (such as APNs, FCM)
 - [SMS](/integrations/sms/overview) (such as Twilio, Telnyx)
 - [Chat](/integrations/chat/overview) (such as Slack, Microsoft Teams, and Discord)

--- a/content/in-app-ui/guides/render-guides.mdx
+++ b/content/in-app-ui/guides/render-guides.mdx
@@ -7,6 +7,14 @@ section: Building in-app UI > Guides
 
 Once you've [created a guide](/in-app-ui/guides/create-guides), you'll need to render it in your product using the [guides API](/api-reference/users/guides/). This involves fetching the guide data from Knock and displaying it to your users based on their eligibility. You can render guides using Knock's client-side SDKs, which provide built-in state management and helper methods, or by directly calling the [guides API](/api-reference/users/guides) to build a custom implementation. Below we cover both approaches and how to filter guides to show the right content to your users.
 
+## Guide identifiers
+
+There are three identifiers you'll work with when implementing guides:
+
+- **Guide channel ID.** Guides are delivered through a dedicated channel called "In-app guide". You can find your guide channel ID under [Channels and sources](/integrations/overview) in your Knock dashboard. You'll use this UUID to initialize the guides provider in your client SDK or to call the [guides API](/api-reference/users/guides/) directly.
+- **Guide key.** The `key` is a unique identifier for a specific guide instance, set when [creating the guide](/in-app-ui/guides/create-guides). E.g., `subscription-expiration-banner` or `spring-promo-modal`.
+- **Guide type.** The `type` of a guide corresponds to the key of its [message type](/in-app-ui/message-types), selected when creating the guide. E.g., `banner` or `custom-modal`.
+
 ## Fetching guides
 
 There are two ways to fetch and render guides: using Knock's client-side SDKs, which provide built-in state management and helper methods, or by directly calling the [guides API](/api-reference/users/guides) to build a custom implementation. Our [step-by-step React example](/in-app-ui/react/headless/guide) demonstrates how to incorporate the SDK's guide provider into your application and render guide components to your users.

--- a/content/in-app-ui/guides/render-guides.mdx
+++ b/content/in-app-ui/guides/render-guides.mdx
@@ -59,6 +59,8 @@ Knock exposes a set of client SDKs that provide helpers and logic to make it eas
   ]}
 />
 
+For a step-by-step example of how to implement guides with the JavaScript SDK in a Vue.js application, see the [Guides in Vue.js](/tutorials/guides-in-vue) tutorial.
+
 #### Key SDK resources
 
 When working with Knock's SDKs to fetch and render guides, you'll use the following components and hooks for React:

--- a/content/integrations/overview.mdx
+++ b/content/integrations/overview.mdx
@@ -34,7 +34,8 @@ You can use Knock to power sophisticated cross-channel notification workflows fo
 We support the following channel types today:
 
 - [Email](/integrations/email/overview) (such as Sendgrid, Postmark)
-- [In-app](/integrations/in-app/overview) (such as feeds, toasts, banners)
+- [In-app](/integrations/in-app/overview) (such as feeds and toasts)
+- [In-app guide](/in-app-ui/guides/overview) (such as banners, modals, and other in-product messaging)
 - [Push](/integrations/push/overview) (such as APNs, FCM)
 - [SMS](/integrations/sms/overview) (such as Twilio, Telnyx)
 - [Chat](/integrations/chat/overview) (such as Slack, Microsoft Teams, and Discord)

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -1,25 +1,26 @@
 ---
 title: Implementing Knock guides in Vue.js
-description: Learn how to implement Knock guides in a Vue.js application using the Knock JavaScript SDK with Vue composables and components.
+description: Learn how to implement Knock guides in a Vue.js application using the Knock JavaScript SDK.
 tags: ["guides", "vue", "typescript", "in-app"]
 section: Tutorials
 ---
 
-<Callout type="community" />
+<Callout type="community_sourced" />
 
-In this tutorial we'll walk through how to implement [Knock guides](/in-app-ui/guides/overview) in a Vue.js application. Knock's JavaScript SDK is framework-agnostic, but its React components aren't available in Vue.js, so you'll need to replicate the provider and hook patterns using Vue composables.
+In this tutorial we'll walk through how to implement [Knock guides](/in-app-ui/guides/overview) in a Vue.js application. Knock's [guide provider and hooks](/in-app-ui/guides/render-guides#client-side-sdks) are built for React, so we'll use the underlying [Knock JavaScript SDK](/in-app-ui/javascript/sdk/reference) directly to recreate the same behavior using Vue composables.
 
 ## Prerequisites
 
 You'll need:
 
-- A Knock account with [guides](/in-app-ui/guides/overview) configured
 - A Vue.js 3 project
-- Your Knock public API key and a guide channel ID
+- A Knock account with at least one [guide created](/in-app-ui/guides/create-guides)
+- Your [Knock public API key](/developer-tools/api-keys)
+- Your [guide channel ID](/in-app-ui/guides/render-guides#guide-identifiers)
 
 ## Architecture overview
 
-The Knock React SDK uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables.
+The [Knock React SDK](/in-app-ui/react/sdk/overview) uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables.
 
 | React                | Vue.js                              |
 | -------------------- | ----------------------------------- |
@@ -27,50 +28,31 @@ The Knock React SDK uses a provider/hook pattern (`KnockProvider`, `KnockGuidePr
 | `KnockGuideProvider` | Included in `KnockProvider.vue`     |
 | `useGuide()` hook    | `useGuide()` composable             |
 
-The Knock client must initialize in a specific sequence before guides are available: the Knock client initializes first, the user authenticates, then the guide client initializes and fetches guides. Always check that the Knock client exists before calling guide client methods.
+The Knock client must initialize in a specific sequence before guides are available: the Knock client initializes first, the user authenticates, then the guide client initializes and fetches guides.
 
 ## Implementation
 
 <Steps>
-<Step title="Install required packages">
+<Step title="Install required packages and dependencies">
 
-Install the Knock JavaScript SDK and its dependencies:
-
-```bash title="Install required packages"
+```bash title="Install the JavaScript SDK, state management library, and URL pattern polyfill"
 npm install @knocklabs/client @tanstack/store urlpattern-polyfill
-```
-
-- **`@knocklabs/client`** — the core Knock JavaScript SDK with guide client support.
-- **`@tanstack/store`** — state management library used internally by the Knock SDK.
-- **`urlpattern-polyfill`** — polyfill for URL pattern matching used in guide activation rules.
-
-Import the polyfill at the top of your app entry point before initializing Knock:
-
-```typescript title="Import the URL pattern polyfill"
-import "urlpattern-polyfill";
 ```
 
 </Step>
 <Step title="Create the Knock client composable">
 
-This composable manages the Knock client lifecycle — initialization and authentication. It returns a reactive `knockClient` ref that other composables depend on.
+This composable initializes the Knock client and authenticates the user. It exposes a reactive `knockClient` ref used by the other composables.
 
 ```typescript title="Knock client composable"
 import { reactive, computed } from "vue";
-import Knock, { KnockGuideClient } from "@knocklabs/client";
+import Knock from "@knocklabs/client";
 
 interface KnockState {
   knockClient: Knock | null;
   isAuthenticated: boolean;
   isInitializing: boolean;
   lastError: Error | null;
-}
-
-interface KnockGuidesState {
-  guideClient: KnockGuideClient | null;
-  guides: unknown[];
-  loading: boolean;
-  error: Error | null;
 }
 
 export function useKnock() {
@@ -128,7 +110,7 @@ export function useKnock() {
 </Step>
 <Step title="Create the guide client composable">
 
-This composable manages the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
+This composable initializes the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
 
 ```typescript title="Guide client composable"
 import { reactive, computed, type Ref } from "vue";
@@ -205,7 +187,7 @@ export function useKnockGuides(
 </Step>
 <Step title="Create the provider component">
 
-The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches for async authentication completion to ensure guides initialize even if the client becomes ready after mount.
+The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches `knock.isReady` to handle cases where authentication completes after mount.
 
 ```vue title="Provider component"
 <template>
@@ -277,7 +259,7 @@ Use the provider at the root of any view that needs guide functionality:
 </Step>
 <Step title="Create the useGuide composable">
 
-The `useGuide` composable selects a specific guide from the guide client by type or key, matching the behavior of the React `useGuide` hook. It uses `inject` to access the guide client provided by `KnockProvider`.
+The `useGuide` composable mirrors the React [`useGuide`](/in-app-ui/react/sdk/hooks/use-guide) hook — it fetches a single guide by `type` or `key`. It takes the `knockGuides` instance as a parameter, which the calling component retrieves via `inject` from `KnockProvider`.
 
 ```typescript title="useGuide composable"
 import { computed } from "vue";
@@ -456,21 +438,13 @@ onMounted(() => {
 
 ## Troubleshooting
 
-**Guides not appearing after authentication**
+See [debugging guides](/in-app-ui/guides/debugging-guides) for general troubleshooting guidance related to guide activation and targeting. You may also encounter these Vue-specific issues:
 
-If guides aren't loading after the user authenticates, check that `knock.knockClient.value` exists before calling `initializeGuideClient`. The `watch` on `knock.isReady` in `KnockProvider.vue` handles cases where the client becomes ready asynchronously.
-
-**Store subscription not updating components**
-
-The `subscribe` call in `useKnockGuides` keeps Vue's reactive state in sync with the guide client's internal store. If guide state isn't updating, confirm that `state.guideClient.store.subscribe` is being called after `initializeGuideClient`.
-
-**`urlpattern-polyfill` not applying**
-
-Import the polyfill at the top of your app entry point before initializing Knock:
-
-```typescript title="Import the URL pattern polyfill"
-import "urlpattern-polyfill";
-```
+| Issue                                                                                | Solution                                                                                                                                                                                               |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. The `watch` on `knock.isReady` in `KnockProvider.vue` handles cases where the client becomes ready asynchronously. |
+| The store subscription is not updating components.                                   | Confirm that `state.guideClient.store.subscribe` is being called after `initializeGuideClient`.                                                                                                        |
+| [Guide activation rules](/in-app-ui/guides/create-guides#activation) aren't working. | Ensure `urlpattern-polyfill` is imported at the top of your app entry point before initializing Knock: `import "urlpattern-polyfill"`                                                                  |
 
 ## Related docs
 

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -33,31 +33,31 @@ The Knock client must initialize in a specific sequence before guides are availa
 ## Implementation
 
 <Steps>
-<Step title="Install required packages and dependencies.">
+<Step title="Install required packages and add an import for the URL pattern polyfill.">
 
-```bash title="Install the JavaScript SDK, state management library, and URL pattern polyfill"
-npm install @knocklabs/client @tanstack/store urlpattern-polyfill
+```bash title="Install the JavaScript SDK and URL pattern polyfill"
+npm install @knocklabs/client urlpattern-polyfill
+```
+
+Then import the polyfill at the top of your app entry point (e.g. `main.ts`):
+
+```typescript title="main.ts"
+import "urlpattern-polyfill";
+// ... rest of your app setup
 ```
 
 </Step>
 <Step title="Create the Knock client composable.">
 
-This composable initializes the Knock client and authenticates the user. It uses `shallowRef` for the client instance — rather than `reactive()` — to avoid TypeScript errors from Vue's deep unwrapping of class internals.
+This composable initializes the Knock client and authenticates the user. It uses `shallowRef` for the client instance — rather than `reactive()` — to avoid TypeScript errors from Vue's deep unwrapping of class internals. The client instance is shared via the returned `knockClient` ref, which `useKnockGuides` takes as a parameter.
 
 ```typescript title="composables/useKnock.ts"
-import { shallowRef, ref, computed } from "vue";
+import { shallowRef } from "vue";
 import Knock from "@knocklabs/client";
 
 export function useKnock() {
   // shallowRef avoids Vue unwrapping class internals, which causes TS errors with reactive()
   const knockClient = shallowRef<Knock | null>(null);
-  const isAuthenticated = ref(false);
-  const isInitializing = ref(false);
-
-  // True only when the client exists, the user is authenticated, and no initialization is in progress
-  const isReady = computed(
-    () => knockClient.value && isAuthenticated.value && !isInitializing.value,
-  );
 
   const initializeKnock = async (apiKey: string): Promise<Knock> => {
     if (!apiKey) {
@@ -68,29 +68,20 @@ export function useKnock() {
       return knockClient.value;
     }
 
-    isInitializing.value = true;
-    try {
-      knockClient.value = new Knock(apiKey);
-      return knockClient.value;
-    } finally {
-      isInitializing.value = false;
-    }
+    knockClient.value = new Knock(apiKey);
+    return knockClient.value;
   };
 
-  const authenticate = async (user: { id: string }): Promise<void> => {
+  const authenticate = (user: { id: string }): void => {
     if (!knockClient.value) {
       throw new Error("Knock client must be initialized before authentication");
     }
 
-    // authenticate() registers the user synchronously — no await needed
     knockClient.value.authenticate(user);
-    isAuthenticated.value = true;
   };
 
   return {
     knockClient,
-    isAuthenticated,
-    isReady,
     initializeKnock,
     authenticate,
   };
@@ -104,7 +95,7 @@ This composable initializes the guide client, subscribes to guide updates, and e
 
 ```typescript title="composables/useKnockGuides.ts"
 import { shallowRef, reactive, computed, type Ref } from "vue";
-import { KnockGuideClient } from "@knocklabs/client";
+import { KnockGuideClient, type KnockGuide } from "@knocklabs/client";
 import type Knock from "@knocklabs/client";
 
 export function useKnockGuides(knockClient: Ref<Knock | null>) {
@@ -113,7 +104,7 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
   const guideClient = shallowRef<KnockGuideClient | null>(null);
 
   const state = reactive<{
-    guides: unknown[];
+    guides: KnockGuide[];
     loading: boolean;
     error: Error | null;
   }>({
@@ -126,7 +117,7 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
     () => guideClient.value && knockClient.value && !state.loading,
   );
 
-  const initializeGuideClient = async (channelId: string): Promise<void> => {
+  const initializeGuideClient = (channelId: string): void => {
     if (!knockClient.value) {
       throw new Error("Knock client is required");
     }
@@ -137,7 +128,7 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
     guideClient.value.store.subscribe(() => {
       if (guideClient.value) {
         const storeState = guideClient.value.store.state;
-        state.guides = guideClient.value.selectGuides(storeState) || [];
+        state.guides = guideClient.value.selectGuides(storeState);
       }
     });
 
@@ -145,35 +136,27 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
     guideClient.value.subscribe();
   };
 
-  const fetchGuides = async (
-    filters: Record<string, unknown> = {},
-  ): Promise<void> => {
+  const fetchGuides = async (): Promise<void> => {
     if (!guideClient.value) return;
 
     state.loading = true;
     try {
-      await guideClient.value.fetch({ filters });
+      await guideClient.value.fetch();
+    } catch (err) {
+      state.error = err instanceof Error ? err : new Error(String(err));
     } finally {
       state.loading = false;
     }
   };
 
-  const getGuide = (filters: Record<string, unknown> = {}): unknown | null => {
-    if (!guideClient.value) return null;
-
-    const storeState = guideClient.value.store.state;
-    const selectedGuides = guideClient.value.selectGuides(storeState, filters);
-    return selectedGuides?.[0] || null;
-  };
-
   return {
+    guideClient,
     guides: computed(() => state.guides),
     loading: computed(() => state.loading),
     error: computed(() => state.error),
     isReady,
     initializeGuideClient,
     fetchGuides,
-    getGuide,
   };
 }
 ```
@@ -181,7 +164,7 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
 </Step>
 <Step title="Create the provider component.">
 
-The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. An `isInitializingGuides` flag prevents the `knock.isReady` watcher from triggering a duplicate initialization while `onMounted` is already awaiting the first one.
+The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`.
 
 ```vue title="components/KnockProvider.vue"
 <template>
@@ -189,7 +172,7 @@ The provider component initializes Knock, authenticates the user, and makes the 
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, provide, ref, watch } from "vue";
+import { onMounted, onUnmounted, provide } from "vue";
 import { useKnock } from "../composables/useKnock";
 import { useKnockGuides } from "../composables/useKnockGuides";
 
@@ -204,49 +187,21 @@ const knockGuides = useKnockGuides(knock.knockClient);
 
 // Make the guide client available to all descendant components
 provide("knockGuides", knockGuides);
-provide("knockChannelId", props.channelId);
-
-// Tracks whether guide initialization is in progress. This prevents the
-// knock.isReady watcher from triggering a second initializeGuideClient call
-// while onMounted is still awaiting the first one: authenticate() sets
-// isAuthenticated synchronously, which makes knock.isReady true and queues
-// the watcher before onMounted resumes after its await.
-const isInitializingGuides = ref(false);
-
-const initializeGuides = async (): Promise<void> => {
-  if (isInitializingGuides.value || knockGuides.isReady.value) return;
-
-  isInitializingGuides.value = true;
-  try {
-    await knockGuides.initializeGuideClient(props.channelId);
-    await knockGuides.fetchGuides();
-  } finally {
-    isInitializingGuides.value = false;
-  }
-};
 
 onMounted(async () => {
   try {
     await knock.initializeKnock(props.apiKey);
-    await knock.authenticate(props.user);
+    knock.authenticate(props.user);
 
-    if (knock.knockClient.value) {
-      await initializeGuides();
-    }
+    knockGuides.initializeGuideClient(props.channelId);
+    await knockGuides.fetchGuides();
   } catch (error) {
     console.error("Failed to initialize Knock guides:", error);
   }
 });
 
-// Re-initialize guides if the Knock client becomes ready after mount
-// (e.g. when authentication is handled asynchronously outside this component)
-watch(knock.isReady, async (isReady) => {
-  if (isReady) {
-    await initializeGuides();
-  }
-});
-
 onUnmounted(() => {
+  knockGuides.guideClient.value?.cleanup();
   knock.knockClient.value?.teardown();
 });
 </script>
@@ -275,7 +230,7 @@ The `useGuide` composable mirrors the React [`useGuide`](/in-app-ui/react/sdk/ho
 ```typescript title="composables/useGuide.ts"
 import { computed } from "vue";
 
-interface GuideFilters extends Record<string, unknown> {
+interface GuideFilters {
   type?: string;
   key?: string;
 }
@@ -295,28 +250,22 @@ export function useGuide(
       guides: computed(() => []),
       loading: computed(() => false),
       error: computed(() => null),
+      isReady: computed(() => false),
     };
   }
 
-  const filters: GuideFilters = {};
-  if (type) filters.type = type;
-  if (key) filters.key = key;
-
+  // Filter from the reactive guides ref so step recomputes whenever the
+  // store subscription updates state.guides in useKnockGuides
   const step = computed(() => {
-    try {
-      const matchingGuide = knockGuides.getGuide(filters) as {
-        steps?: unknown[];
-      } | null;
+    const match = knockGuides.guides.value.find((g) => {
+      if (type && g.type !== type) return false;
+      if (key && g.key !== key) return false;
+      return true;
+    });
 
-      if (!matchingGuide?.steps?.length) {
-        return null;
-      }
-
-      return matchingGuide.steps[0] || null;
-    } catch (error) {
-      console.error("Error getting guide step:", error);
-      return null;
-    }
+    // getStep() applies the SDK's display-ordering logic rather than
+    // indexing steps directly
+    return match?.getStep() ?? null;
   });
 
   return {
@@ -343,7 +292,7 @@ Each step also provides these methods for [tracking engagement](/in-app-ui/guide
 
 | Method               | Description                                                                                               |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `markAsSeen()`       | Marks the guide as read.                                                                                  |
+| `markAsSeen()`       | Marks the guide as seen.                                                                                  |
 | `markAsInteracted()` | Marks the guide as interacted, recording a click event or other user interaction, with optional metadata. |
 | `markAsArchived()`   | Marks the guide as archived, removing the guide from eligibility for the user.                            |
 
@@ -413,10 +362,8 @@ interface ButtonContent {
 
 interface GuideStep {
   content?: Record<string, any>;
-  markAsSeen?: () => void;
-  markAsInteracted?: (opts: {
-    metadata: Record<string, unknown>;
-  }) => Promise<void>;
+  markAsSeen?: () => Promise<void>;
+  markAsInteracted?: (metadata?: Record<string, unknown>) => Promise<void>;
   markAsArchived?: () => Promise<void>;
 }
 
@@ -432,7 +379,8 @@ const handleButtonClick = async (
 ): Promise<void> => {
   if (typedStep.value?.markAsInteracted) {
     await typedStep.value.markAsInteracted({
-      metadata: { type: "button_click", button_type: buttonType },
+      type: "button_click",
+      button_type: buttonType,
     });
   }
 
@@ -447,13 +395,16 @@ const handleDismiss = async (): Promise<void> => {
   }
 };
 
-// Mark each guide as seen when it first appears; comparing old and new step avoids
-// calling markAsSeen again on unrelated reactive updates to the same step
-watch(typedStep, (newStep, oldStep) => {
-  if (newStep && newStep !== oldStep) {
-    newStep.markAsSeen?.();
-  }
-});
+// Mark the guide as seen each time it renders
+watch(
+  typedStep,
+  (newStep) => {
+    if (newStep) {
+      newStep.markAsSeen?.();
+    }
+  },
+  { immediate: true },
+);
 </script>
 ```
 
@@ -471,8 +422,8 @@ See [debugging guides](/in-app-ui/guides/debugging-guides) for general troublesh
 
 | Issue                                                                                | Solution                                                                                                                                                                                               |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. The `watch` on `knock.isReady` in `KnockProvider.vue` handles cases where the client becomes ready asynchronously. |
-| The store subscription is not updating components.                                   | Confirm that `guideClient.value.store.subscribe` is being called after `initializeGuideClient`.                                                                                                        |
+| Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. Ensure `authenticate` is called before `initializeGuideClient` in `onMounted`.                                     |
+| The store subscription is not updating components.                                   | Confirm that `guideClient.value.store.subscribe` is being called inside `initializeGuideClient`, before `guideClient.value.subscribe()`.                                                               |
 | [Guide activation rules](/in-app-ui/guides/create-guides#activation) aren't working. | Ensure `urlpattern-polyfill` is imported at the top of your app entry point before initializing Knock: `import "urlpattern-polyfill"`                                                                  |
 
 ## Related docs

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -420,11 +420,11 @@ The implementation above authenticates users by `id` only. For production use, y
 
 See [debugging guides](/in-app-ui/guides/debugging-guides) for general troubleshooting guidance related to guide activation and targeting. You may also encounter these Vue-specific issues:
 
-| Issue                                                                                | Solution                                                                                                                                                                                               |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. Ensure `authenticate` is called before `initializeGuideClient` in `onMounted`.                                     |
-| The store subscription is not updating components.                                   | Confirm that `guideClient.value.store.subscribe` is being called inside `initializeGuideClient`, before `guideClient.value.subscribe()`.                                                               |
-| [Guide activation rules](/in-app-ui/guides/create-guides#activation) aren't working. | Ensure `urlpattern-polyfill` is imported at the top of your app entry point before initializing Knock: `import "urlpattern-polyfill"`                                                                  |
+| Issue                                                                                | Solution                                                                                                                                                           |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. Ensure `authenticate` is called before `initializeGuideClient` in `onMounted`. |
+| The store subscription is not updating components.                                   | Confirm that `guideClient.value.store.subscribe` is being called inside `initializeGuideClient`, before `guideClient.value.subscribe()`.                           |
+| [Guide activation rules](/in-app-ui/guides/create-guides#activation) aren't working. | Ensure `urlpattern-polyfill` is imported at the top of your app entry point before initializing Knock: `import "urlpattern-polyfill"`                              |
 
 ## Related docs
 

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -22,49 +22,41 @@ You'll need:
 
 The [Knock React SDK](/in-app-ui/react/sdk/overview) uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables.
 
-| React                | Vue.js                              |
-| -------------------- | ----------------------------------- |
-| `KnockProvider`      | `KnockProvider.vue` using `provide` |
-| `KnockGuideProvider` | Included in `KnockProvider.vue`     |
-| `useGuide()` hook    | `useGuide()` composable             |
+| React                | Vue                                                                 |
+| -------------------- | ------------------------------------------------------------------- |
+| `KnockProvider`      | A `KnockProvider.vue` component that uses Vue's `provide`/`inject`. |
+| `KnockGuideProvider` | Included in `KnockProvider.vue`.                                    |
+| `useGuide()` hook    | A `useGuide()` composable.                                          |
 
 The Knock client must initialize in a specific sequence before guides are available: the Knock client initializes first, the user authenticates, then the guide client initializes and fetches guides.
 
 ## Implementation
 
 <Steps>
-<Step title="Install required packages and dependencies">
+<Step title="Install required packages and dependencies.">
 
 ```bash title="Install the JavaScript SDK, state management library, and URL pattern polyfill"
 npm install @knocklabs/client @tanstack/store urlpattern-polyfill
 ```
 
 </Step>
-<Step title="Create the Knock client composable">
+<Step title="Create the Knock client composable.">
 
-This composable initializes the Knock client and authenticates the user. It exposes a reactive `knockClient` ref used by the other composables.
+This composable initializes the Knock client and authenticates the user. It uses `shallowRef` for the client instance — rather than `reactive()` — to avoid TypeScript errors from Vue's deep unwrapping of class internals.
 
 ```typescript title="composables/useKnock.ts"
-import { reactive, computed } from "vue";
+import { shallowRef, ref, computed } from "vue";
 import Knock from "@knocklabs/client";
 
-interface KnockState {
-  knockClient: Knock | null;
-  isAuthenticated: boolean;
-  isInitializing: boolean;
-  lastError: Error | null;
-}
-
 export function useKnock() {
-  const state = reactive<KnockState>({
-    knockClient: null,
-    isAuthenticated: false,
-    isInitializing: false,
-    lastError: null,
-  });
+  // shallowRef avoids Vue unwrapping class internals, which causes TS errors with reactive()
+  const knockClient = shallowRef<Knock | null>(null);
+  const isAuthenticated = ref(false);
+  const isInitializing = ref(false);
 
+  // True only when the client exists, the user is authenticated, and no initialization is in progress
   const isReady = computed(
-    () => state.knockClient && state.isAuthenticated && !state.isInitializing,
+    () => knockClient.value && isAuthenticated.value && !isInitializing.value,
   );
 
   const initializeKnock = async (apiKey: string): Promise<Knock> => {
@@ -72,34 +64,31 @@ export function useKnock() {
       throw new Error("API key is required to initialize Knock");
     }
 
-    if (state.knockClient) {
-      return state.knockClient;
+    if (knockClient.value) {
+      return knockClient.value;
     }
 
-    state.isInitializing = true;
+    isInitializing.value = true;
     try {
-      state.knockClient = new Knock(apiKey);
-      return state.knockClient;
+      knockClient.value = new Knock(apiKey);
+      return knockClient.value;
     } finally {
-      state.isInitializing = false;
+      isInitializing.value = false;
     }
   };
 
-  const authenticate = async (
-    userId: string,
-    userToken: string | null = null,
-  ): Promise<void> => {
-    if (!state.knockClient) {
+  const authenticate = async (user: { id: string }): Promise<void> => {
+    if (!knockClient.value) {
       throw new Error("Knock client must be initialized before authentication");
     }
 
-    state.knockClient.authenticate({ id: userId }, userToken ?? undefined);
-    state.isAuthenticated = true;
+    knockClient.value.authenticate(user);
+    isAuthenticated.value = true;
   };
 
   return {
-    knockClient: computed(() => state.knockClient),
-    isAuthenticated: computed(() => state.isAuthenticated),
+    knockClient,
+    isAuthenticated,
     isReady,
     initializeKnock,
     authenticate,
@@ -108,7 +97,7 @@ export function useKnock() {
 ```
 
 </Step>
-<Step title="Create the guide client composable">
+<Step title="Create the guide client composable.">
 
 This composable initializes the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
 
@@ -152,8 +141,8 @@ export function useKnockGuides(
       }
     });
 
-    // Set up real-time subscription for live guide updates
-    await state.guideClient.subscribe();
+    // Join the socket channel for live guide updates (synchronous, returns void)
+    state.guideClient.subscribe();
   };
 
   const fetchGuides = async (
@@ -185,7 +174,7 @@ export function useKnockGuides(
 ```
 
 </Step>
-<Step title="Create the provider component">
+<Step title="Create the provider component.">
 
 The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches `knock.isReady` to handle cases where authentication completes after mount.
 
@@ -198,12 +187,12 @@ The provider component initializes Knock, authenticates the user, and makes the 
 
 <script setup lang="ts">
 import { onMounted, onUnmounted, provide, watch } from "vue";
-import { useKnock, useKnockGuides } from "../composables/useKnock";
+import { useKnock } from "../composables/useKnock";
+import { useKnockGuides } from "../composables/useKnockGuides";
 
 const props = defineProps<{
   apiKey: string;
-  userId: string;
-  userToken?: string | null;
+  user: { id: string };
   channelId: string;
 }>();
 
@@ -217,7 +206,7 @@ provide("knockChannelId", props.channelId);
 onMounted(async () => {
   try {
     await knock.initializeKnock(props.apiKey);
-    await knock.authenticate(props.userId, props.userToken ?? null);
+    await knock.authenticate(props.user);
 
     if (knock.knockClient.value) {
       await knockGuides.initializeGuideClient(props.channelId);
@@ -250,21 +239,26 @@ Use the provider at the root of any view that needs guide functionality:
 
 ```vue title="Using the provider"
 <template>
-  <KnockProvider :api-key="apiKey" :user-id="userId" :channel-id="channelId">
+  <!-- Channel ID is a UUID from Channels and sources in your Knock dashboard -->
+  <KnockProvider
+    :api-key="KNOCK_PUBLIC_API_KEY"
+    :user="{ id: 'user_123' }"
+    :channel-id="GUIDE_CHANNEL_UUID"
+  >
     <YourApp />
   </KnockProvider>
 </template>
 ```
 
 </Step>
-<Step title="Create the useGuide composable">
+<Step title="Create the useGuide composable.">
 
 The `useGuide` composable mirrors the React [`useGuide`](/in-app-ui/react/sdk/hooks/use-guide) hook — it fetches a single guide by `type` or `key`. It takes the `knockGuides` instance as a parameter, which the calling component retrieves via `inject` from `KnockProvider`.
 
 ```typescript title="composables/useGuide.ts"
 import { computed } from "vue";
 
-interface GuideFilters {
+interface GuideFilters extends Record<string, unknown> {
   type?: string;
   key?: string;
 }
@@ -330,14 +324,14 @@ Each guide step exposes a `content` object whose shape is determined by your [me
 
 Each step also provides these methods for [tracking engagement](/in-app-ui/guides/handling-engagement):
 
-| Method                       | Description                                        |
-| ---------------------------- | -------------------------------------------------- |
-| `markAsSeen()`               | Marks the guide as viewed.                         |
-| `markAsInteracted(metadata)` | Records a user interaction with optional metadata. |
-| `markAsArchived()`           | Removes the guide from the user's view.            |
+| Method               | Description                                                                                               |
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
+| `markAsSeen()`       | Marks the guide as read.                                                                                  |
+| `markAsInteracted()` | Marks the guide as interacted, recording a click event or other user interaction, with optional metadata. |
+| `markAsArchived()`   | Marks the guide as archived, removing the guide from eligibility for the user.                            |
 
 </Step>
-<Step title="Build a guide component">
+<Step title="Build a guide component.">
 
 With the composables in place, you can build components to render guides. This example shows a banner component that renders a guide, tracks engagement, and handles dismissal.
 
@@ -346,34 +340,37 @@ With the composables in place, you can build components to render guides. This e
   <div v-if="shouldShowBanner" class="knock-guide-banner">
     <div class="knock-guide-banner__message">
       <div class="knock-guide-banner__title">
-        {{ step?.content?.title }}
+        {{ typedStep?.content?.title }}
       </div>
-      <div class="knock-guide-banner__body" v-html="step?.content?.body" />
+      <div class="knock-guide-banner__body" v-html="typedStep?.content?.body" />
     </div>
 
     <div class="knock-guide-banner__actions">
       <button
-        v-if="step?.content?.secondary_button"
+        v-if="typedStep?.content?.secondary_button"
         class="knock-guide-banner__action knock-guide-banner__action--secondary"
         @click="
-          handleButtonClick('secondary_button', step.content.secondary_button)
+          handleButtonClick(
+            'secondary_button',
+            typedStep.content.secondary_button,
+          )
         "
       >
-        {{ step.content.secondary_button.text }}
+        {{ typedStep.content.secondary_button.text }}
       </button>
 
       <button
-        v-if="step?.content?.primary_button"
+        v-if="typedStep?.content?.primary_button"
         class="knock-guide-banner__action"
         @click="
-          handleButtonClick('primary_button', step.content.primary_button)
+          handleButtonClick('primary_button', typedStep.content.primary_button)
         "
       >
-        {{ step.content.primary_button.text }}
+        {{ typedStep.content.primary_button.text }}
       </button>
 
       <button
-        v-if="step?.content?.dismissible"
+        v-if="typedStep?.content?.dismissible"
         class="knock-guide-banner__close"
         aria-label="Dismiss banner"
         @click="handleDismiss"
@@ -385,7 +382,7 @@ With the composables in place, you can build components to render guides. This e
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, inject } from "vue";
+import { computed, onMounted, ref, watch, inject } from "vue";
 import { useGuide } from "../composables/useGuide";
 
 interface ButtonContent {
@@ -393,21 +390,31 @@ interface ButtonContent {
   action?: string;
 }
 
+interface GuideStep {
+  content?: Record<string, any>;
+  markAsSeen?: () => void;
+  markAsInteracted?: (opts: {
+    metadata: Record<string, unknown>;
+  }) => Promise<void>;
+  markAsArchived?: () => Promise<void>;
+}
+
 const knockGuides = inject("knockGuides") as ReturnType<
   typeof import("../composables/useKnockGuides").useKnockGuides
 > | null;
 const { step } = useGuide(knockGuides, { type: "banner" });
+const typedStep = computed(() => step.value as GuideStep | null);
 
 const isMounted = ref(false);
 
-const shouldShowBanner = computed(() => step.value && isMounted.value);
+const shouldShowBanner = computed(() => typedStep.value && isMounted.value);
 
 const handleButtonClick = async (
   buttonType: string,
   button: ButtonContent,
 ): Promise<void> => {
-  if (step.value?.markAsInteracted) {
-    await step.value.markAsInteracted({
+  if (typedStep.value?.markAsInteracted) {
+    await typedStep.value.markAsInteracted({
       metadata: { type: "button_click", button_type: buttonType },
     });
   }
@@ -418,20 +425,29 @@ const handleButtonClick = async (
 };
 
 const handleDismiss = async (): Promise<void> => {
-  if (step.value?.markAsArchived) {
-    await step.value.markAsArchived();
+  if (typedStep.value?.markAsArchived) {
+    await typedStep.value.markAsArchived();
   }
 };
 
 onMounted(() => {
   isMounted.value = true;
+});
 
-  if (step.value?.markAsSeen) {
-    step.value.markAsSeen();
+// Mark each guide as seen when it first appears; comparing old and new step avoids
+// calling markAsSeen again on unrelated reactive updates to the same step
+watch(typedStep, (newStep, oldStep) => {
+  if (newStep && newStep !== oldStep) {
+    newStep.markAsSeen?.();
   }
 });
 </script>
 ```
+
+</Step>
+<Step title="Secure the client with user tokens.">
+
+The implementation above authenticates users by `id` only. For production use, you should also pass a [user token](/in-app-ui/security-and-authentication) — a short-lived JWT signed by your backend — to verify that the client is authorized to act on behalf of the user.
 
 </Step>
 </Steps>

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -106,10 +106,7 @@ import { reactive, computed, type Ref } from "vue";
 import { KnockGuideClient } from "@knocklabs/client";
 import type Knock from "@knocklabs/client";
 
-export function useKnockGuides(
-  knockClient: Ref<Knock | null>,
-  channelId: string | null = null,
-) {
+export function useKnockGuides(knockClient: Ref<Knock | null>) {
   const state = reactive<{
     guideClient: KnockGuideClient | null;
     guides: unknown[];
@@ -126,12 +123,12 @@ export function useKnockGuides(
     () => state.guideClient && knockClient.value && !state.loading,
   );
 
-  const initializeGuideClient = async (newChannelId: string): Promise<void> => {
+  const initializeGuideClient = async (channelId: string): Promise<void> => {
     if (!knockClient.value) {
       throw new Error("Knock client is required");
     }
 
-    state.guideClient = new KnockGuideClient(knockClient.value, newChannelId);
+    state.guideClient = new KnockGuideClient(knockClient.value, channelId);
 
     // Subscribe to store changes to keep guide state reactive
     state.guideClient.store.subscribe(() => {
@@ -197,7 +194,7 @@ const props = defineProps<{
 }>();
 
 const knock = useKnock();
-const knockGuides = useKnockGuides(knock.knockClient, props.channelId);
+const knockGuides = useKnockGuides(knock.knockClient);
 
 // Make the guide client available to all descendant components
 provide("knockGuides", knockGuides);

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -1,7 +1,7 @@
 ---
 title: Implementing Knock guides in Vue.js
 description: Learn how to implement Knock guides in a Vue.js application using the Knock JavaScript SDK.
-tags: ["guides", "vue", "typescript", "in-app"]
+tags: ["guides", "vue", "in-app"]
 section: Tutorials
 ---
 
@@ -44,7 +44,7 @@ npm install @knocklabs/client @tanstack/store urlpattern-polyfill
 
 This composable initializes the Knock client and authenticates the user. It exposes a reactive `knockClient` ref used by the other composables.
 
-```typescript title="Knock client composable"
+```typescript title="composables/useKnock.ts"
 import { reactive, computed } from "vue";
 import Knock from "@knocklabs/client";
 
@@ -112,7 +112,7 @@ export function useKnock() {
 
 This composable initializes the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
 
-```typescript title="Guide client composable"
+```typescript title="composables/useKnockGuides.ts"
 import { reactive, computed, type Ref } from "vue";
 import { KnockGuideClient } from "@knocklabs/client";
 import type Knock from "@knocklabs/client";
@@ -189,7 +189,7 @@ export function useKnockGuides(
 
 The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches `knock.isReady` to handle cases where authentication completes after mount.
 
-```vue title="Provider component"
+```vue title="components/KnockProvider.vue"
 <template>
   <div>
     <slot />
@@ -261,7 +261,7 @@ Use the provider at the root of any view that needs guide functionality:
 
 The `useGuide` composable mirrors the React [`useGuide`](/in-app-ui/react/sdk/hooks/use-guide) hook — it fetches a single guide by `type` or `key`. It takes the `knockGuides` instance as a parameter, which the calling component retrieves via `inject` from `KnockProvider`.
 
-```typescript title="useGuide composable"
+```typescript title="composables/useGuide.ts"
 import { computed } from "vue";
 
 interface GuideFilters {
@@ -328,7 +328,7 @@ Each guide step exposes a `content` object whose shape is determined by your [me
 | `secondary_button` | `{ text: string; action: string }` | Secondary action button.            |
 | `dismissible`      | `boolean`                          | Whether the guide can be dismissed. |
 
-Each step also provides these methods for tracking engagement:
+Each step also provides these methods for [tracking engagement](/in-app-ui/guides/handling-engagement):
 
 | Method                       | Description                                        |
 | ---------------------------- | -------------------------------------------------- |
@@ -341,7 +341,7 @@ Each step also provides these methods for tracking engagement:
 
 With the composables in place, you can build components to render guides. This example shows a banner component that renders a guide, tracks engagement, and handles dismissal.
 
-```vue title="Banner component"
+```vue title="components/GuideBanner.vue"
 <template>
   <div v-if="shouldShowBanner" class="knock-guide-banner">
     <div class="knock-guide-banner__message">

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -5,23 +5,7 @@ tags: ["guides", "vue", "typescript", "in-app"]
 section: Tutorials
 ---
 
-<Callout
-  type="community"
-  title="Community-sourced."
-  text={
-    <>
-      This tutorial is based on a real Knock implementation and may reflect
-      preferences of the original developer. If you spot something that could be
-      improved, we welcome{" "}
-      <a href="https://github.com/knocklabs/docs/" target="_blank">
-        contributions
-      </a>
-      . Join our <a href="https://knock.app/join-slack" target="_blank">
-        community Slack
-      </a> to discuss this implementation or share your own.
-    </>
-  }
-/>
+<Callout type="community" />
 
 In this tutorial we'll walk through how to implement [Knock guides](/in-app-ui/guides/overview) in a Vue.js application. Knock's JavaScript SDK is framework-agnostic, but its React components aren't available in Vue.js, so you'll need to replicate the provider and hook patterns using Vue composables.
 

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -1,0 +1,495 @@
+---
+title: Implementing Knock guides in Vue.js
+description: Learn how to implement Knock guides in a Vue.js application using the Knock JavaScript SDK with Vue composables and components.
+tags: ["guides", "vue", "typescript", "in-app"]
+section: Tutorials
+---
+
+<Callout
+  type="community"
+  title="Community-sourced."
+  text={
+    <>
+      This tutorial is based on a real Knock implementation and may reflect
+      preferences of the original developer. If you spot something that could be
+      improved, we welcome{" "}
+      <a href="https://github.com/knocklabs/docs/" target="_blank">
+        contributions
+      </a>
+      . Join our <a href="https://knock.app/join-slack" target="_blank">
+        community Slack
+      </a> to discuss this implementation or share your own.
+    </>
+  }
+/>
+
+In this tutorial we'll walk through how to implement [Knock guides](/in-app-ui/guides/overview) in a Vue.js application. Knock's JavaScript SDK is framework-agnostic, but its React components aren't available in Vue.js, so you'll need to replicate the provider and hook patterns using Vue composables.
+
+## Prerequisites
+
+You'll need:
+
+- A Knock account with [guides](/in-app-ui/guides/overview) configured
+- A Vue.js 3 project
+- Your Knock public API key and a guide channel ID
+
+## Architecture overview
+
+The Knock React SDK uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables.
+
+| React                | Vue.js                              |
+| -------------------- | ----------------------------------- |
+| `KnockProvider`      | `KnockProvider.vue` using `provide` |
+| `KnockGuideProvider` | Included in `KnockProvider.vue`     |
+| `useGuide()` hook    | `useGuide()` composable             |
+
+The Knock client must initialize in a specific sequence before guides are available: the Knock client initializes first, the user authenticates, then the guide client initializes and fetches guides. Always check that the Knock client exists before calling guide client methods.
+
+## Implementation
+
+<Steps>
+<Step title="Install required packages">
+
+Install the Knock JavaScript SDK and its dependencies:
+
+```bash title="Install required packages"
+npm install @knocklabs/client @tanstack/store urlpattern-polyfill
+```
+
+- **`@knocklabs/client`** — the core Knock JavaScript SDK with guide client support.
+- **`@tanstack/store`** — state management library used internally by the Knock SDK.
+- **`urlpattern-polyfill`** — polyfill for URL pattern matching used in guide activation rules.
+
+Import the polyfill at the top of your app entry point before initializing Knock:
+
+```typescript title="Import the URL pattern polyfill"
+import "urlpattern-polyfill";
+```
+
+</Step>
+<Step title="Create the Knock client composable">
+
+This composable manages the Knock client lifecycle — initialization and authentication. It returns a reactive `knockClient` ref that other composables depend on.
+
+```typescript title="Knock client composable"
+import { reactive, computed } from "vue";
+import Knock, { KnockGuideClient } from "@knocklabs/client";
+
+interface KnockState {
+  knockClient: Knock | null;
+  isAuthenticated: boolean;
+  isInitializing: boolean;
+  lastError: Error | null;
+}
+
+interface KnockGuidesState {
+  guideClient: KnockGuideClient | null;
+  guides: unknown[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useKnock() {
+  const state = reactive<KnockState>({
+    knockClient: null,
+    isAuthenticated: false,
+    isInitializing: false,
+    lastError: null,
+  });
+
+  const isReady = computed(
+    () => state.knockClient && state.isAuthenticated && !state.isInitializing,
+  );
+
+  const initializeKnock = async (apiKey: string): Promise<Knock> => {
+    if (!apiKey) {
+      throw new Error("API key is required to initialize Knock");
+    }
+
+    if (state.knockClient) {
+      return state.knockClient;
+    }
+
+    state.isInitializing = true;
+    try {
+      state.knockClient = new Knock(apiKey);
+      return state.knockClient;
+    } finally {
+      state.isInitializing = false;
+    }
+  };
+
+  const authenticate = async (
+    userId: string,
+    userToken: string | null = null,
+  ): Promise<void> => {
+    if (!state.knockClient) {
+      throw new Error("Knock client must be initialized before authentication");
+    }
+
+    state.knockClient.authenticate({ id: userId }, userToken ?? undefined);
+    state.isAuthenticated = true;
+  };
+
+  return {
+    knockClient: computed(() => state.knockClient),
+    isAuthenticated: computed(() => state.isAuthenticated),
+    isReady,
+    initializeKnock,
+    authenticate,
+  };
+}
+```
+
+</Step>
+<Step title="Create the guide client composable">
+
+This composable manages the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
+
+```typescript title="Guide client composable"
+import { reactive, computed, type Ref } from "vue";
+import { KnockGuideClient } from "@knocklabs/client";
+import type Knock from "@knocklabs/client";
+
+export function useKnockGuides(
+  knockClient: Ref<Knock | null>,
+  channelId: string | null = null,
+) {
+  const state = reactive<{
+    guideClient: KnockGuideClient | null;
+    guides: unknown[];
+    loading: boolean;
+    error: Error | null;
+  }>({
+    guideClient: null,
+    guides: [],
+    loading: false,
+    error: null,
+  });
+
+  const isReady = computed(
+    () => state.guideClient && knockClient.value && !state.loading,
+  );
+
+  const initializeGuideClient = async (newChannelId: string): Promise<void> => {
+    if (!knockClient.value) {
+      throw new Error("Knock client is required");
+    }
+
+    state.guideClient = new KnockGuideClient(knockClient.value, newChannelId);
+
+    // Subscribe to store changes to keep guide state reactive
+    state.guideClient.store.subscribe(() => {
+      if (state.guideClient) {
+        const storeState = state.guideClient.store.state;
+        state.guides = state.guideClient.selectGuides(storeState) || [];
+      }
+    });
+
+    // Set up real-time subscription for live guide updates
+    await state.guideClient.subscribe();
+  };
+
+  const fetchGuides = async (
+    filters: Record<string, unknown> = {},
+  ): Promise<void> => {
+    if (state.guideClient) {
+      await state.guideClient.fetch({ filters });
+    }
+  };
+
+  const getGuide = (filters: Record<string, unknown> = {}): unknown | null => {
+    if (!state.guideClient) return null;
+
+    const storeState = state.guideClient.store.state;
+    const selectedGuides = state.guideClient.selectGuides(storeState, filters);
+    return selectedGuides?.[0] || null;
+  };
+
+  return {
+    guides: computed(() => state.guides),
+    loading: computed(() => state.loading),
+    error: computed(() => state.error),
+    isReady,
+    initializeGuideClient,
+    fetchGuides,
+    getGuide,
+  };
+}
+```
+
+</Step>
+<Step title="Create the provider component">
+
+The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches for async authentication completion to ensure guides initialize even if the client becomes ready after mount.
+
+```vue title="Provider component"
+<template>
+  <div>
+    <slot />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, onUnmounted, provide, watch } from "vue";
+import { useKnock, useKnockGuides } from "../composables/useKnock";
+
+const props = defineProps<{
+  apiKey: string;
+  userId: string;
+  userToken?: string | null;
+  channelId: string;
+}>();
+
+const knock = useKnock();
+const knockGuides = useKnockGuides(knock.knockClient, props.channelId);
+
+// Make the guide client available to all descendant components
+provide("knockGuides", knockGuides);
+provide("knockChannelId", props.channelId);
+
+onMounted(async () => {
+  try {
+    await knock.initializeKnock(props.apiKey);
+    await knock.authenticate(props.userId, props.userToken ?? null);
+
+    if (knock.knockClient.value) {
+      await knockGuides.initializeGuideClient(props.channelId);
+      await knockGuides.fetchGuides();
+    }
+  } catch (error) {
+    console.error("Failed to initialize Knock guides:", error);
+  }
+});
+
+// Re-initialize guides if the Knock client becomes ready after mount
+watch(knock.isReady, async (isReady) => {
+  if (isReady && !knockGuides.isReady.value) {
+    try {
+      await knockGuides.initializeGuideClient(props.channelId);
+      await knockGuides.fetchGuides();
+    } catch (error) {
+      console.error("Failed to initialize guides after authentication:", error);
+    }
+  }
+});
+
+onUnmounted(() => {
+  knock.knockClient.value?.teardown();
+});
+</script>
+```
+
+Use the provider at the root of any view that needs guide functionality:
+
+```vue title="Using the provider"
+<template>
+  <KnockProvider :api-key="apiKey" :user-id="userId" :channel-id="channelId">
+    <YourApp />
+  </KnockProvider>
+</template>
+```
+
+</Step>
+<Step title="Create the useGuide composable">
+
+The `useGuide` composable selects a specific guide from the guide client by type or key, matching the behavior of the React `useGuide` hook. It uses `inject` to access the guide client provided by `KnockProvider`.
+
+```typescript title="useGuide composable"
+import { computed } from "vue";
+
+interface GuideFilters {
+  type?: string;
+  key?: string;
+}
+
+export function useGuide(
+  knockGuides: ReturnType<
+    typeof import("./useKnockGuides").useKnockGuides
+  > | null,
+  options: GuideFilters = {},
+) {
+  const { type, key } = options;
+
+  if (!knockGuides) {
+    console.warn("knockGuides instance is required for guide functionality");
+    return {
+      step: computed(() => null),
+      guides: computed(() => []),
+      loading: computed(() => false),
+      error: computed(() => null),
+    };
+  }
+
+  const filters: GuideFilters = {};
+  if (type) filters.type = type;
+  if (key) filters.key = key;
+
+  const step = computed(() => {
+    try {
+      const matchingGuide = knockGuides.getGuide(filters) as {
+        steps?: unknown[];
+      } | null;
+
+      if (!matchingGuide?.steps?.length) {
+        return null;
+      }
+
+      return matchingGuide.steps[0] || null;
+    } catch (error) {
+      console.error("Error getting guide step:", error);
+      return null;
+    }
+  });
+
+  return {
+    step,
+    guides: knockGuides.guides,
+    loading: knockGuides.loading,
+    error: knockGuides.error,
+    isReady: knockGuides.isReady,
+  };
+}
+```
+
+Each guide step exposes a `content` object whose shape is determined by your [message type schema](/in-app-ui/message-types#schemas). Common properties include:
+
+| Property           | Type                               | Description                         |
+| ------------------ | ---------------------------------- | ----------------------------------- |
+| `title`            | `string`                           | Guide title text.                   |
+| `body`             | `string`                           | Guide body content (supports HTML). |
+| `primary_button`   | `{ text: string; action: string }` | Primary action button.              |
+| `secondary_button` | `{ text: string; action: string }` | Secondary action button.            |
+| `dismissible`      | `boolean`                          | Whether the guide can be dismissed. |
+
+Each step also provides these methods for tracking engagement:
+
+| Method                       | Description                                        |
+| ---------------------------- | -------------------------------------------------- |
+| `markAsSeen()`               | Marks the guide as viewed.                         |
+| `markAsInteracted(metadata)` | Records a user interaction with optional metadata. |
+| `markAsArchived()`           | Removes the guide from the user's view.            |
+
+</Step>
+<Step title="Build a guide component">
+
+With the composables in place, you can build components to render guides. This example shows a banner component that renders a guide, tracks engagement, and handles dismissal.
+
+```vue title="Banner component"
+<template>
+  <div v-if="shouldShowBanner" class="knock-guide-banner">
+    <div class="knock-guide-banner__message">
+      <div class="knock-guide-banner__title">
+        {{ step?.content?.title }}
+      </div>
+      <div class="knock-guide-banner__body" v-html="step?.content?.body" />
+    </div>
+
+    <div class="knock-guide-banner__actions">
+      <button
+        v-if="step?.content?.secondary_button"
+        class="knock-guide-banner__action knock-guide-banner__action--secondary"
+        @click="
+          handleButtonClick('secondary_button', step.content.secondary_button)
+        "
+      >
+        {{ step.content.secondary_button.text }}
+      </button>
+
+      <button
+        v-if="step?.content?.primary_button"
+        class="knock-guide-banner__action"
+        @click="
+          handleButtonClick('primary_button', step.content.primary_button)
+        "
+      >
+        {{ step.content.primary_button.text }}
+      </button>
+
+      <button
+        v-if="step?.content?.dismissible"
+        class="knock-guide-banner__close"
+        aria-label="Dismiss banner"
+        @click="handleDismiss"
+      >
+        ×
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, inject } from "vue";
+import { useGuide } from "../composables/useGuide";
+
+interface ButtonContent {
+  text: string;
+  action?: string;
+}
+
+const knockGuides = inject("knockGuides") as ReturnType<
+  typeof import("../composables/useKnockGuides").useKnockGuides
+> | null;
+const { step } = useGuide(knockGuides, { type: "banner" });
+
+const isMounted = ref(false);
+
+const shouldShowBanner = computed(() => step.value && isMounted.value);
+
+const handleButtonClick = async (
+  buttonType: string,
+  button: ButtonContent,
+): Promise<void> => {
+  if (step.value?.markAsInteracted) {
+    await step.value.markAsInteracted({
+      metadata: { type: "button_click", button_type: buttonType },
+    });
+  }
+
+  if (button.action?.startsWith("http")) {
+    window.open(button.action, "_blank");
+  }
+};
+
+const handleDismiss = async (): Promise<void> => {
+  if (step.value?.markAsArchived) {
+    await step.value.markAsArchived();
+  }
+};
+
+onMounted(() => {
+  isMounted.value = true;
+
+  if (step.value?.markAsSeen) {
+    step.value.markAsSeen();
+  }
+});
+</script>
+```
+
+</Step>
+</Steps>
+
+## Troubleshooting
+
+**Guides not appearing after authentication**
+
+If guides aren't loading after the user authenticates, check that `knock.knockClient.value` exists before calling `initializeGuideClient`. The `watch` on `knock.isReady` in `KnockProvider.vue` handles cases where the client becomes ready asynchronously.
+
+**Store subscription not updating components**
+
+The `subscribe` call in `useKnockGuides` keeps Vue's reactive state in sync with the guide client's internal store. If guide state isn't updating, confirm that `state.guideClient.store.subscribe` is being called after `initializeGuideClient`.
+
+**`urlpattern-polyfill` not applying**
+
+Import the polyfill at the top of your app entry point before initializing Knock:
+
+```typescript title="Import the URL pattern polyfill"
+import "urlpattern-polyfill";
+```
+
+## Related docs
+
+- [Knock guides overview](/in-app-ui/guides/overview)
+- [Knock JavaScript SDK reference](/in-app-ui/javascript/sdk/reference)
+- [Message types and schemas](/in-app-ui/message-types)

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -20,13 +20,13 @@ You'll need:
 
 ## Architecture overview
 
-The [Knock React SDK](/in-app-ui/react/sdk/overview) uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables.
+The [Knock React SDK](/in-app-ui/react/sdk/overview) uses a provider/hook pattern (`KnockProvider`, `KnockGuideProvider`, `useGuide`). In Vue.js, you replicate this with `provide`/`inject` and composables. Here's a comparison of Knock's React components and their Vue equivalents.
 
-| React                | Vue                                                                 |
-| -------------------- | ------------------------------------------------------------------- |
-| `KnockProvider`      | A `KnockProvider.vue` component that uses Vue's `provide`/`inject`. |
-| `KnockGuideProvider` | Included in `KnockProvider.vue`.                                    |
-| `useGuide()` hook    | A `useGuide()` composable.                                          |
+| React                | Vue                                                                  |
+| -------------------- | -------------------------------------------------------------------- |
+| `KnockProvider`      | A `KnockProvider.vue` component that uses Vue's `provide`/`inject`.  |
+| `KnockGuideProvider` | `useKnockGuideClient()` composable, used inside `KnockProvider.vue`. |
+| `useGuide()` hook    | A `useGuide()` composable.                                           |
 
 The Knock client must initialize in a specific sequence before guides are available: the Knock client initializes first, the user authenticates, then the guide client initializes and fetches guides.
 
@@ -39,7 +39,9 @@ The Knock client must initialize in a specific sequence before guides are availa
 npm install @knocklabs/client urlpattern-polyfill
 ```
 
-Then import the polyfill at the top of your app entry point (e.g. `main.ts`):
+The Knock guides client uses the [`URLPattern` API](https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API) to evaluate guide activation rules based on the current URL. `URLPattern` is not yet available in all browsers, so the polyfill ensures consistent behavior across environments.
+
+Import the polyfill at the top of your app entry point (e.g. `main.ts`):
 
 ```typescript title="main.ts"
 import "urlpattern-polyfill";
@@ -49,7 +51,7 @@ import "urlpattern-polyfill";
 </Step>
 <Step title="Create the Knock client composable.">
 
-This composable initializes the Knock client and authenticates the user. It uses `shallowRef` for the client instance — rather than `reactive()` — to avoid TypeScript errors from Vue's deep unwrapping of class internals. The client instance is shared via the returned `knockClient` ref, which `useKnockGuides` takes as a parameter.
+This composable initializes the Knock client and authenticates the user. It uses `shallowRef` for the client instance — rather than `reactive()` — to avoid TypeScript errors from Vue's deep unwrapping of class internals. The client instance is shared via the returned `knockClient` ref, which `useKnockGuideClient` takes as a parameter.
 
 ```typescript title="composables/useKnock.ts"
 import { shallowRef } from "vue";
@@ -93,12 +95,12 @@ export function useKnock() {
 
 This composable initializes the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
 
-```typescript title="composables/useKnockGuides.ts"
+```typescript title="composables/useKnockGuideClient.ts"
 import { shallowRef, reactive, computed, type Ref } from "vue";
 import { KnockGuideClient, type KnockGuide } from "@knocklabs/client";
 import type Knock from "@knocklabs/client";
 
-export function useKnockGuides(knockClient: Ref<Knock | null>) {
+export function useKnockGuideClient(knockClient: Ref<Knock | null>) {
   // shallowRef avoids Vue unwrapping KnockGuideClient class internals —
   // the same reason useKnock uses shallowRef for the Knock client
   const guideClient = shallowRef<KnockGuideClient | null>(null);
@@ -174,7 +176,7 @@ The provider component initializes Knock, authenticates the user, and makes the 
 <script setup lang="ts">
 import { onMounted, onUnmounted, provide } from "vue";
 import { useKnock } from "../composables/useKnock";
-import { useKnockGuides } from "../composables/useKnockGuides";
+import { useKnockGuideClient } from "../composables/useKnockGuideClient";
 
 const props = defineProps<{
   apiKey: string;
@@ -183,7 +185,7 @@ const props = defineProps<{
 }>();
 
 const knock = useKnock();
-const knockGuides = useKnockGuides(knock.knockClient);
+const knockGuides = useKnockGuideClient(knock.knockClient);
 
 // Make the guide client available to all descendant components
 provide("knockGuides", knockGuides);
@@ -237,7 +239,7 @@ interface GuideFilters {
 
 export function useGuide(
   knockGuides: ReturnType<
-    typeof import("./useKnockGuides").useKnockGuides
+    typeof import("./useKnockGuideClient").useKnockGuideClient
   > | null,
   options: GuideFilters = {},
 ) {
@@ -255,7 +257,7 @@ export function useGuide(
   }
 
   // Filter from the reactive guides ref so step recomputes whenever the
-  // store subscription updates state.guides in useKnockGuides
+  // store subscription updates state.guides in useKnockGuideClient
   const step = computed(() => {
     const match = knockGuides.guides.value.find((g) => {
       if (type && g.type !== type) return false;
@@ -368,7 +370,7 @@ interface GuideStep {
 }
 
 const knockGuides = inject("knockGuides") as ReturnType<
-  typeof import("../composables/useKnockGuides").useKnockGuides
+  typeof import("../composables/useKnockGuideClient").useKnockGuideClient
 > | null;
 const { step } = useGuide(knockGuides, { type: "banner" });
 const typedStep = computed(() => step.value as GuideStep | null);

--- a/content/tutorials/guides-in-vue.mdx
+++ b/content/tutorials/guides-in-vue.mdx
@@ -82,6 +82,7 @@ export function useKnock() {
       throw new Error("Knock client must be initialized before authentication");
     }
 
+    // authenticate() registers the user synchronously — no await needed
     knockClient.value.authenticate(user);
     isAuthenticated.value = true;
   };
@@ -102,25 +103,27 @@ export function useKnock() {
 This composable initializes the guide client, subscribes to guide updates, and exposes methods for fetching and selecting guides. The store subscription keeps Vue's reactive state in sync with the guide client's internal store.
 
 ```typescript title="composables/useKnockGuides.ts"
-import { reactive, computed, type Ref } from "vue";
+import { shallowRef, reactive, computed, type Ref } from "vue";
 import { KnockGuideClient } from "@knocklabs/client";
 import type Knock from "@knocklabs/client";
 
 export function useKnockGuides(knockClient: Ref<Knock | null>) {
+  // shallowRef avoids Vue unwrapping KnockGuideClient class internals —
+  // the same reason useKnock uses shallowRef for the Knock client
+  const guideClient = shallowRef<KnockGuideClient | null>(null);
+
   const state = reactive<{
-    guideClient: KnockGuideClient | null;
     guides: unknown[];
     loading: boolean;
     error: Error | null;
   }>({
-    guideClient: null,
     guides: [],
     loading: false,
     error: null,
   });
 
   const isReady = computed(
-    () => state.guideClient && knockClient.value && !state.loading,
+    () => guideClient.value && knockClient.value && !state.loading,
   );
 
   const initializeGuideClient = async (channelId: string): Promise<void> => {
@@ -128,33 +131,38 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
       throw new Error("Knock client is required");
     }
 
-    state.guideClient = new KnockGuideClient(knockClient.value, channelId);
+    guideClient.value = new KnockGuideClient(knockClient.value, channelId);
 
     // Subscribe to store changes to keep guide state reactive
-    state.guideClient.store.subscribe(() => {
-      if (state.guideClient) {
-        const storeState = state.guideClient.store.state;
-        state.guides = state.guideClient.selectGuides(storeState) || [];
+    guideClient.value.store.subscribe(() => {
+      if (guideClient.value) {
+        const storeState = guideClient.value.store.state;
+        state.guides = guideClient.value.selectGuides(storeState) || [];
       }
     });
 
     // Join the socket channel for live guide updates (synchronous, returns void)
-    state.guideClient.subscribe();
+    guideClient.value.subscribe();
   };
 
   const fetchGuides = async (
     filters: Record<string, unknown> = {},
   ): Promise<void> => {
-    if (state.guideClient) {
-      await state.guideClient.fetch({ filters });
+    if (!guideClient.value) return;
+
+    state.loading = true;
+    try {
+      await guideClient.value.fetch({ filters });
+    } finally {
+      state.loading = false;
     }
   };
 
   const getGuide = (filters: Record<string, unknown> = {}): unknown | null => {
-    if (!state.guideClient) return null;
+    if (!guideClient.value) return null;
 
-    const storeState = state.guideClient.store.state;
-    const selectedGuides = state.guideClient.selectGuides(storeState, filters);
+    const storeState = guideClient.value.store.state;
+    const selectedGuides = guideClient.value.selectGuides(storeState, filters);
     return selectedGuides?.[0] || null;
   };
 
@@ -173,17 +181,15 @@ export function useKnockGuides(knockClient: Ref<Knock | null>) {
 </Step>
 <Step title="Create the provider component.">
 
-The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. It also watches `knock.isReady` to handle cases where authentication completes after mount.
+The provider component initializes Knock, authenticates the user, and makes the guide client available to all child components via `provide`. An `isInitializingGuides` flag prevents the `knock.isReady` watcher from triggering a duplicate initialization while `onMounted` is already awaiting the first one.
 
 ```vue title="components/KnockProvider.vue"
 <template>
-  <div>
-    <slot />
-  </div>
+  <slot />
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, provide, watch } from "vue";
+import { onMounted, onUnmounted, provide, ref, watch } from "vue";
 import { useKnock } from "../composables/useKnock";
 import { useKnockGuides } from "../composables/useKnockGuides";
 
@@ -200,14 +206,32 @@ const knockGuides = useKnockGuides(knock.knockClient);
 provide("knockGuides", knockGuides);
 provide("knockChannelId", props.channelId);
 
+// Tracks whether guide initialization is in progress. This prevents the
+// knock.isReady watcher from triggering a second initializeGuideClient call
+// while onMounted is still awaiting the first one: authenticate() sets
+// isAuthenticated synchronously, which makes knock.isReady true and queues
+// the watcher before onMounted resumes after its await.
+const isInitializingGuides = ref(false);
+
+const initializeGuides = async (): Promise<void> => {
+  if (isInitializingGuides.value || knockGuides.isReady.value) return;
+
+  isInitializingGuides.value = true;
+  try {
+    await knockGuides.initializeGuideClient(props.channelId);
+    await knockGuides.fetchGuides();
+  } finally {
+    isInitializingGuides.value = false;
+  }
+};
+
 onMounted(async () => {
   try {
     await knock.initializeKnock(props.apiKey);
     await knock.authenticate(props.user);
 
     if (knock.knockClient.value) {
-      await knockGuides.initializeGuideClient(props.channelId);
-      await knockGuides.fetchGuides();
+      await initializeGuides();
     }
   } catch (error) {
     console.error("Failed to initialize Knock guides:", error);
@@ -215,14 +239,10 @@ onMounted(async () => {
 });
 
 // Re-initialize guides if the Knock client becomes ready after mount
+// (e.g. when authentication is handled asynchronously outside this component)
 watch(knock.isReady, async (isReady) => {
-  if (isReady && !knockGuides.isReady.value) {
-    try {
-      await knockGuides.initializeGuideClient(props.channelId);
-      await knockGuides.fetchGuides();
-    } catch (error) {
-      console.error("Failed to initialize guides after authentication:", error);
-    }
+  if (isReady) {
+    await initializeGuides();
   }
 });
 
@@ -334,11 +354,15 @@ With the composables in place, you can build components to render guides. This e
 
 ```vue title="components/GuideBanner.vue"
 <template>
-  <div v-if="shouldShowBanner" class="knock-guide-banner">
+  <div v-if="typedStep" class="knock-guide-banner">
     <div class="knock-guide-banner__message">
       <div class="knock-guide-banner__title">
         {{ typedStep?.content?.title }}
       </div>
+      <!-- v-html renders raw HTML from your Knock guide content. Guide content
+           is authored in your Knock dashboard, not by end users, so the XSS
+           risk is low — but sanitize with DOMPurify if that assumption doesn't
+           hold in your app. -->
       <div class="knock-guide-banner__body" v-html="typedStep?.content?.body" />
     </div>
 
@@ -379,7 +403,7 @@ With the composables in place, you can build components to render guides. This e
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch, inject } from "vue";
+import { computed, watch, inject } from "vue";
 import { useGuide } from "../composables/useGuide";
 
 interface ButtonContent {
@@ -402,10 +426,6 @@ const knockGuides = inject("knockGuides") as ReturnType<
 const { step } = useGuide(knockGuides, { type: "banner" });
 const typedStep = computed(() => step.value as GuideStep | null);
 
-const isMounted = ref(false);
-
-const shouldShowBanner = computed(() => typedStep.value && isMounted.value);
-
 const handleButtonClick = async (
   buttonType: string,
   button: ButtonContent,
@@ -426,10 +446,6 @@ const handleDismiss = async (): Promise<void> => {
     await typedStep.value.markAsArchived();
   }
 };
-
-onMounted(() => {
-  isMounted.value = true;
-});
 
 // Mark each guide as seen when it first appears; comparing old and new step avoids
 // calling markAsSeen again on unrelated reactive updates to the same step
@@ -456,7 +472,7 @@ See [debugging guides](/in-app-ui/guides/debugging-guides) for general troublesh
 | Issue                                                                                | Solution                                                                                                                                                                                               |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Guides are not appearing after authentication.                                       | Check that `knock.knockClient.value` exists before calling `initializeGuideClient`. The `watch` on `knock.isReady` in `KnockProvider.vue` handles cases where the client becomes ready asynchronously. |
-| The store subscription is not updating components.                                   | Confirm that `state.guideClient.store.subscribe` is being called after `initializeGuideClient`.                                                                                                        |
+| The store subscription is not updating components.                                   | Confirm that `guideClient.value.store.subscribe` is being called after `initializeGuideClient`.                                                                                                        |
 | [Guide activation rules](/in-app-ui/guides/create-guides#activation) aren't working. | Ensure `urlpattern-polyfill` is imported at the top of your app entry point before initializing Knock: `import "urlpattern-polyfill"`                                                                  |
 
 ## Related docs

--- a/data/sidebars/tutorialsSidebar.ts
+++ b/data/sidebars/tutorialsSidebar.ts
@@ -52,4 +52,8 @@ export const TUTORIALS_SIDEBAR: SidebarContent[] = [
     slug: `${baseSlug}/migrate-email-with-mcp-server`,
     title: "Email template migration",
   },
+  {
+    slug: `${baseSlug}/guides-in-vue`,
+    title: "Guides in Vue.js",
+  },
 ];


### PR DESCRIPTION
## KNO-12274: [Docs] Add guides in Vue tutorial

### Summary
- Adds a new "community-sourced" tutorial for implementing Knock guides in Vue.js, based on the existing Notion doc a few customers have used.
- Adds a "Guide identifiers" section to the rendering guides doc (channel ID, guide key, guide type)
- Adds in-app guide as a destination channel type in the integrations overview and channels concept pages

### Changes
- `content/tutorials/guides-in-vue.mdx` — new tutorial on implementing guides in Vue.js
- `data/sidebars/tutorialsSidebar.ts` — added sidebar entry for tutorial page
- `components/ui/Callout.tsx` — added `community_sourced` type with fixed title and body copy via `COMMUNITY_CONTENT` constant; idea is that this will always have the same copy every time it's used and we expect to use it again on other tutorials.
- `components/ui/CodeBlock.tsx` — registered `vue` as a syntax highlighting language (aliased to `xml`/hljs, which handles Vue SFC template syntax)
- `content/in-app-ui/guides/render-guides.mdx` — added "Guide identifiers" section explaining guide channel ID, guide key, and guide type based on some recent customer confusion
- `content/integrations/overview.mdx` — added in-app guide to the destination channels list
- `content/concepts/channels.mdx` — added in-app guide to the destination channels list


### Notes
- TypeScript types for guide steps are loosely typed (`unknown`) in places where the exact exported types from `@knocklabs/client` are unclear — we may want to change that.
- Follow-up ticket filed for rethinking in-app channel coverage in the integrations section: [KNO-12277](https://linear.app/knock/issue/KNO-12277)