### PR TITLE
chore(KNO-11766): Update MS bot registration and add app publishing guidance

### DIFF
--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -27,22 +27,13 @@ If you're using a Microsoft Teams bot, make sure your bot has been registered an
 
 Additionally, if you intend to use [TeamsKit](/in-app-ui/react/teams-kit) or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure a Graph API-enabled application in the Microsoft Entra admin center](#configuring-a-graph-api-enabled-application-in-microsoft-entra).
 
-<Callout
-  type="info"
-  title="Note:"
-  text={
-    <>
-      As of July 31, 2025, Microsoft no longer allows the creation of
-      multi-tenant bots in Azure. Knock continues to support existing (legacy)
-      multi-tenant bots.
-      <br />
-      <br />
-      For new Microsoft Teams integrations, you should register your bot as single-tenant
-      and publish it to the Microsoft Teams app store as a cross-tenant app so that
-      it can be installed across customer workspaces.
-    </>
-  }
-/>
+#### Registering a new bot
+
+As of July 31, 2025, Microsoft no longer allows the creation of multi-tenant bots in Azure. If you're registering a new bot, you'll need to register it as single-tenant and publish it to the Microsoft Teams app store as a cross-tenant app so it can be installed across customer workspaces.
+
+The app store submission process is managed entirely by Microsoft and typically takes 4–6 weeks to complete. We recommend reviewing Microsoft's <a href="https://learn.microsoft.com/en-us/partner-center/marketplace-offers/add-in-submission-guide" target="_blank" rel="noreferrer noopener">app submission guide</a> ahead of time to understand what's required, as there are several steps involved.
+
+While your submission is under review, you can test your integration end-to-end by sideloading your app into a tenant directly. Download your Teams app as a `.zip` package from the <a href="https://dev.teams.microsoft.com/" target="_blank" rel="noreferrer noopener">Teams Developer Portal</a>, then upload it to the Teams Admin Center of the tenant you want to test in under **Teams apps** > **Manage app** > **Upload**. This makes your app available in that tenant's catalog without needing to wait for store approval.
 
 ### Add Teams to Knock as a channel
 


### PR DESCRIPTION
### Description

I've reworked the Prerequisites section of our Microsoft Teams overview page to add a new "Registering a new bot" heading under the bot prerequisites. This heading incorporates the existing callout on bot type selection and adds guidance on the Microsoft App Store publishing process, based on customer feedback. It's important that customers registering a new bot are aware of the submission and review timelines upfront, and that we point them to Microsoft's documentation to help them prepare. I also added a tip on how customers can test their bot while waiting for store approval. 

https://docs-git-rt-kno-11766-ms-teams-publishing-guidance-knocklabs.vercel.app/integrations/chat/microsoft-teams/overview#registering-a-new-bot

In this process, I made a few decisions:
1. Instead of stacking multiple callouts in this section, I opted to create a new heading. IMO multiple callouts in close proximity tend to lose their importance, and a dedicated heading also gives us an easy anchor to link customers to directly when they're starting the MS Teams integration process.
2. I removed the note about Knock continuing to support existing legacy multi-tenant bots, as it didn't fit naturally with the new organization. This is still covered in the bot configuration section below, where we walk through single-tenant vs. multi-tenant bot setup.
3. I opted for a heading rather than an accordion. While this is one of our longer pages, this information is important enough that I think it should be immediately visible to the user vs nested in an accordion.

That said, I am very open to feedback on the approach I've taken! 

### Tasks

[KNO-11766](https://linear.app/knock/issue/KNO-11766/docs-ms-teams-overview-page-app-store-publishing-guidance)
