### PR TITLE
docs(KNO-12856): point React Native SDK docs at the example app

### DIFF
--- a/content/in-app-ui/react-native/overview.mdx
+++ b/content/in-app-ui/react-native/overview.mdx
@@ -38,6 +38,7 @@ npm install @knocklabs/expo
 ## Links
 
 - [React Native SDK reference](/in-app-ui/react-native/sdk/reference)
+- [React Native example app](https://github.com/knocklabs/javascript/tree/main/examples/react-native-example)
 - [Expo SDK reference](/in-app-ui/expo/sdk/reference)
 - [JavaScript SDK reference](/in-app-ui/javascript/sdk/reference)
 - [`@knocklabs/react-native` on npm](https://www.npmjs.com/package/@knocklabs/react-native)

--- a/content/in-app-ui/react-native/sdk/quick-start.mdx
+++ b/content/in-app-ui/react-native/sdk/quick-start.mdx
@@ -19,6 +19,7 @@ To get started, you will need the following:
       <a
         href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example"
         target="_blank"
+        rel="noopener"
       >
         React Native example app
       </a>{" "}

--- a/content/in-app-ui/react-native/sdk/quick-start.mdx
+++ b/content/in-app-ui/react-native/sdk/quick-start.mdx
@@ -10,6 +10,27 @@ To get started, you will need the following:
 - A public API key for the Knock environment (which you'll use in the `publishableKey`)
 - An in-app feed channel with a workflow that produces in-app feed messages (optional)
 
+<Callout
+  type="info"
+  title="Try the example app"
+  text={
+    <>
+      The{" "}
+      <a
+        href="https://github.com/knocklabs/javascript/tree/main/examples/react-native-example"
+        target="_blank"
+      >
+        React Native example app
+      </a>{" "}
+      in the <code>knocklabs/javascript</code> monorepo demonstrates the SDK
+      end-to-end: identifying a user, rendering the in-app feed with the
+      prebuilt <code>NotificationFeed</code> component, reading and writing
+      preferences, and switching tenants. Clone the repo, fill in{" "}
+      <code>src/config.ts</code>, and run <code>yarn ios</code>.
+    </>
+  }
+/>
+
 ## Installation
 
 - Via NPM: `npm install @knocklabs/react-native`


### PR DESCRIPTION
### Description

Adds a callout to the React Native SDK Quick start and a link from the SDK overview's Links section, both pointing at the new in-tree example app at `knocklabs/javascript/examples/react-native-example`. Companion to https://github.com/knocklabs/javascript/pull/976.

### Tasks

[KNO-12856](https://linear.app/knock/issue/KNO-12856)