### PR TITLE
chore(KNO-12588): Add information about test run trigger frequency behavior

### DIFF
--- a/content/send-notifications/debugging-workflows.mdx
+++ b/content/send-notifications/debugging-workflows.mdx
@@ -63,6 +63,27 @@ You can also access it from our "Logs" page, which you'll find in the left-hand 
 
 When a workflow runs, each step is executed in sequence. Sometimes an individual step is skipped or encounters an error, and it's important to understand how this affects the workflow run as a whole.
 
+<Callout
+  type="info"
+  title="Note:"
+  text={
+    <>
+      If you're reviewing a{" "}
+      <a href="/send-notifications/testing-workflows">test run</a>, keep in mind
+      that some workflow settings are not enforced by the dashboard test runner.{" "}
+      <a href="/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency">
+        Trigger frequency
+      </a>{" "}
+      (for example, {'"'}once per recipient{'"'}) is bypassed during test runs,
+      so the workflow will execute for the selected recipient each time
+      regardless of your frequency setting. This is expected behavior. To
+      validate trigger frequency as it works in production, trigger the workflow
+      using the <a href="/send-notifications/triggering-workflows/api">API</a>{" "}
+      directly.
+    </>
+  }
+/>
+
 ### When a workflow step is skipped
 
 There are several controlled scenarios where a step is skipped and the workflow run continues to execute subsequent steps.

--- a/content/send-notifications/debugging-workflows.mdx
+++ b/content/send-notifications/debugging-workflows.mdx
@@ -70,16 +70,16 @@ When a workflow runs, each step is executed in sequence. Sometimes an individual
     <>
       If you're reviewing a{" "}
       <a href="/send-notifications/testing-workflows">test run</a>, keep in mind
-      that some workflow settings are not enforced by the dashboard test runner.{" "}
+      that{" "}
       <a href="/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency">
-        Trigger frequency
+        trigger frequency
       </a>{" "}
-      (for example, {'"'}once per recipient{'"'}) is bypassed during test runs,
-      so the workflow will execute for the selected recipient each time
-      regardless of your frequency setting. This is expected behavior. To
-      validate trigger frequency as it works in production, trigger the workflow
-      using the <a href="/send-notifications/triggering-workflows/api">API</a>{" "}
-      directly.
+      is not enforced by the dashboard test runner. Settings like {'"'}once per
+      recipient{'"'} are bypassed during test runs, so the workflow will execute
+      for the selected recipient each time regardless of your frequency setting.
+      This is expected behavior. To validate trigger frequency as it works in
+      production, trigger the workflow using the{" "}
+      <a href="/send-notifications/triggering-workflows/api">API</a> directly.
     </>
   }
 />

--- a/content/send-notifications/testing-workflows.mdx
+++ b/content/send-notifications/testing-workflows.mdx
@@ -18,7 +18,9 @@ Two things to know about workflow test configuration:
 - The data field is populated using the workflow's schema as defined in your templates. You can click "Reset" at any time to reset the data field to the latest and greatest schema for your workflow.
 - The recipient and actor fields can contain either a [user](/concepts/users) or an [object](/concepts/objects). Use the toggle above the field to switch between these options.
 
-When you run a test workflow, every step of the workflow will execute as it normally would. You'll see an affordance to "View log" when the workflow runs to see its output and what was sent. You can learn more about Knock logs and our debugger [here](/send-notifications/debugging-workflows).
+After clicking "Run test," you will see a confirmation and a link to see the log to review the output and what was sent. You can learn more about Knock logs and the debugger [here](/send-notifications/debugging-workflows).
+
+Note that some workflow settings are not enforced during test runs. [Trigger frequency](/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency) (for example, "once per recipient") is bypassed — each time you run a test, the workflow will execute for the selected recipient regardless of your frequency setting. To validate trigger frequency as it behaves in production, use the [trigger API](/send-notifications/triggering-workflows/api).
 
 You can also use the workflow test runner to run a test payload for a [source event trigger](/integrations/sources/overview#workflow-triggers). If your workflow is triggered by an event, you will automatically see a JSON payload of the last received event that you can use to run a test. You can edit this payload or click "Fetch the latest event" to get the most recent from your source.
 

--- a/content/send-notifications/testing-workflows.mdx
+++ b/content/send-notifications/testing-workflows.mdx
@@ -20,7 +20,7 @@ Two things to know about workflow test configuration:
 
 After clicking "Run test," you will see a confirmation and a link to see the log to review the output and what was sent. You can learn more about Knock logs and the debugger [here](/send-notifications/debugging-workflows).
 
-Note that some workflow settings are not enforced during test runs. [Trigger frequency](/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency) (for example, "once per recipient") is bypassed — each time you run a test, the workflow will execute for the selected recipient regardless of your frequency setting. To validate trigger frequency as it behaves in production, use the [trigger API](/send-notifications/triggering-workflows/api).
+Note that [trigger frequency](/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency) is not enforced during test runs. Settings like "once per recipient" are bypassed — each time you run a test, the workflow will execute for the selected recipient regardless of your frequency setting. To validate trigger frequency as it behaves in production, use the [trigger API](/send-notifications/triggering-workflows/api).
 
 You can also use the workflow test runner to run a test payload for a [source event trigger](/integrations/sources/overview#workflow-triggers). If your workflow is triggered by an event, you will automatically see a JSON payload of the last received event that you can use to run a test. You can edit this payload or click "Fetch the latest event" to get the most recent from your source.
 

--- a/content/send-notifications/triggering-workflows/overview.mdx
+++ b/content/send-notifications/triggering-workflows/overview.mdx
@@ -46,4 +46,15 @@ When you specify "Once per recipient" frequency, you can include the tenant in t
     [error](/api-reference/overview/errors) when triggered and will not generate
     any workflow recipient runs.
   </Accordion>
+  <Accordion title="Is trigger frequency enforced during test runs?">
+    No. [Trigger
+    frequency](/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency)
+    is not enforced by the [workflow test
+    runner](/send-notifications/testing-workflows). Settings like "once per
+    recipient" are bypassed — the workflow will execute for the selected
+    recipient every time you run a test, regardless of your frequency setting.
+    This is expected behavior. To test trigger frequency as it works in
+    production, trigger the workflow via the [trigger
+    API](/send-notifications/triggering-workflows/api) directly.
+  </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

Adds information to the docs (testing workflows and debugging workflow pages) to clarify that trigger frequency settings are not enforced during test runs. 

https://docs-git-rt-kno-12588-trigger-frequency-callout-knocklabs.vercel.app/send-notifications/testing-workflows#the-workflow-test-runner

https://docs-git-rt-kno-12588-trigger-frequency-callout-knocklabs.vercel.app/send-notifications/debugging-workflows#understanding-workflow-execution-behavior

### Tasks

[KNO-12588](https://linear.app/knock/issue/KNO-12588/docs-add-callout-to-testing-workflows-page-clarifying-that-trigger)