### PR TITLE
chore(kno-12665): update MJML documentation to reflect ending tag behavior

### DIFF
--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -72,9 +72,9 @@ This behavior applies whether the HTML is provided directly in the template cont
   text={
     <>
       HTML partials cannot include MJML. Partials must be HTML. When an HTML
-      partial is used inside an MJML template outside of an ending tag, Knock wraps the partial's content
-      in <code>&lt;mjml-raw&gt;</code> tags so it renders correctly within the
-      MJML document.
+      partial is used inside an MJML template outside of an ending tag, Knock
+      wraps the partial's content in <code>&lt;mjml-raw&gt;</code> tags so it
+      renders correctly within the MJML document.
     </>
   }
 />

--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -45,7 +45,26 @@ When you use an MJML template with a layout, the layout must also be MJML. When 
 
 ## Mixing HTML and MJML
 
-Knock automatically wraps plain HTML inside MJML templates and layouts in `<mjml-raw>` tags. This means you can include HTML snippets in your MJML and they will render correctly.
+Knock automatically wraps plain HTML inside MJML templates and layouts in `<mjml-raw>` tags when the HTML appears at the `<mj-body>`, section, or column level. This means you can include HTML snippets in your MJML and they will render correctly.
+
+### Ending tags
+
+Knock skips this auto-wrapping when the parent element is an MJML <a href="https://documentation.mjml.io/#ending-tags" target="_blank" rel="noopener">ending tag</a>. Ending tags are MJML components that expect plain HTML as their direct children by spec, so wrapping their contents in `<mjml-raw>` would break template rendering.
+
+The following MJML ending tags do not have their HTML children wrapped:
+
+- `<mj-accordion-text>`
+- `<mj-accordion-title>`
+- `<mj-button>`
+- `<mj-navbar-link>`
+- `<mj-preview>`
+- `<mj-social-element>`
+- `<mj-style>`
+- `<mj-table>`
+- `<mj-text>`
+- `<mj-title>`
+
+This behavior applies whether the HTML is provided directly in the template content or as an [HTML partial](/template-editor/partials/html-partials).
 
 <Callout
   emoji="🌠"
@@ -53,7 +72,7 @@ Knock automatically wraps plain HTML inside MJML templates and layouts in `<mjml
   text={
     <>
       HTML partials cannot include MJML. Partials must be HTML. When an HTML
-      partial is used inside an MJML template, Knock wraps the partial's content
+      partial is used inside an MJML template outside of an ending tag, Knock wraps the partial's content
       in <code>&lt;mjml-raw&gt;</code> tags so it renders correctly within the
       MJML document.
     </>

--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -64,7 +64,6 @@ The following MJML tags do not have their HTML children wrapped:
 - `<mj-text>`
 - `<mj-title>`
 
-
 <Callout
   emoji="🌠"
   title="Note:"

--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -45,13 +45,13 @@ When you use an MJML template with a layout, the layout must also be MJML. When 
 
 ## Mixing HTML and MJML
 
-Knock automatically wraps plain HTML inside MJML templates and layouts in `<mjml-raw>` tags when the HTML appears at the `<mj-body>`, section, or column level. This means you can include HTML snippets in your MJML and they will render correctly.
+Knock automatically wraps plain HTML inside MJML templates and layouts in `<mjml-raw>` tags when the HTML appears at the `<mj-body>`, `<mj-section>`, or `<mj-column>` level. This means you can include HTML snippets in your MJML templates and they will render correctly.
 
 ### Ending tags
 
-Knock skips this auto-wrapping when the parent element is an MJML <a href="https://documentation.mjml.io/#ending-tags" target="_blank" rel="noopener">ending tag</a>. Ending tags are MJML components that expect plain HTML as their direct children by spec, so wrapping their contents in `<mjml-raw>` would break template rendering.
+Knock skips auto-wrapping of HTML when the parent element is an MJML <a href="https://documentation.mjml.io/#ending-tags" target="_blank" rel="noopener">ending tag</a>. Ending tags are MJML components that expect plain HTML or text content as their direct children by spec.
 
-The following MJML ending tags do not have their HTML children wrapped:
+The following MJML tags do not have their HTML children wrapped:
 
 - `<mj-accordion-text>`
 - `<mj-accordion-title>`
@@ -64,17 +64,16 @@ The following MJML ending tags do not have their HTML children wrapped:
 - `<mj-text>`
 - `<mj-title>`
 
-This behavior applies whether the HTML is provided directly in the template content or as an [HTML partial](/template-editor/partials/html-partials).
 
 <Callout
   emoji="🌠"
   title="Note:"
   text={
     <>
-      HTML partials cannot include MJML. Partials must be HTML. When an HTML
-      partial is used inside an MJML template outside of an ending tag, Knock
-      wraps the partial's content in <code>&lt;mjml-raw&gt;</code> tags so it
-      renders correctly within the MJML document.
+      HTML partials cannot include MJML. When an HTML partial is used in an MJML
+      template and is not rendered as a direct child of an MJML ending tag,
+      Knock wraps the partial's content in <code>&lt;mjml-raw&gt;</code> tags so
+      that it renders correctly within the MJML document.
     </>
   }
 />
@@ -82,4 +81,4 @@ This behavior applies whether the HTML is provided directly in the template cont
 ## Limitations
 
 - **MJML layouts require the `<mjml>` root tag.** Layouts set to MJML mode must be valid MJML documents.
-- **HTML partials cannot include MJML.** [HTML partials](/template-editor/partials/html-partials) must contain HTML only. When used in an MJML template, their content is wrapped in `<mjml-raw>` automatically.
+- **Partials cannot include MJML.** [HTML partials](/template-editor/partials/html-partials) must contain HTML only. When used in an MJML template, their content is automatically wrapped in `<mjml-raw>` tags where appropriate.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR updates the MJML documentation to reflect the corrected ending tag behavior.

**Changes:**
- Clarified that Knock auto-wraps plain HTML in `<mjml-raw>` tags when the HTML appears at the `<mj-body>`, section, or column level
- Added a new "Ending tags" subsection explaining that auto-wrapping is skipped when the parent element is an MJML ending tag
- Listed all 10 MJML ending tags where wrapping is skipped: `<mj-accordion-text>`, `<mj-accordion-title>`, `<mj-button>`, `<mj-navbar-link>`, `<mj-preview>`, `<mj-social-element>`, `<mj-style>`, `<mj-table>`, `<mj-text>`, `<mj-title>`
- Added a link to the MJML ending tags specification
- Updated the callout note to clarify behavior for HTML partials outside ending tags

### Screenshots

Updated "Mixing HTML and MJML" section with new "Ending tags" subsection:

[MJML ending tags section in documentation](https://cursor.com/agents/bc-f679e205-34bf-4361-91b8-86fac5417640/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmjml_ending_tags_section.webp)

Link to MJML ending tags specification works correctly:

[MJML ending tags specification page](https://cursor.com/agents/bc-f679e205-34bf-4361-91b8-86fac5417640/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmjml_ending_tags_spec_link.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-12665](https://linear.app/knock/issue/KNO-12665/docs-update-mjml-documentation-to-reflect-ending-tag-behavior)

<div><a href="https://cursor.com/agents/bc-f679e205-34bf-4361-91b8-86fac5417640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f679e205-34bf-4361-91b8-86fac5417640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

