### PR TITLE
Surface agent function under Knock AI sidebar section

### DIFF
--- a/content/ai/agent-function.mdx
+++ b/content/ai/agent-function.mdx
@@ -1,0 +1,38 @@
+---
+title: Agent function
+description: Learn how the agent workflow function brings AI-powered enrichment and personalization into your Knock workflows.
+tags: ["AI", "agent", "workflows", "functions", "personalization", "LLM"]
+section: AI
+---
+
+<Image
+  src="/images/designing-workflows/agent-function.png"
+  alt="A workflow with an agent step that qualifies sign-ups, showing the agent configuration and response"
+  width={1498}
+  height={812}
+  className="mx-auto"
+/>
+
+The agent function is a workflow step that runs a prompt on an AI model of your choice and makes the response available in your workflow run. You can use it to enrich recipient data, personalize messaging, and bring AI-powered context into your notification flows.
+
+Common use cases include:
+
+- **Enriching recipient data.** Use user and tenant properties (such as domain) to understand a recipient's market, use cases, and target persona.
+- **Personalizing messaging.** Bring that context into your [channel step templates](/template-editor/overview) to drive higher conversion rates.
+- **Summarizing batch content.** Distill heterogeneous actions into a concise summary that reduces noise in digest notifications.
+
+<Callout
+  type="info"
+  title="Not the same as the Knock agent."
+  text={
+    <>
+      The agent function is a workflow step that runs inside a workflow run. It
+      is separate from the <a href="/ai/agent">Knock agent</a>, the
+      conversational assistant you use in the dashboard.
+    </>
+  }
+/>
+
+## Learn more
+
+The agent function lives alongside Knock's other workflow functions. To learn how it works, how to configure a prompt and response format, and how credits and billing work, see the [full reference](/designing-workflows/ai-agent-function) in the designing workflows docs.

--- a/content/designing-workflows/ai-agent-function.mdx
+++ b/content/designing-workflows/ai-agent-function.mdx
@@ -21,20 +21,6 @@ Common use cases include:
 - **Personalizing messaging.** Bring that context into your [channel step templates](/template-editor/overview) to drive higher conversion rates.
 - **Summarizing batch content.** Distill heterogeneous actions into a concise summary that reduces noise in digest notifications.
 
-<Callout
-  type="beta"
-  text={
-    <>
-      Agent function is currently in beta. If you'd like early access, or if
-      this is blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Agent function beta access">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
 ## How it works
 
 When a workflow run reaches an agent step, Knock:

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -43,6 +43,17 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
     ],
   },
   {
+    title: "Knock AI",
+    slug: "/ai",
+    desc: "Use the Knock Agent in the dashboard, the MCP server in your editor, and skills for coding agents.",
+    pages: [
+      { slug: "/agent", title: "Knock agent" },
+      { slug: "/agent-function", title: "Agent function" },
+      { slug: "/mcp-server", title: "MCP server" },
+      { slug: "/skills", title: "Skills" },
+    ],
+  },
+  {
     title: "Workflows",
     slug: "/designing-workflows",
     desc: "Learn how to design notifications using Knock's workflow builder, then explore advanced features such as batching, delays, and more.",
@@ -55,17 +66,9 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
           { slug: "/delay-function", title: "Delay function" },
           { slug: "/batch-function", title: "Batch function" },
           { slug: "/branch-function", title: "Branch function" },
-          {
-            slug: "/experiment-function",
-            title: "Experiment function",
-            isBeta: true,
-          },
+          { slug: "/experiment-function", title: "Experiment function" },
           { slug: "/fetch-function", title: "Fetch function" },
-          {
-            slug: "/ai-agent-function",
-            title: "Agent function",
-            isBeta: true,
-          },
+          { slug: "/ai-agent-function", title: "Agent function" },
           { slug: "/throttle-function", title: "Throttle function" },
           {
             slug: "/trigger-workflow-function",
@@ -203,16 +206,6 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
       { slug: "/environments", title: "Environments" },
       { slug: "/branches", title: "Branches" },
       { slug: "/commits", title: "Commits" },
-    ],
-  },
-  {
-    title: "Knock AI",
-    slug: "/ai",
-    desc: "Use the Knock Agent in the dashboard, the MCP server in your editor, and skills for coding agents.",
-    pages: [
-      { slug: "/agent", title: "Knock agent", isBeta: true },
-      { slug: "/mcp-server", title: "MCP server" },
-      { slug: "/skills", title: "Skills" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add a lightweight Agent function landing page at `/ai/agent-function` so builders browsing the Knock AI section can discover the workflow function and jump to the full reference.
- Reorder the platform sidebar so the Knock AI section sits between Concepts and Workflows, giving it top-level prominence alongside core product areas.
- Remove beta flags now that agent function and experiment function are generally available: drops `isBeta` from the Knock agent, agent function (both Knock AI and Workflows sidebar entries), and experiment function sidebar entries, and removes the beta callout from the agent function reference page.

## Test plan
- [ ] Run `yarn dev` and confirm the Knock AI section renders above Workflows with Knock agent, Agent function, MCP server, and Skills entries (no beta badges).
- [ ] Visit `/ai/agent-function` and verify the hero image, intro, disambiguation callout, and the link to `/designing-workflows/ai-agent-function` all render correctly.
- [ ] Visit `/designing-workflows/ai-agent-function` and confirm the beta callout is gone and the page still reads cleanly.
- [ ] Confirm the Workflows sidebar shows Agent function and Experiment function without beta badges.