### PR TITLE
feat(KNO-7916): Add support for linking to Accordion components

### DIFF
--- a/components/ui/Accordion.tsx
+++ b/components/ui/Accordion.tsx
@@ -31,8 +31,8 @@ type AccordionProps = {
   title: string;
   description?: string;
   defaultOpen?: boolean;
-  /** When set, this value is used as the element `id` and the accordion opens if the URL hash matches (for deep links). */
-  anchorId?: string;
+  /** When set, this slug is used as the element `id` and the accordion opens if the URL hash matches (for deep links). Use a URL-safe hyphenated fragment, e.g. `my-section`. */
+  anchorSlug?: string;
 };
 
 // Helper function to parse title and split into text and code parts
@@ -81,25 +81,25 @@ const Accordion = ({
   title,
   description,
   defaultOpen = false,
-  anchorId,
+  anchorSlug,
 }: AccordionProps) => {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   const titleParts = useMemo(() => parseTitleWithCode(title), [title]);
 
   useLayoutEffect(() => {
-    if (!anchorId) return;
+    if (!anchorSlug) return;
     const syncFromHash = () => {
-      if (getHashFragment() === anchorId) {
+      if (getHashFragment() === anchorSlug) {
         setOpen(true);
       }
     };
     syncFromHash();
     window.addEventListener("hashchange", syncFromHash);
     return () => window.removeEventListener("hashchange", syncFromHash);
-  }, [anchorId]);
+  }, [anchorSlug]);
 
   return (
-    <Box role="listitem" id={anchorId}>
+    <Box role="listitem" id={anchorSlug}>
       <MenuItem
         as="button"
         onClick={() => setOpen(!open)}

--- a/components/ui/Accordion.tsx
+++ b/components/ui/Accordion.tsx
@@ -2,7 +2,7 @@ import { Box, Stack } from "@telegraph/layout";
 import { MenuItem } from "@telegraph/menu";
 import { Icon } from "@telegraph/icon";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useLayoutEffect } from "react";
 import { Text, Code } from "@telegraph/typography";
 import { ChevronRight } from "lucide-react";
 
@@ -15,11 +15,24 @@ const AccordionGroup = ({ children }) => (
   </div>
 );
 
+function getHashFragment(): string {
+  if (typeof window === "undefined") return "";
+  const { hash } = window.location;
+  if (!hash || hash === "#") return "";
+  try {
+    return decodeURIComponent(hash.slice(1));
+  } catch {
+    return hash.slice(1);
+  }
+}
+
 type AccordionProps = {
   children: React.ReactNode;
   title: string;
   description?: string;
   defaultOpen?: boolean;
+  /** When set, this value is used as the element `id` and the accordion opens if the URL hash matches (for deep links). */
+  anchorId?: string;
 };
 
 // Helper function to parse title and split into text and code parts
