### PR TITLE
chore (kno-12808): Update pre-content variables instructions for new UI

### DIFF
--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -233,7 +233,7 @@ For example, if your template uses a <a href="https://shopify.github.io/liquid/t
 
 At send time, Knock compiles your template into its layout's `{{ content }}` tag to produce the final email. If you need a template-level variable to be available _above_ `{{ content }}` in your layout, use **pre-content variables**.
 
-To set them, open the email template editor, click the three-dot menu, and select "Manage template overrides." Add your variables to the pre-content field using Liquid syntax.
+To set them, open the email template editor and click the gear icon (⚙️) at the top of the template editor to open the template settings modal. Add your variables to the pre-content field using Liquid syntax.
 
 Pre-content variables are useful for:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Update the documentation for setting pre-content variables in email templates to use the standardized gear icon (⚙️) phrasing instead of the outdated three-dot menu reference.

**Before:**
> "To set them, open the email template editor, click the three-dot menu, and select 'Manage template overrides.'"

**After:**
> "To set them, open the email template editor and click the gear icon (⚙️) at the top of the template editor to open the template settings modal."

This aligns with the consistent UI phrasing used throughout the rest of the documentation (e.g., in SMS settings, push notification templates, and email attachments docs).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-12808](https://linear.app/knock/issue/KNO-12808/docs-update-pre-content-variables-instructions-for-new-ui)

<div><a href="https://cursor.com/agents/bc-1688ac41-5464-40fd-aebd-d9d4c1334acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1688ac41-5464-40fd-aebd-d9d4c1334acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

