### PR TITLE
chore(kno-12709): relocate per-tenant preferences to multi-tenancy section

### DIFF
--- a/content/designing-workflows/update-tenant-function.mdx
+++ b/content/designing-workflows/update-tenant-function.mdx
@@ -7,7 +7,7 @@ section: Designing workflows
 
 An update tenant function updates a [tenant](/concepts/tenants) stored in Knock as a step in your workflow. Use it when you need to change a tenant's properties based on workflow context to enable downstream steps or other workflows to use the updated data.
 
-Common use cases include syncing tenant state from your trigger (for example, approval status or feature flags), updating [tenant-level preference defaults](/preferences/tenant-preferences), or storing data on the tenant that you reference later in the same workflow or in another workflow.
+Common use cases include syncing tenant state from your trigger (for example, approval status or feature flags), updating [tenant-level preference defaults](/multi-tenancy/per-tenant-preferences), or storing data on the tenant that you reference later in the same workflow or in another workflow.
 
 ## Selecting the tenant
 
@@ -39,7 +39,7 @@ The update tenant step supports upserting. If you specify a tenant ID that does 
 
 ## Updating preferences
 
-You can update a tenant's default [preferences](/preferences/overview) from within a workflow. Use the `preference_set` key nested under `settings` (not `preferences`) when setting tenant preferences. The value should follow the structure of a [`PreferenceSet`](/api-reference/recipients/preferences/schemas/preference_set). For more information on how tenant preferences work and how to structure them, see [tenant preferences](/preferences/tenant-preferences).
+You can update a tenant's default [preferences](/preferences/overview) from within a workflow. Use the `preference_set` key nested under `settings` (not `preferences`) when setting tenant preferences. The value should follow the structure of a [`PreferenceSet`](/api-reference/recipients/preferences/schemas/preference_set). For more information on how tenant preferences work and how to structure them, see [per-tenant preferences](/multi-tenancy/per-tenant-preferences).
 
 ```json title="Setting tenant preferences via the update tenant step"
 {
@@ -67,7 +67,7 @@ Tenant preference defaults are deep-merged into the tenant's existing preference
 }
 ```
 
