### PR TITLE
fix: image component and image style issues

### DIFF
--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -26,7 +26,6 @@ To ensure consistency between the dashboard's template preview and the guide com
   width={600}
   height={100}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 The guides toolbar is a floating panel that enables you to inspect and debug guides on any page of your application. Use it to understand why a guide is or isn't showing in a given context, force guides to display for testing, and inspect the targeting parameters being evaluated for the current user.
@@ -103,7 +102,6 @@ Click **Focus** on a guide row to force that guide to display, bypassing eligibi
   width={600}
   height={100}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 Select the settings icon to expand the toolbar settings panel. From there, you can control the behavior of engagement tracking while testing, toggle throttle settings, and view the data currently passed to the guide provider. The following controls are available:

--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -25,7 +25,7 @@ To ensure consistency between the dashboard's template preview and the guide com
   alt="Example of the guides toolbar"
   width={600}
   height={100}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 The guides toolbar is a floating panel that enables you to inspect and debug guides on any page of your application. Use it to understand why a guide is or isn't showing in a given context, force guides to display for testing, and inspect the targeting parameters being evaluated for the current user.
@@ -101,7 +101,7 @@ Click **Focus** on a guide row to force that guide to display, bypassing eligibi
   alt="Toolbar controls"
   width={600}
   height={100}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 Select the settings icon to expand the toolbar settings panel. From there, you can control the behavior of engagement tracking while testing, toggle throttle settings, and view the data currently passed to the guide provider. The following controls are available:

--- a/content/in-app-ui/react/banner.mdx
+++ b/content/in-app-ui/react/banner.mdx
@@ -17,7 +17,6 @@ The banner component enables you to display important notifications, alerts, or 
   width={1356}
   height={1000}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Getting started
@@ -123,7 +122,6 @@ The pre-built banner message type supports three variants for different use case
   width={1506}
   height={466}
   className="mx-auto border border-gray-200 w-full"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Handling user engagement

--- a/content/in-app-ui/react/banner.mdx
+++ b/content/in-app-ui/react/banner.mdx
@@ -16,7 +16,7 @@ The banner component enables you to display important notifications, alerts, or 
   alt="BannerComponent"
   width={1356}
   height={1000}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 ## Getting started
@@ -121,7 +121,7 @@ The pre-built banner message type supports three variants for different use case
   alt="BannerVariants"
   width={1506}
   height={466}
-  className="mx-auto border border-gray-200 w-full"
+  className="mx-auto border border-gray-200 rounded-xl w-full"
 />
 
 ## Handling user engagement

--- a/content/in-app-ui/react/card.mdx
+++ b/content/in-app-ui/react/card.mdx
@@ -17,7 +17,6 @@ The card component enables you to display contextual information, tips, or inter
   width={1356}
   height={1000}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Getting started
@@ -134,7 +133,6 @@ The pre-built card message type supports three variants for different use cases:
   width={1506}
   height={466}
   className="mx-auto border border-gray-200 w-full"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Handling user engagement

--- a/content/in-app-ui/react/card.mdx
+++ b/content/in-app-ui/react/card.mdx
@@ -16,7 +16,7 @@ The card component enables you to display contextual information, tips, or inter
   alt="CardComponent"
   width={1356}
   height={1000}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 ## Getting started
@@ -132,7 +132,7 @@ The pre-built card message type supports three variants for different use cases:
   alt="CardVariants"
   width={1506}
   height={466}
-  className="mx-auto border border-gray-200 w-full"
+  className="mx-auto border border-gray-200 rounded-xl w-full"
 />
 
 ## Handling user engagement

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -17,7 +17,6 @@ See a <a href="https://in-app-demo.knock.app/" target="_blank" rel="noopener">li
   width={1356}
   height={1000}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Getting started

--- a/content/in-app-ui/react/feed.mdx
+++ b/content/in-app-ui/react/feed.mdx
@@ -16,7 +16,7 @@ See a <a href="https://in-app-demo.knock.app/" target="_blank" rel="noopener">li
   alt="FeedComponent"
   width={1356}
   height={1000}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 ## Getting started

