### PR TITLE
fix(KNO-12807): Remove inline code sizing

### DIFF
--- a/lib/mdxComponents.tsx
+++ b/lib/mdxComponents.tsx
@@ -66,7 +66,6 @@ export const MDX_COMPONENTS = {
       color="blue"
       backgroundColor="transparent"
       px="0_5"
-      size="0"
       data-tgph-code
       {...props}
     >


### PR DESCRIPTION
### Description

The `Code` component was rendering inline code at a fixed `size="0"` regardless of context, making it smaller than surrounding text in list items, tables, and small headings like h4. Removing it lets inline code inherit its font size from the parent element, so it stays visually consistent with whatever text surrounds it.

### Tasks

[KNO-12807](https://linear.app/knock/issue/KNO-12807/docs-adjust-inline-code-sizing-for-list-items-tables-etc)

### Screenshots

Before: 
<img width="857" height="514" alt="Screenshot 2026-04-21 at 11 02 53 AM" src="https://github.com/user-attachments/assets/bcd27947-0b45-44fe-bdb4-2b3d7aec9e8b" />

After:
<img width="809" height="506" alt="Screenshot 2026-04-21 at 11 17 49 AM" src="https://github.com/user-attachments/assets/74ebdfe9-90fa-454b-bc43-9af25b306d7d" />