-For more details on updating tenant default preferences and how to modify the merge behavior, see the [tenant preferences FAQ](/preferences/tenant-preferences#frequently-asked-questions).
+For more details on updating tenant default preferences and how to modify the merge behavior, see the [per-tenant preferences FAQ](/multi-tenancy/per-tenant-preferences#frequently-asked-questions).
 
 ## Configuring properties
 

--- a/content/managing-recipients/identifying-recipients.mdx
+++ b/content/managing-recipients/identifying-recipients.mdx
@@ -216,7 +216,7 @@ To set preferences during identification, provide a dictionary under the `prefer
     }
     ```
 
-    For workflow triggers with [inline identify](/send-notifications/triggering-workflows/api#identifying-recipients-inline), one or more preference sets (including [per-tenant preferences](/preferences/tenant-preferences)) can be upserted by passing a dictionary of [PreferenceSets](/preferences/overview).
+    For workflow triggers with [inline identify](/send-notifications/triggering-workflows/api#identifying-recipients-inline), one or more preference sets (including [per-tenant preferences](/multi-tenancy/per-tenant-preferences)) can be upserted by passing a dictionary of [PreferenceSets](/preferences/overview).
 
     <MultiLangCodeBlock
       title="Setting preferences during a workflow trigger"

--- a/content/multi-tenancy/overview.mdx
+++ b/content/multi-tenancy/overview.mdx
@@ -12,7 +12,7 @@ You use tenants in Knock to:
 
 - [Scope in-app feeds](/multi-tenancy/tenant-scoped-messaging) so users only see notifications relevant to their active workspace.
 - Apply [per-tenant branding](/multi-tenancy/per-tenant-branding) in emails.
-- Define [per-tenant preference defaults](/preferences/tenant-preferences#create-a-per-tenant-default-preferenceset) that apply to all users within that tenant and [per-user, per-tenant preferences](/preferences/tenant-preferences#set-a-per-tenant-user-preferenceset).
+- Define [per-tenant preference defaults](/multi-tenancy/per-tenant-preferences#create-a-per-tenant-default-preferenceset) that apply to all users within that tenant and [per-user, per-tenant preferences](/multi-tenancy/per-tenant-preferences#set-a-per-tenant-user-preferenceset).
 - Apply [per-tenant translations](/multi-tenancy/per-tenant-translations).
 
 ## How tenants work
@@ -124,7 +124,7 @@ You can also use the tenant in step conditions to only trigger steps for particu
   }
 />
 
-You can manage different sets of preferences for each user-tenant pair. A user may have different preferences configured for "Acme Fish Co." than they do for "Bell's Bagels," two workspaces within the same product. You can also set per-tenant defaults, where an admin in a tenant can set the default preferences for all users within that tenant. You can learn more in [our tenant preferences documentation](/preferences/tenant-preferences).
+You can manage different sets of preferences for each user-tenant pair. A user may have different preferences configured for "Acme Fish Co." than they do for "Bell's Bagels," two workspaces within the same product. You can also set per-tenant defaults, where an admin in a tenant can set the default preferences for all users within that tenant. You can learn more in [our per-tenant preferences documentation](/multi-tenancy/per-tenant-preferences).
 
 ## Frequently asked questions
 

--- a/content/multi-tenancy/per-tenant-preferences.mdx
+++ b/content/multi-tenancy/per-tenant-preferences.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tenant preferences
+title: Per-tenant preferences
 description: Learn how to enable your customer admins to set default preferences for users in their tenant.
 tags:
   [
@@ -9,7 +9,7 @@ tags:
     "per tenant preferences",
     "preferences",
   ]
-section: Preferences
+section: Multi-tenancy
 ---
 
 <Callout
@@ -38,7 +38,7 @@ If you're a B2B application or a multi-tenant SaaS product, you can use tenant p
     <>
       This documentation assumes you know about tenants in Knock and what they
       do. If you're new to tenants, we recommend familiarizing yourself with the
-      concept of <a href="/concepts/tenants">tenants</a> before continuing.
+      concept of <a href="/multi-tenancy/overview">tenants</a> before continuing.
     </>
   }
 />
@@ -173,7 +173,7 @@ Here are a few things to keep in mind when using tenant preferences. You can lea
 
 - When executing a workflow trigger, passing in a `tenant` will automatically load that tenant's default `PreferenceSet` (if one exists) for all recipients of the workflow. These tenant-level defaults will override a recipient's own `default` preferences.
 - If the recipient has any per-tenant preferences set for that `tenant.id`, they will take precedence over the tenant-level default preferences. For more information on how to override a recipient's per-tenant preferences to respect the tenant-level default preferences, see the [frequently asked questions](#frequently-asked-questions) below.
-- If there is no default `PreferenceSet` on the tenant AND the recipient has no per-tenant preferences set, the recipient’s `default` preferences will be used. As always, the recipient's `default` preferences are [merged](/preferences/overview#merging-preferences) with the environment-level preference defaults.
+- If there is no default `PreferenceSet` on the tenant AND the recipient has no per-tenant preferences set, the recipient's `default` preferences will be used. As always, the recipient's `default` preferences are [merged](/preferences/overview#merging-preferences) with the environment-level preference defaults.
 
 ## Frequently asked questions
 

--- a/content/multi-tenancy/per-tenant-preferences.mdx
+++ b/content/multi-tenancy/per-tenant-preferences.mdx
@@ -38,7 +38,8 @@ If you're a B2B application or a multi-tenant SaaS product, you can use tenant p
     <>
       This documentation assumes you know about tenants in Knock and what they
       do. If you're new to tenants, we recommend familiarizing yourself with the
-      concept of <a href="/multi-tenancy/overview">tenants</a> before continuing.
+      concept of <a href="/multi-tenancy/overview">tenants</a> before
+      continuing.
     </>
   }
 />

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -244,8 +244,8 @@ The following hierarchies are used when merging preferences.
   <Accordion title="Standard preference merge hierarchy">
     The following standard hierarchy is used to merge preferences when no `tenant` is applied to the workflow trigger. Each item in the list takes precedence over the ones that follow it:
     
-    1. A recipient's `default` preference set
-    2. The environment-level default preference set
+    1. A [recipient's default preference](/preferences/overview#create-a-default-preferenceset) set
+    2. The [environment-level default preference](/preferences/overview#create-a-default-preferenceset) set
 
     Let's take a look at an example to visualize this merge. Suppose that you have the following preference sets:
     <Image
@@ -284,9 +284,9 @@ The following hierarchies are used when merging preferences.
   <Accordion title="Tenant-specific preference merge hierarchy">
     The following hierarchy is used to merge preferences when a `tenant` is applied to the workflow trigger. Each item in the list takes precedence over the ones that follow it:
     
-    1. A recipient's tenant-specific preference set
-    2. The tenant's default preference set
-    3. The environment-level default preference set
+    1. A recipient's [tenant-specific preference](/multi-tenancy/per-tenant-preferences) set
+    2. The [tenant's default preference](/multi-tenancy/per-tenant-preferences#create-a-per-tenant-default-preferenceset) set
+    3. The [environment-level default preference](/preferences/overview#create-a-default-preferenceset) set
 
     This merge works in the same way as the standard merge above, but it evaluates different preference sets. Let's take a look at an example to visualize this merge. Suppose that you have the following preference sets:
 
@@ -388,7 +388,7 @@ You can update the preferences of up to 1000 users in a single batch by using th
 
 ## Advanced concepts
 
-- [Per-tenant preferences](/preferences/tenant-preferences). In multi-tenant B2B applications, an advanced use case is customer admins who want to set the tenant-level default `PreferenceSet` for new users within their tenant.
+- [Per-tenant preferences](/multi-tenancy/per-tenant-preferences). In multi-tenant B2B applications, an advanced use case is customer admins who want to set the tenant-level default `PreferenceSet` for new users within their tenant.
 - [Object preferences](/preferences/object-preferences). You can set preferences for object recipients, just as you can for users.
 - [Preference conditions](/preferences/preference-conditions). You can build advanced conditions and store them on Knock’s preference model to power use cases such as per-resource muting (example: mute notifications about this task) or threshold alerts (example: only notify me if my account balance is below $5).
 - Merge strategy. It's possible to configure the merge strategy on specific preferences within a `PreferenceSet`. This allows you to override the default merge hierarchy when preferences are evaluated. See the [frequently asked questions](#frequently-asked-questions) section below for more details and use cases.
@@ -614,11 +614,11 @@ You can update the preferences of up to 1000 users in a single batch by using th
 
     #### Removing the `replace` strategy
 
-        Setting preferences on a tenant has [the default behavior](/preferences/tenant-preferences/#updating-the-per-tenant-default-preferenceset) of merging the new preferences with any existing preferences. This means that once a preference has been set with the `replace` strategy, simply omitting the `__strategy__` from your next request will not remove it.
+        Setting preferences on a tenant has [the default behavior](/multi-tenancy/per-tenant-preferences/#updating-the-per-tenant-default-preferenceset) of merging the new preferences with any existing preferences. This means that once a preference has been set with the `replace` strategy, simply omitting the `__strategy__` from your next request will not remove it.
 
         There are two ways to remove it from the preference set:
         - Explicitly set the `__strategy__` key to `"merge"` for the preference(s) that should no longer override the user's preferences. This is the default behavior (a user's tenant-specific preferences will take precedence over the tenant's own default).
-        - Use the `__persistence_strategy__` key on your request to replace the entire preference set rather than merging your new preferences with the existing ones. See the FAQ [here](/preferences/tenant-preferences#frequently-asked-questions) for more information.
+        - Use the `__persistence_strategy__` key on your request to replace the entire preference set rather than merging your new preferences with the existing ones. See the FAQ [here](/multi-tenancy/per-tenant-preferences#frequently-asked-questions) for more information.
 
   </Accordion>
   <Accordion title="Why do I see 'channel types' preferences in the workflow debugger even though I didn't set them?">

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -244,7 +244,7 @@ The following hierarchies are used when merging preferences.
   <Accordion title="Standard preference merge hierarchy">
     The following standard hierarchy is used to merge preferences when no `tenant` is applied to the workflow trigger. Each item in the list takes precedence over the ones that follow it:
     
-    1. A [recipient's default preference](/preferences/overview#create-a-default-preferenceset) set
+    1. A [recipient's default preference](/preferences/overview#how-preferences-work) set
     2. The [environment-level default preference](/preferences/overview#create-a-default-preferenceset) set
 
     Let's take a look at an example to visualize this merge. Suppose that you have the following preference sets:

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -524,7 +524,7 @@ You can update the preferences of up to 1000 users in a single batch by using th
   <Accordion title="What is the merge strategy, and how can I use it to override the merge hierarchy?">
     By default, a recipient's individual preferences will always take the highest precedence in the merge when preferences are evaluated (according to the hierarchy outlined under [Merging preferences](#merging-preferences) above).
     
-    Some applications have use cases where it's necessary for a preference that is set at the tenant level to override a user's individual preference. For example, you may want to allow a team admin to disable a certain type of notification for their entire team, regardless of whether an individual user has opted in to that notification. To achieve this, you can set the `__strategy__` key on the preference you'd like to override to a value of `"replace"`.
+    Some applications have use cases where it's necessary for a [preference that is set at the tenant level](/multi-tenancy/per-tenant-preferences#set-a-per-tenant-user-preferenceset) to override a user's individual preference. For example, you may want to allow a team admin to disable a certain type of notification for their entire team, regardless of whether an individual user has opted in to that notification. To achieve this, you can set the `__strategy__` key on the preference you'd like to override to a value of `"replace"`.
 
     In the following example, although the user has specifically opted into receiving email notifications for the `collaboration` category, email notifications with that category will not send because the `tenant`'s default preference set has set the `collaboration` category to `false`. Consider the following preference sets:
 

--- a/content/tutorials/implementation-guide.mdx
+++ b/content/tutorials/implementation-guide.mdx
@@ -136,7 +136,7 @@ While there is no one-size-fits-all approach to planning a migration to Knock, w
 
   </Step>
   <Step title="Tenants">
-    If your notifications should be scoped to a particular workspace or organization, you’ll need to implement [Tenants](/multi-tenancy/overview) in your Knock integration. A `tenant` can be applied as context to a workflow trigger in order to [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [per-tenant preferences](/preferences/tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
+    If your notifications should be scoped to a particular workspace or organization, you’ll need to implement [Tenants](/multi-tenancy/overview) in your Knock integration. A `tenant` can be applied as context to a workflow trigger in order to [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [per-tenant preferences](/multi-tenancy/per-tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
 
     <Callout
 
@@ -168,7 +168,7 @@ text={
   <Step title="Preferences">
     Once your recipients (both users and objects) and tenants have been migrated to Knock, you’ll want to consider delivery preferences for your notifications to give your users control of where and when they receive updates from your product. For more information on building a preference center in your app, check out the section on [Completing your client-side integration](#completing-your-client-side-integration) below.
 
-    Knock’s powerful [Preferences](/preferences/overview) API allows your users to opt out of notifications based on the notification’s delivery `channel_type`, the `category` of the notification, the specific notification `workflow`, or a combination of these properties. You can also extend these preferences to be [tenant-specific](/preferences/tenant-preferences) or to [evaluate conditionally](/preferences/preference-conditions) at runtime.
+    Knock’s powerful [Preferences](/preferences/overview) API allows your users to opt out of notifications based on the notification’s delivery `channel_type`, the `category` of the notification, the specific notification `workflow`, or a combination of these properties. You can also extend these preferences to be [tenant-specific](/multi-tenancy/per-tenant-preferences) or to [evaluate conditionally](/preferences/preference-conditions) at runtime.
 
     You can set environment-level default preferences (for example, maybe a given workflow should require a user to manually opt in to receive those notifications) as well as tenant-specific default preferences that will be overridden by a recipient’s individual preferences.
 

--- a/content/tutorials/migrate-from-braze.mdx
+++ b/content/tutorials/migrate-from-braze.mdx
@@ -51,7 +51,7 @@ When using the `t` tag [method](/template-editor/translations#translation-method
 
 In Braze, there isn't a direct equivalent to Knock's tenant functionality. Most Braze customers handle customer/organization segmentation through custom attributes (like `organization_id`, `account_id`, `company_name`) combined with segments built on those attributes. This approach requires manual campaign targeting, complex segmentation logic, and offers no native support for per-organization branding, preferences, or scoped in-app feeds.
 
-In Knock, [tenants](/multi-tenancy/overview) provide native multi-tenancy support that eliminates these workarounds. Tenants represent organizations your users belong to—what you might call "accounts" or "workspaces." Per-tenant branding attributes are stored directly on a tenant in Knock rather than requiring separate campaigns or complex attribute management. Knock tenants are applied as context to workflow triggers to automatically [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [manage per-tenant preferences](/preferences/tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
+In Knock, [tenants](/multi-tenancy/overview) provide native multi-tenancy support that eliminates these workarounds. Tenants represent organizations your users belong to—what you might call "accounts" or "workspaces." Per-tenant branding attributes are stored directly on a tenant in Knock rather than requiring separate campaigns or complex attribute management. Knock tenants are applied as context to workflow triggers to automatically [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [manage per-tenant preferences](/multi-tenancy/per-tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
 
 Key advantages of Knock's tenant approach:
 
@@ -83,7 +83,7 @@ Braze manages user subscription preferences through <a href="https://www.braze.c
 
 Knock provides two features that together replace Braze subscription groups:
 
-- [Preferences](/preferences/overview) handle communication opt-outs similarly to Braze's marketing-focused subscription groups, but with enhanced flexibility for channel-specific, category-based, or workflow-specific preferences that can be [tenant-specific](/preferences/tenant-preferences) or [conditional](/preferences/preference-conditions).
+- [Preferences](/preferences/overview) handle communication opt-outs similarly to Braze's marketing-focused subscription groups, but with enhanced flexibility for channel-specific, category-based, or workflow-specific preferences that can be [tenant-specific](/multi-tenancy/per-tenant-preferences) or [conditional](/preferences/preference-conditions).
 
 - [Subscriptions](/concepts/subscriptions) express relationships between [recipients](/concepts/recipients) and [objects](/concepts/objects) in your [data model](/tutorials/modeling-users-objects-and-tenants), enabling you to notify large numbers of recipients by triggering workflows for a single object recipient and letting Knock handle the recipient fanout for you rather than resolving recipient lists in your system when you trigger your notifications.
 

--- a/content/tutorials/migrate-from-courier.mdx
+++ b/content/tutorials/migrate-from-courier.mdx
@@ -43,7 +43,7 @@ Subscriptions are an extension of [Objects](/concepts/objects) and express the r
 
 If you’re currently using <a href="https://www.courier.com/docs/reference/tenants/" target="_blank">Tenants</a> in Courier to scope your notifications to a particular workspace or organization (and optionally associating <a href="https://www.courier.com/docs/reference/brands/" target="_blank">Brands</a> with those Tenants), you can achieve similar functionality with Knock [Tenants](/multi-tenancy/overview).
 
-Unlike Courier, per-tenant branding attributes are stored directly on a Tenant in Knock rather than as a separate resource. Knock also does not directly associate Tenants with the recipients of a notification (no subscription logic necessary!); rather, a `tenant` is applied as context to a particular workflow trigger in order to [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [per-tenant preferences](/preferences/tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
+Unlike Courier, per-tenant branding attributes are stored directly on a Tenant in Knock rather than as a separate resource. Knock also does not directly associate Tenants with the recipients of a notification (no subscription logic necessary!); rather, a `tenant` is applied as context to a particular workflow trigger in order to [apply per-tenant branding](/multi-tenancy/per-tenant-branding), [per-tenant preferences](/multi-tenancy/per-tenant-preferences), and [scope in-app feed messages to particular tenants](/multi-tenancy/tenant-scoping).
 
 <Callout
   emoji="✨"
@@ -68,7 +68,7 @@ Courier’s <a href="https://www.courier.com/docs/reference/user-preferences/int
 
 Knock’s [Preferences](/preferences/overview) model has a single high-level `category` property that can be assigned on a Workflow; because a given workflow can have more than one `category`, you can use this property to map both Topics and Preference Sections to your notifications in Knock.
 
-Our powerful Preferences API allows your users to opt out of notifications based on the notification’s delivery `channel_type`, the `category` of the notification, the specific notification `workflow`, or a combination of these properties. You can also extend these preferences to be [tenant-specific](/preferences/tenant-preferences) or to [evaluate conditionally](/preferences/preference-conditions).
+Our powerful Preferences API allows your users to opt out of notifications based on the notification’s delivery `channel_type`, the `category` of the notification, the specific notification `workflow`, or a combination of these properties. You can also extend these preferences to be [tenant-specific](/multi-tenancy/per-tenant-preferences) or to [evaluate conditionally](/preferences/preference-conditions).
 
 ### Translations
 

--- a/content/tutorials/modeling-users-objects-and-tenants.mdx
+++ b/content/tutorials/modeling-users-objects-and-tenants.mdx
@@ -218,6 +218,6 @@ await knock.workflows.trigger("new-comment", {
 });
 ```
 
-Tagging messages with a particular tenant can help you segment your notifications and apply [per-tenant branding](/multi-tenancy/per-tenant-branding) and [preferences](/preferences/tenant-preferences).
+Tagging messages with a particular tenant can help you segment your notifications and apply [per-tenant branding](/multi-tenancy/per-tenant-branding) and [preferences](/multi-tenancy/per-tenant-preferences).
 
 Tenants are also useful for helping you [scope the in-app feed](/multi-tenancy/tenant-scoping) to messages about a certain workspace or organization.

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -178,6 +178,7 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
       { slug: "/tenant-scoping", title: "Tenant scoping" },
       { slug: "/per-tenant-branding", title: "Per-tenant branding" },
       { slug: "/per-tenant-translations", title: "Per-tenant translations" },
+      { slug: "/per-tenant-preferences", title: "Per-tenant preferences" },
     ],
   },
   {
@@ -186,7 +187,6 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
     desc: "Learn how to power notification preferences with Knock.",
     pages: [
       { slug: "/overview", title: "Overview" },
-      { slug: "/tenant-preferences", title: "Tenant preferences" },
       { slug: "/object-preferences", title: "Object preferences" },
       { slug: "/preference-conditions", title: "Preferences conditions" },
       {

--- a/next.config.js
+++ b/next.config.js
@@ -203,6 +203,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: "/preferences/tenant-preferences",
+        destination: "/multi-tenancy/per-tenant-preferences",
+        permanent: true,
+      },
+      {
         source: "/send-notifications/workflow-functions",
         destination: "/designing-workflows/overview",
         permanent: true,


### PR DESCRIPTION
### Summary
- Relocates `preferences/tenant-preferences.mdx` to `multi-tenancy/per-tenant-preferences.mdx` so per-tenant preferences live alongside the other per-tenant capability pages (branding, translations, scoping)
- Adds redirect from `/preferences/tenant-preferences` to `/multi-tenancy/per-tenant-preferences`
- Updates sidebar, internal links, and cross-links in preference docs so customers can find per-tenant preferences from both sections

### Changes
- `content/multi-tenancy/per-tenant-preferences.mdx` — new file (relocated from `preferences/tenant-preferences.mdx`)
- `content/preferences/tenant-preferences.mdx` — deleted (redirect handles old URL)
- `data/sidebars/platformSidebar.ts` — adds per-tenant-preferences to multi-tenancy section; removes tenant-preferences from preferences section
- `next.config.js` — adds redirect from `/preferences/tenant-preferences` to `/multi-tenancy/per-tenant-preferences`
- `content/multi-tenancy/overview.mdx` — updated two links to per-tenant preferences
- `content/preferences/overview.mdx` — updated three links; updated "Advanced concepts" bullet to point to new URL; Added links to merge hierarchy sections
- `content/designing-workflows/update-tenant-function.mdx` — updated link to per-tenant preferences