### PR TITLE
fix(KNO-12548): Update link styling in Table cells

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -148,7 +148,19 @@ Below is a description of the columns included in the table and the data type of
           "combined_trigger_data",
           "json",
           <div key="combined_trigger_data_body">
-            Combined and truncated trigger data for the workflow run that generated the message, at the time the message was created. See the <a target="_blank" rel="noreferrer" href="/api-reference/overview/trigger-data-filtering">trigger data filtering documentation</a> for more info.
+            Combined and truncated trigger data for the workflow run that generated the message, at the time the message was created. See the{" "}
+            <a
+              href="/api-reference/overview/trigger-data-filtering"
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                color: "var(--tgph-accent-11)",
+                textDecoration: "underline",
+              }}
+            >
+              trigger data filtering documentation
+            </a>{" "}
+            for more info.
           </div>
         ],
         [
@@ -163,9 +175,13 @@ Below is a description of the columns included in the table and the data type of
           <div key="recipient_type_body">
             The{" "}
             <a
+              href="/concepts/recipients"
               target="_blank"
               rel="noreferrer"
-              href="/concepts/recipients"
+              style={{
+                color: "var(--tgph-accent-11)",
+                textDecoration: "underline",
+              }}
             >
               type of recipient for the message
             </a>
@@ -203,12 +219,17 @@ Below is a description of the columns included in the table and the data type of
           <div key="message_status_body">
             The latest{" "}
             <a
+              href="/send-notifications/message-statuses#delivery-status"
               target="_blank"
               rel="noreferrer"
-              href="/send-notifications/message-statuses#delivery-status"
+              style={{
+                color: "var(--tgph-accent-11)",
+                textDecoration: "underline",
+              }}
             >
               delivery status of a message
-            </a>.
+            </a>
+            .
           </div>,
         ],
         [
@@ -267,7 +288,19 @@ Below is a description of the columns included in the table and the data type of
           "actors",
           "json",
           <div key="actors">
-            A JSON array of actor users or objects. Users are provided as string IDs. Objects are provided as JSON dictionaries with keys for "id" and "collection". See the <a target="_blank" rel="noreferrer" href="/concepts/recipients#recipientidentifier-definition"><code>RecipientIdentifier</code> definition</a> for more info.
+            A JSON array of actor users or objects. Users are provided as string IDs. Objects are provided as JSON dictionaries with keys for "id" and "collection". See the{" "}
+            <a
+              href="/concepts/recipients#recipientidentifier-definition"
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                color: "var(--tgph-accent-11)",
+                textDecoration: "underline",
+              }}
+            >
+              <code>RecipientIdentifier</code> definition
+            </a>{" "}
+            for more info.
           </div>
         ],
         [
@@ -344,7 +377,18 @@ Below is a description of the columns included in the table and the data type of
         ["recipient_id", "string", "The ID of the recipient for the message"],
         ["recipient_type", "string",
             <div key="recipient_type_body">
-              The <a target="_blank" rel="noreferrer" href="/concepts/recipients"> type of recipient recorded</a>
+              The{" "}
+              <a
+                href="/concepts/recipients"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  color: "var(--tgph-accent-11)",
+                  textDecoration: "underline",
+                }}
+              >
+                type of recipient recorded
+              </a>
             </div>,
         ],
         ["event_type", "string",

--- a/content/template-editor/reference-liquid-helpers.mdx
+++ b/content/template-editor/reference-liquid-helpers.mdx
@@ -63,9 +63,19 @@ The Knock template editor uses Liquid syntax for control flow and variable decla
           IANA tz database timezone
         </a>{" "}
         provided. You can use the built-in <code>timestamp</code>{" "}
-        <a href="/template-editor/variables">template variable</a> to reference
-        the current datetime. When formatting with the <code>date</code> filter,
-        we recommend using the <code>timezone</code>
+        <a
+          href="/template-editor/variables"
+          target="_blank"
+          rel="noreferrer"
+          style={{
+            color: "var(--tgph-accent-11)",
+            textDecoration: "underline",
+          }}
+        >
+          template variable
+        </a>{" "}
+        to reference the current datetime. When formatting with the{" "}
+        <code>date</code> filter, we recommend using the <code>timezone</code>
         option on the <code>date</code> filter instead.
       </div>,
       '{{ timestamp | timezone: "America/New_York"}}',
@@ -91,8 +101,15 @@ The Knock template editor uses Liquid syntax for control flow and variable decla
         <code>date_format</code>: <code>"short"</code>
         (default), <code>"medium"</code>, <code>"long"</code>, or <code>
           "full"
-        </code>. See the <a href="#date-format-options">date format options</a> table
-        below for examples.
+        </code>. See the <a
+          href="#date-format-options"
+          style={{
+            color: "var(--tgph-accent-11)",
+            textDecoration: "underline",
+          }}
+        >
+          date format options
+        </a> table below for examples.
       </div>,
       '{{ timestamp | format_date_in_locale: "en-GB", "long" }}',
       "31 December 2023",
@@ -105,10 +122,23 @@ The Knock template editor uses Liquid syntax for control flow and variable decla
         <code>time_format</code> parameters. Date and time formats can be:{" "}
         <code>"short"</code> (default), <code>"medium"</code>,{" "}
         <code>"long"</code>, or
-        <code>"full"</code>. See the <a href="#date-format-options">
+        <code>"full"</code>. See the <a
+          href="#date-format-options"
+          style={{
+            color: "var(--tgph-accent-11)",
+            textDecoration: "underline",
+          }}
+        >
           date format options
-        </a> and <a href="#time-format-options">time format options</a> tables below
-        for examples.
+        </a> and <a
+          href="#time-format-options"
+          style={{
+            color: "var(--tgph-accent-11)",
+            textDecoration: "underline",
+          }}
+        >
+          time format options
+        </a> tables below for examples.
       </div>,
       '{{ timestamp | format_datetime_in_locale: "en-GB", "medium", "short" }}',
       "31 Dec 2023, 14:30",


### PR DESCRIPTION
### Description

This updates links in `Table` cells so that styling is applied to make it clear to users that they are links. In my review, it looks like we just needed to update `content/integrations/extensions/data-sync.mdx` (both [messages](https://docs-git-rt-kno-12548-update-table-links-knocklabs.vercel.app/integrations/extensions/data-sync#messages-table) and [recipient changes](https://docs-git-rt-kno-12548-update-table-links-knocklabs.vercel.app/integrations/extensions/data-sync#recipient-change-stream-table) tables) and `content/template-editor/reference-liquid-helpers.mdx` ([link](https://docs-git-rt-kno-12548-update-table-links-knocklabs.vercel.app/designing-workflows/template-editor/reference-liquid-helpers#knock-specific-liquid-helpers))


### Tasks

[KNO-12548](https://linear.app/knock/issue/KNO-12548/docs-fix-link-visibility-in-table-rows)

### Screenshots

Before:
<img width="750" height="1070" alt="Screenshot 2026-04-09 at 12 41 35 PM" src="https://github.com/user-attachments/assets/141a31db-1d61-4584-affc-702682be9ed7" />

After:
<img width="742" height="1060" alt="Screenshot 2026-04-09 at 12 41 17 PM" src="https://github.com/user-attachments/assets/1db6bcf9-1c58-4bf8-a5c4-f53530f138af" />
