### PR TITLE
chore(kno-12129): update deprecated feed event format

### DIFF
--- a/typedocs/client/feed.mdx
+++ b/typedocs/client/feed.mdx
@@ -151,7 +151,7 @@ Programmatically access the current `FeedStoreState`.
 
 ### `markAllAsSeen`
 
-Marks all of the items in the store optimistically as seen and performs a server-side request to mark **all items on the feed in the current scope** as seen. Broadcasts a `items:all_seen` event.
+Marks all of the items in the store optimistically as seen and performs a server-side request to mark **all items on the feed in the current scope** as seen. Broadcasts an `items.all_seen` event.
 
 **Please note**: this operation is deferred and may take some time to process all items in the feed.
 
@@ -191,7 +191,7 @@ Removes the `seen` status on the item or items given. Will perform the operation
 
 ### `markAllAsRead`
 
-Marks all of the items in the store optimistically as read and performs a server-side request to mark **all items on the feed in the current scope** as read. Broadcasts a `items:all_read` event.
+Marks all of the items in the store optimistically as read and performs a server-side request to mark **all items on the feed in the current scope** as read. Broadcasts an `items.all_read` event.
 
 **Please note**: this operation is deferred and may take some time to process all items in the feed.
 
@@ -231,7 +231,7 @@ Removes the `read` status on the item or items given. Will perform the operation
 
 ### `markAllAsArchived`
 
-Marks all of the items in the store optimistically as archived and performs a server-side request to mark **all items on the feed in the current scope** as archived. Broadcasts a `items:all_archived` event.
+Marks all of the items in the store optimistically as archived and performs a server-side request to mark **all items on the feed in the current scope** as archived. Broadcasts an `items.all_archived` event.
 
 **Please note**: this operation is deferred and may take some time to process all items in the feed.
 
@@ -239,7 +239,7 @@ Marks all of the items in the store optimistically as archived and performs a se
 
 ### `markAsArchived`
 
-Sets the `archived` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts a `items:archived` event.
+Sets the `archived` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts an `items.archived` event.
 
 **Parameters**:
 
@@ -271,7 +271,7 @@ Removes the `archived` status on the item or items given. Will perform the opera
 
 ### `markAsInteracted`
 
-Sets the `interacted` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts an `items:interacted` event.
+Sets the `interacted` status on the item or items given. Will perform the operation optimistically, including updating the current `metadata` in the `FeedStoreState`. Broadcasts an `items.interacted` event.
 
 **Parameters**:
 


### PR DESCRIPTION
### Description

This PR updates the documentation for all feed events under methods in the JavaScript SDK's feed client reference (/in-app-ui/javascript/sdk/feed-client) to reflect that emitted events should use `items.*` format (dot notation) rather than `items:*` (with a colon). The SDK still emits both for backwards compatibility, but dot notation is considered canonical and the rest of our documentation uses it.
