### PR TITLE
chore: document execution order for action mappings

### DIFF
--- a/content/integrations/sources/clerk.mdx
+++ b/content/integrations/sources/clerk.mdx
@@ -109,6 +109,8 @@ See the <a href="https://clerk.com/docs/guides/development/webhooks/overview#sup
 
 You can modify the default action mappings or add new ones for any event type Knock receives from Clerk. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
+If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
+
 If you need to map Clerk events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
 
 ## Event idempotency

--- a/content/integrations/sources/custom.mdx
+++ b/content/integrations/sources/custom.mdx
@@ -161,18 +161,17 @@ You can create multiple action mappings for a single event type. For example, a 
 
 If a single event type has multiple action mappings, Knock executes them in a fixed priority order based on action type, not the order in which you create mappings in the dashboard.
 
-1. `:users_identify`
-2. `:users_delete`
-3. `:objects_set`
-4. `:objects_delete`
-5. `:tenants_set`
-6. `:tenants_delete`
-7. `:objects_subscribe`
-8. `:objects_unsubscribe`
-9. `:audiences_add_member`
-10. `:audiences_remove_member`
-11. `:workflows_trigger`
-12. `:webhook_workflow_trigger`
+1. `users_identify`
+2. `users_delete`
+3. `objects_set`
+4. `objects_delete`
+5. `tenants_set`
+6. `tenants_delete`
+7. `objects_subscribe`
+8. `objects_unsubscribe`
+9. `audiences_add_member`
+10. `audiences_remove_member`
+11. `workflows_trigger`
 
 For incoming webhook context and related behavior, see [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings) in the sources overview.
 

--- a/content/integrations/sources/custom.mdx
+++ b/content/integrations/sources/custom.mdx
@@ -157,6 +157,25 @@ After events start flowing into Knock, you can configure what action Knock shoul
 
 You can create multiple action mappings for a single event type. For example, a `customer.created` event could both identify a user and trigger a welcome workflow.
 
+### Execution order for multiple mappings
+
+If a single event type has multiple action mappings, Knock executes them in a fixed priority order based on action type, not the order in which you create mappings in the dashboard.
+
+1. `:users_identify`
+2. `:users_delete`
+3. `:objects_set`
+4. `:objects_delete`
+5. `:tenants_set`
+6. `:tenants_delete`
+7. `:objects_subscribe`
+8. `:objects_unsubscribe`
+9. `:audiences_add_member`
+10. `:audiences_remove_member`
+11. `:workflows_trigger`
+12. `:webhook_workflow_trigger`
+
+For incoming webhook context and related behavior, see [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings) in the sources overview.
+
 <Image
   src="/images/integrations/sources/custom/event-action-mapping.png"
   alt="The Custom HTTP source Mappings page showing an action mapping with field mappings and a sample payload"

--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -109,6 +109,25 @@ For example, a Stripe `invoice.paid` event includes nested data about the invoic
 
 You could map `data.object.customer` to the `recipients` field and `data.object` to the `data` field when triggering a workflow, giving your templates access to the invoice amount, currency, and subscription details.
 
+### Execution order for multiple mappings
+
+If a single event type has multiple action mappings, Knock executes them in a fixed priority order based on action type, not the order in which you create mappings in the dashboard.
+
+1. `:users_identify`
+2. `:users_delete`
+3. `:objects_set`
+4. `:objects_delete`
+5. `:tenants_set`
+6. `:tenants_delete`
+7. `:objects_subscribe`
+8. `:objects_unsubscribe`
+9. `:audiences_add_member`
+10. `:audiences_remove_member`
+11. `:workflows_trigger`
+12. `:webhook_workflow_trigger`
+
+This ordering is consistent across incoming webhook sources, including custom sources.
+
 For full details on configuring custom event types and field mappings, see the [custom source page](/integrations/sources/custom).
 
 ## Debugging source events

--- a/content/integrations/sources/overview.mdx
+++ b/content/integrations/sources/overview.mdx
@@ -113,18 +113,17 @@ You could map `data.object.customer` to the `recipients` field and `data.object`
 
 If a single event type has multiple action mappings, Knock executes them in a fixed priority order based on action type, not the order in which you create mappings in the dashboard.
 
-1. `:users_identify`
-2. `:users_delete`
-3. `:objects_set`
-4. `:objects_delete`
-5. `:tenants_set`
-6. `:tenants_delete`
-7. `:objects_subscribe`
-8. `:objects_unsubscribe`
-9. `:audiences_add_member`
-10. `:audiences_remove_member`
-11. `:workflows_trigger`
-12. `:webhook_workflow_trigger`
+1. `users_identify`
+2. `users_delete`
+3. `objects_set`
+4. `objects_delete`
+5. `tenants_set`
+6. `tenants_delete`
+7. `objects_subscribe`
+8. `objects_unsubscribe`
+9. `audiences_add_member`
+10. `audiences_remove_member`
+11. `workflows_trigger`
 
 This ordering is consistent across incoming webhook sources, including custom sources.
 

--- a/content/integrations/sources/posthog.mdx
+++ b/content/integrations/sources/posthog.mdx
@@ -103,6 +103,8 @@ The exact event types depend on how you configure your PostHog actions and webho
 
 You can modify the default action mappings or add new ones for any event type Knock receives from PostHog. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
+If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
+
 If you need to map PostHog events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
 
 ## Event idempotency

--- a/content/integrations/sources/stripe.mdx
+++ b/content/integrations/sources/stripe.mdx
@@ -170,6 +170,8 @@ See the <a href="https://docs.stripe.com/api/events/types" target="_blank">Strip
 
 You can modify the default action mappings or add new ones for any event type Knock receives from Stripe. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
+If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
+
 If you need to map Stripe events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
 
 ## Event idempotency

--- a/content/integrations/sources/supabase.mdx
+++ b/content/integrations/sources/supabase.mdx
@@ -129,6 +129,8 @@ The exact event types depend on which tables and operations you configure in you
 
 You can modify the default action mappings or add new ones for any event type Knock receives from Supabase. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
+If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
+
 If you need to map Supabase events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
 
 ## Event idempotency

--- a/content/integrations/sources/workos.mdx
+++ b/content/integrations/sources/workos.mdx
@@ -114,6 +114,8 @@ See the <a href="https://workos.com/docs/events" target="_blank">WorkOS events d
 
 You can modify the default action mappings or add new ones for any event type Knock receives from WorkOS. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
+If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
+
 If you need to map WorkOS events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
 
 ## Event idempotency


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds docs that explain how Knock handles multiple action mappings for a single source event type by executing actions in a guaranteed priority order.

This updates:
- The sources overview page with a dedicated execution-order section and the priority list.
- The custom source page with the same guaranteed order and a link back to sources overview.
- Incoming webhook source pages (Stripe, Clerk, WorkOS, Supabase, PostHog) with links to the execution-order section.

Follow-up refinement:
- Removed `:` prefixes from action names in the published priority list.
- Removed `webhook_workflow_trigger` from docs to keep only user-facing `workflows_trigger`.

### Todos

- [ ] None.

### Tasks

- [ ] N/A

### Screenshots

Not applicable (documentation-only changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-077bd5a9-9bd9-4354-82e8-eb54eea9201a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-077bd5a9-9bd9-4354-82e8-eb54eea9201a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