@@ -68,12 +81,25 @@ const Accordion = ({
   title,
   description,
   defaultOpen = false,
+  anchorId,
 }: AccordionProps) => {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   const titleParts = useMemo(() => parseTitleWithCode(title), [title]);
 
+  useLayoutEffect(() => {
+    if (!anchorId) return;
+    const syncFromHash = () => {
+      if (getHashFragment() === anchorId) {
+        setOpen(true);
+      }
+    };
+    syncFromHash();
+    window.addEventListener("hashchange", syncFromHash);
+    return () => window.removeEventListener("hashchange", syncFromHash);
+  }, [anchorId]);
+
   return (
-    <Box role="listitem">
+    <Box role="listitem" id={anchorId}>
       <MenuItem
         as="button"
         onClick={() => setOpen(!open)}

--- a/components/ui/Accordion.tsx
+++ b/components/ui/Accordion.tsx
@@ -94,26 +94,12 @@ const Accordion = ({
     let resizeObserver: ResizeObserver | null = null;
     let stopWatchingTimeoutId: number | null = null;
 
-    const log = (label: string, extra?: Record<string, unknown>) => {
-      // eslint-disable-next-line no-console
-      console.log(`[Accordion:${anchorSlug}] ${label}`, {
-        time: performance.now().toFixed(1),
-        scrollY: window.scrollY,
-        elementTop: elementRef.current?.getBoundingClientRect().top,
-        bodyHeight: document.body.scrollHeight,
-        ...extra,
-      });
-    };
-
-    const performScroll = (source: string) => {
+    const performScroll = () => {
       if (cancelled) return;
-      const el = elementRef.current;
-      if (!el) return;
-      el.scrollIntoView({
+      elementRef.current?.scrollIntoView({
         block: "start",
-        behavior: "instant" as ScrollBehavior,
+        behavior: "smooth",
       });
-      log(`scroll:${source}`);
     };
 
     const stopWatching = () => {
@@ -127,14 +113,10 @@ const Accordion = ({
       }
     };
 
-    const syncFromHash = (source: string) => {
-      log(`syncFromHash:${source}`);
+    const syncFromHash = () => {
       if (getHashFragment() !== anchorSlug) return;
       setOpen(true);
-
-      // Scroll immediately so the user goes directly from the previous page to
-      // the correct position. This runs in useLayoutEffect, before paint.
-      performScroll("immediate");
+      performScroll();
 
       // Re-scroll whenever layout shifts (images loading, async content, etc.)
       // so the accordion stays anchored to its intended position even as the
@@ -142,7 +124,7 @@ const Accordion = ({
       stopWatching();
       if (typeof ResizeObserver !== "undefined") {
         resizeObserver = new ResizeObserver(() => {
-          performScroll("resize");
+          performScroll();
         });
         resizeObserver.observe(document.body);
       }
@@ -151,13 +133,12 @@ const Accordion = ({
       stopWatchingTimeoutId = window.setTimeout(stopWatching, 1500);
     };
 
-    syncFromHash("mount");
-    const handler = () => syncFromHash("hashchange");
-    window.addEventListener("hashchange", handler);
+    syncFromHash();
+    window.addEventListener("hashchange", syncFromHash);
     return () => {
       cancelled = true;
       stopWatching();
-      window.removeEventListener("hashchange", handler);
+      window.removeEventListener("hashchange", syncFromHash);
     };
   }, [anchorSlug]);
 

--- a/components/ui/Accordion.tsx
+++ b/components/ui/Accordion.tsx
@@ -2,7 +2,7 @@ import { Box, Stack } from "@telegraph/layout";
 import { MenuItem } from "@telegraph/menu";
 import { Icon } from "@telegraph/icon";
 import { AnimatePresence, motion } from "framer-motion";
-import { useState, useMemo, useLayoutEffect } from "react";
+import { useState, useMemo, useLayoutEffect, useRef } from "react";
 import { Text, Code } from "@telegraph/typography";
 import { ChevronRight } from "lucide-react";
 
@@ -85,21 +85,84 @@ const Accordion = ({
 }: AccordionProps) => {
   const [open, setOpen] = useState<boolean>(defaultOpen);
   const titleParts = useMemo(() => parseTitleWithCode(title), [title]);
+  const elementRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
     if (!anchorSlug) return;
-    const syncFromHash = () => {
-      if (getHashFragment() === anchorSlug) {
-        setOpen(true);
+
+    let cancelled = false;
+    let resizeObserver: ResizeObserver | null = null;
+    let stopWatchingTimeoutId: number | null = null;
+
+    const log = (label: string, extra?: Record<string, unknown>) => {
+      // eslint-disable-next-line no-console
+      console.log(`[Accordion:${anchorSlug}] ${label}`, {
+        time: performance.now().toFixed(1),
+        scrollY: window.scrollY,
+        elementTop: elementRef.current?.getBoundingClientRect().top,
+        bodyHeight: document.body.scrollHeight,
+        ...extra,
+      });
+    };
+
+    const performScroll = (source: string) => {
+      if (cancelled) return;
+      const el = elementRef.current;
+      if (!el) return;
+      el.scrollIntoView({
+        block: "start",
+        behavior: "instant" as ScrollBehavior,
+      });
+      log(`scroll:${source}`);
+    };
+
+    const stopWatching = () => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+      if (stopWatchingTimeoutId !== null) {
+        clearTimeout(stopWatchingTimeoutId);
+        stopWatchingTimeoutId = null;
       }
     };
-    syncFromHash();
-    window.addEventListener("hashchange", syncFromHash);
-    return () => window.removeEventListener("hashchange", syncFromHash);
+
+    const syncFromHash = (source: string) => {
+      log(`syncFromHash:${source}`);
+      if (getHashFragment() !== anchorSlug) return;
+      setOpen(true);
+
+      // Scroll immediately so the user goes directly from the previous page to
+      // the correct position. This runs in useLayoutEffect, before paint.
+      performScroll("immediate");
+
+      // Re-scroll whenever layout shifts (images loading, async content, etc.)
+      // so the accordion stays anchored to its intended position even as the
+      // document height changes.
+      stopWatching();
+      if (typeof ResizeObserver !== "undefined") {
+        resizeObserver = new ResizeObserver(() => {
+          performScroll("resize");
+        });
+        resizeObserver.observe(document.body);
+      }
+      // Stop correcting after layout has had time to settle so we don't
+      // fight subsequent user-initiated scrolls.
+      stopWatchingTimeoutId = window.setTimeout(stopWatching, 1500);
+    };
+
+    syncFromHash("mount");
+    const handler = () => syncFromHash("hashchange");
+    window.addEventListener("hashchange", handler);
+    return () => {
+      cancelled = true;
+      stopWatching();
+      window.removeEventListener("hashchange", handler);
+    };
   }, [anchorSlug]);
 
   return (
-    <Box role="listitem" id={anchorSlug}>
+    <Box tgphRef={elementRef} role="listitem" id={anchorSlug}>
       <MenuItem
         as="button"
         onClick={() => setOpen(!open)}

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -163,7 +163,7 @@ To use TeamsKit, you'll need to configure the API permissions and OAuth redirect
 
 ## How to set channel data for a Microsoft Teams integration in Knock
 
-In Knock, the [`ChannelData`](/managing-recipients/setting-channel-data) concept provides you a way of storing recipient-specific connection data for a given integration. If you reference the [channel data requirements for Microsoft Teams](/managing-recipients/setting-channel-data#chat-app-channels), you'll see that there are two different schemas for an `MsTeamsConnection` stored on a [`User`](/concepts/users) or an [`Object`](/concepts/objects) in Knock.
+In Knock, the [`ChannelData`](/managing-recipients/setting-channel-data) concept provides you a way of storing recipient-specific connection data for a given integration. If you reference the [channel data requirements for Microsoft Teams](/managing-recipients/setting-channel-data#microsoft-teams-channel-data), you'll see that there are two different schemas for an `MsTeamsConnection` stored on a [`User`](/concepts/users) or an [`Object`](/concepts/objects) in Knock.
 
 Here's an example of setting channel data on an `Object` in Knock.
 

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -241,7 +241,7 @@ The `PushDevice` object is used to optionally set device-level metadata for a pu
     | incoming_webhook.url | `string` | The Discord incoming webhook URL (to be used instead of the properties above) |
 
   </Accordion>
-  <Accordion title ="Microsoft Teams" anchorId="microsoft-teams-channel-data">
+  <Accordion title ="Microsoft Teams" anchorSlug="microsoft-teams-channel-data">
     | Property    | Type                  | Description                        |
     | ----------- | --------------------- | ---------------------------------- |
     | connections | `MsTeamsConnection[]` | One or more connections to MsTeams |

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -241,7 +241,7 @@ The `PushDevice` object is used to optionally set device-level metadata for a pu
     | incoming_webhook.url | `string` | The Discord incoming webhook URL (to be used instead of the properties above) |
 
   </Accordion>
-  <Accordion title ="Microsoft Teams">
+  <Accordion title ="Microsoft Teams" anchorId="microsoft-teams-channel-data">
     | Property    | Type                  | Description                        |
     | ----------- | --------------------- | ---------------------------------- |
     | connections | `MsTeamsConnection[]` | One or more connections to MsTeams |

--- a/content/multi-tenancy/per-tenant-preferences.mdx
+++ b/content/multi-tenancy/per-tenant-preferences.mdx
@@ -170,11 +170,11 @@ The Knock workflow engine uses that `tenant` parameter to evaluate the user's `P
 
 ## Tenant preference evaluation rules
 
-Here are a few things to keep in mind when using tenant preferences. You can learn more about how preferences are merged and evaluated [here](/preferences/overview#merging-preferences).
+Here are a few things to keep in mind when using tenant preferences. You can learn more about how preferences are merged and evaluated [here](/preferences/overview#tenant-specific-preference-merge-hierarchy).
 
 - When executing a workflow trigger, passing in a `tenant` will automatically load that tenant's default `PreferenceSet` (if one exists) for all recipients of the workflow. These tenant-level defaults will override a recipient's own `default` preferences.
 - If the recipient has any per-tenant preferences set for that `tenant.id`, they will take precedence over the tenant-level default preferences. For more information on how to override a recipient's per-tenant preferences to respect the tenant-level default preferences, see the [frequently asked questions](#frequently-asked-questions) below.
-- If there is no default `PreferenceSet` on the tenant AND the recipient has no per-tenant preferences set, the recipient's `default` preferences will be used. As always, the recipient's `default` preferences are [merged](/preferences/overview#merging-preferences) with the environment-level preference defaults.
+- If there is no default `PreferenceSet` on the tenant AND the recipient has no per-tenant preferences set, the recipient's `default` preferences will be used. As always, the recipient's `default` preferences are [merged](/preferences/overview#tenant-specific-preference-merge-hierarchy) with the environment-level preference defaults.
 
 ## Frequently asked questions
 

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -281,7 +281,7 @@ The following hierarchies are used when merging preferences.
     The environment-level setting to opt all users into `collaboration` notifications will be respected because the recipient doesn't have an explicit preference for that category, but the recipient's preference to specifically opt in to SMS messages will override the environment-level setting to opt out.
 
   </Accordion>
-  <Accordion title="Tenant-specific preference merge hierarchy">
+  <Accordion title="Tenant-specific preference merge hierarchy" anchorSlug="tenant-specific-preference-merge-hierarchy">
     The following hierarchy is used to merge preferences when a `tenant` is applied to the workflow trigger. Each item in the list takes precedence over the ones that follow it:
     
     1. A recipient's [tenant-specific preference](/multi-tenancy/per-tenant-preferences) set

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/styles/index.css
+++ b/styles/index.css
@@ -102,9 +102,9 @@ textarea:not([rows]) {
   min-height: 10em;
 }
 
-/* Anything that has been anchored to should have extra scroll margin */
+/* Anything anchored to via #hash should clear the sticky page header */
 :target {
-  scroll-margin-block: 5ex;
+  scroll-margin-top: calc(var(--header-height) + 1rem);
 }
 
 .dot-bg {


### PR DESCRIPTION
### Description

Our docs rely heavily on the `Accordion` component to collapse content for better scannability. Currently, when we need to link to a specific accordion (rather than just the nearest heading), we can't - we can only link to a section. In pages with lots of accordions, like [Setting Channel Data](https://docs.knock.app/managing-recipients/setting-channel-data), this means users land on the right section but still have to hunt for the right accordion themselves.

For example, in the [MS Teams overview](https://docs.knock.app/integrations/chat/microsoft-teams/overview#how-to-set-channel-data-for-a-microsoft-teams-integration-in-knock), we link to the channel data docs for MS Teams-specific requirements but we can't deep-link directly to that accordion, so users have to find it manually.

**What this PR does**
Adds an optional `anchorId` prop to the `Accordion` component. When set, it assigns that value as the wrapper's DOM id and automatically opens the accordion on page load if the URL hash matches. Note that this is **optional** and accordions without `anchorId` should behave exactly as before (so there's no requirement to add it everywhere). Also, each `anchorId` must be unique within a page, but the same value can be reused across pages.

In this PR, I've **only** added `anchorId` to the specific example described above.

**Open questions for the team**

1. Should we do a broader audit to add `anchorId` across the docs, or just add them as we notice they'd be useful? My take is that we don't need it on every accordion but rather only where we have a stable deep link that should open a specific one. If an accordion is unlikely to be linked to directly, a heading anchor is probably enough. But open to other opinions!
2. Does the approach I've taken with `Accordion` make the most sense? I'm very open to other opinions here as well!

### Tasks

[KNO-7916](https://linear.app/knock/issue/KNO-7916/docs-support-deep-links-that-open-a-specific-accordion)

### Recordings

Current behavior
<video src="https://github.com/user-attachments/assets/ded1c809-89c3-48ca-8604-9f3acce18f44" controls width="600"></video>

New behavior
https://docs-git-rt-kno-7916-linking-to-accordions-knocklabs.vercel.app/integrations/chat/microsoft-teams/overview#how-to-set-channel-data-for-a-microsoft-teams-integration-in-knock
<video src="https://github.com/user-attachments/assets/648af771-22b2-41f5-9643-2c1807298231" controls width="600"></video>


