### PR TITLE
fix(KNO-12581): Update instructions for setting up an incoming webook in Microsoft

### DIFF
--- a/content/integrations/chat/microsoft-teams/sending-an-internal-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-an-internal-message.mdx
@@ -31,12 +31,7 @@ Once you have a repository object created, you can add the channel data for Micr
 
 ## Objects as workflow recipients
 
-To add channel data, we’ll set up an incoming webhook in Microsoft Teams. There are two ways to generate an incoming webhook URL for a Teams channel:
-
-1. Your customer can [create an incoming webhook](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook) and send it to you.
-2. You can [build a Microsoft 365 Connector](https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/connectors-creating) that your customers will install in Teams and add to their channels. When a customer adds your Connector to a channel, you receive an incoming webhook URL.
-
-Whichever method you choose, the end result is the same: an incoming webhook URL.
+To add channel data, we’ll set up an incoming webhook in Microsoft Teams using the Workflows app (powered by Power Automate). Follow <a href="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-webhooks-using-workflows" target="_blank" rel="noopener noreferrer">Microsoft’s documentation on creating webhooks using Workflows</a> to generate a webhook URL for the Teams channel you want to post to.
 
 ### Set the webhook as channel data
 


### PR DESCRIPTION
### Description

[Microsoft is retiring Office 365 connectors in Teams (final cutoff May 2026)](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/), which means the two previously documented methods for generating an incoming webhook URL (creating a connector directly in Teams and building a Microsoft 365 Connector) will no longer work. This updates the doc to reflect the only supported path going forward, which is generating a webhook URL via the Workflows app (powered by Power Automate). Rather than duplicating Microsoft's setup steps, I opted to just link directly to their documentation for creating webhooks using Workflows to hopefully better ensure that it doesn't easily fall out of date. 

https://docs-git-rt-kno-kno-12581-ms-teams-incoming-we-ca8cf6-knocklabs.vercel.app/integrations/chat/microsoft-teams/sending-an-internal-message#objects-as-workflow-recipients

### Tasks

[KNO-12581](https://linear.app/knock/issue/KNO-12581/docs-ms-teams-incoming-webhooks-page-deprecation-and-migration-updates)
