### PR TITLE
fix(KNO-12588): Remove trigger frequency link in FAQ

### DIFF
--- a/content/send-notifications/triggering-workflows/overview.mdx
+++ b/content/send-notifications/triggering-workflows/overview.mdx
@@ -47,9 +47,7 @@ When you specify "Once per recipient" frequency, you can include the tenant in t
     any workflow recipient runs.
   </Accordion>
   <Accordion title="Is trigger frequency enforced during test runs?">
-    No. [Trigger
-    frequency](/send-notifications/triggering-workflows/overview#controlling-workflow-trigger-frequency)
-    is not enforced by the [workflow test
+    No. Trigger frequency is not enforced by the [workflow test
     runner](/send-notifications/testing-workflows). Settings like "once per
     recipient" are bypassed — the workflow will execute for the selected
     recipient every time you run a test, regardless of your frequency setting.


### PR DESCRIPTION
### Description

Quick follow-up to KNO-12588 that removes the trigger frequency link in the FAQ (links to the same page/section above the FAQ and isn't needed) 

### Tasks

[KNO-12588](https://linear.app/knock/issue/KNO-12588/docs-add-callout-to-testing-workflows-page-clarifying-that-trigger)