--- a/content/in-app-ui/react/modal.mdx
+++ b/content/in-app-ui/react/modal.mdx
@@ -17,7 +17,6 @@ The modal component enables you to display important notifications, announcement
   width={1356}
   height={1000}
   className="mx-auto border border-gray-200"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Getting started
@@ -123,7 +122,6 @@ The pre-built modal message type supports three variants for different use cases
   width={1506}
   height={466}
   className="mx-auto border border-gray-200 w-full"
-  style={{ borderRadius: "var(--tgph-rounded-5)" }}
 />
 
 ## Handling user engagement

--- a/content/in-app-ui/react/modal.mdx
+++ b/content/in-app-ui/react/modal.mdx
@@ -16,7 +16,7 @@ The modal component enables you to display important notifications, announcement
   alt="ModalComponent"
   width={1356}
   height={1000}
-  className="mx-auto border border-gray-200"
+  className="mx-auto border border-gray-200 rounded-xl"
 />
 
 ## Getting started
@@ -121,7 +121,7 @@ The pre-built modal message type supports three variants for different use cases
   alt="ModalVariants"
   width={1506}
   height={466}
-  className="mx-auto border border-gray-200 w-full"
+  className="mx-auto border border-gray-200 rounded-xl w-full"
 />
 
 ## Handling user engagement

--- a/lib/mdxComponents.tsx
+++ b/lib/mdxComponents.tsx
@@ -47,9 +47,10 @@ const Image = ({
   ...props
 }: React.ComponentProps<typeof NextImage> & { border?: boolean }) => (
   <div
-    className={`overflow-hidden rounded-md inline-block ${
+    className={`overflow-hidden rounded-md ${
       border ? "border border-gray-200 dark:border-gray-700" : ""
     } ${className ?? ""}`}
+    style={{ display: "block", width: "fit-content" }}
   >
     <NextImage {...props} />
   </div>


### PR DESCRIPTION
### Description

A previous commit introduced a custom `Image` wrapper component in `lib/mdxComponents.tsx` that had two bugs:                                         
                                                                                   
1. Centering broken — the wrapper used `inline-block`, which doesn't respond to `mx-auto`. Images that were previously centered in `Accordion` components appeared left-aligned.
2. Border radius mismatch — the wrapper applies `overflow-hidden rounded-md` to clip image corners, but 9 images in `content/in-app-ui/`  had baked-in rounded corners (at 0.75rem) in the PNG itself that were larger than the wrapper's `rounded-md` (0.375rem). In dark mode this created a visible gap between the border and the image's corners.

**Changes:**                                                                         
   
- `lib/mdxComponents.tsx` — replaced `inline-block` with `style={{ display: "block", width: "fit-content" }}` on the wrapper `div.` Using inline styles (rather than Tailwind classes) guarantees the CSS is applied regardless of which files Tailwind scans. `display: block` makes `mx-auto` work; `width: fit-content` shrinks the wrapper to the image's natural width so there's something to center.
- `content/in-app-ui/` (5 files, 9 images) — removed the `style={{ borderRadius: "var(--tgph-rounded-5)" }}` prop that was being applied to the inner `img` element (where it had no effect on the wrapper's clipping). Added `rounded-xl` to the `className` instead, which applies to the wrapper div and matches the 0.75rem radius baked into those screenshots. Also removed redundant `border border-gray-200` classes from these images since the component adds a border by default. **Note:** this is a compromise because the original image files have this baked-in border, so the rendered border now matches those images but technically does not match the rest of the images in the docs. If we want them to match, we'll need to either crop the original images so that they are rectangular, or generate new ones.


### Screenshots

**Previous issues (dark mode makes it a bit easier to see the mismatched border radius):**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/112e449d-7bc9-4ec8-8f5a-3ef31969ab4c" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/dd81ec35-3734-46f6-8200-461b0efaf60b" />
<br/>

**Now resolved:**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d5806ede-e738-47b8-b7d8-f6c34b6f4781" />

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f7e82b04-2d80-4792-9ed1-a2ebfe2abd84" />

