### PR TITLE
feat(kno-12316): document dynamic audiences

### DIFF
--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -16,7 +16,6 @@ tags:
     "segments",
     "cohorts",
     "dynamic",
-    "audience",
   ]
 section: Concepts
 ---
@@ -27,7 +26,7 @@ Use audiences to:
 
 - [Trigger workflows](/send-notifications/triggering-workflows/audiences) for lifecycle messaging (such as new user signups) and transactional messaging (such as payment method updates).
 - Orchestrate branch and conditional logic within your workflows using audience membership (e.g. if a user is in a `paid users` audience, opt them out of the workflow).
-- Target users for an [in-app guide](https://docs.knock.app/in-app-ui/guides/overview).
+- Target users for an [in-app guide](/in-app-ui/guides/overview).
 - Send a one-time message to a specific audience with a [broadcast](/concepts/broadcasts).
 
 ## Creating an audience

--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -15,6 +15,8 @@ tags:
     "groups",
     "segments",
     "cohorts",
+    "dynamic",
+    "audience",
   ]
 section: Concepts
 ---
@@ -30,11 +32,11 @@ An Audience is a user segment that you can use to target users for [workflows](/
 
 <Callout
   type="beta"
-  title="Note:"
+  title="Dynamic audiences are currently in beta."
   text={
     <>
-      Dynamic audiences are currently in beta. If you'd like early access, or
-      this is blocking your adoption of Knock, please{" "}
+      If you'd like early access, or this is blocking your adoption of Knock,
+      please{" "}
       <a href="mailto:support@knock.app?subject=Dynamic audiences beta access">
         get in touch
       </a>
@@ -54,7 +56,7 @@ Navigate to the **Audiences** page under the **Recipients** section on the Knock
 
 When creating an audience, you must choose between a static or dynamic audience. You cannot change the type of audience after it has been created.
 
-### Using audiences in environments
+**Using audiences in environments**
 
 You can create an audience in any environment. For production-critical use cases, you can create an audience in your development environment, then promote it to production when you're ready to go live.
 
@@ -62,7 +64,7 @@ Changes to audiences are version controlled and can be rolled back to prior vers
 
 Learn more about [environments](/version-control/environments) and [versioning](/version-control/commits) in Knock.
 
-## Using audiences with workflows
+## Audiences and workflows
 
 ### Triggering workflows
 
@@ -107,7 +109,7 @@ Audience membership can be checked in [branch](/designing-workflows/branch-funct
   className="rounded-md mx-auto border border-gray-200"
 />
 
-## Building a dynamic audience
+## Dynamic audiences
 
 <Callout
   type="beta"
@@ -124,7 +126,20 @@ Audience membership can be checked in [branch](/designing-workflows/branch-funct
   }
 />
 
-Dynamic audiences are built by creating a set of query rules on top of the [user data in Knock](/concepts/recipients), expressed as [conditions](/concepts/conditions). You can build dynamic audiences using any of the properties available on your user objects.
+Dynamic audiences are built by creating a set of query rules on top of the [user data in Knock](/concepts/recipients), expressed as [conditions](/concepts/conditions). You can build dynamic audiences using any of the properties available on your user objects, including string, number, list, and date properties. For a full reference of supported condition types and operators, see the [conditions docs](/concepts/conditions).
+
+<Callout
+  type="info"
+  title="Reserved properties are not available for dynamic audience conditions."
+  text={
+    <>
+      The reserved <code>created_at</code> and <code>updated_at</code>{" "}
+      properties on user objects cannot be used in dynamic audience conditions.
+      If you need to filter users by these values, store them as custom
+      properties on your user objects in Knock.
+    </>
+  }
+/>
 
 Knock will automatically update the dynamic audience in real-time as the [user data](/managing-recipients/identifying-recipients) in Knock changes, moving users in and out of the audience as their properties change. These changes are known as "membership events" and are used to trigger workflows.
 
@@ -132,11 +147,27 @@ When building a dynamic audience, you will see a real-time preview of the audien
 
 All changes to the dynamic audience are [versioned](/version-control/commits) and [promoted](/version-control/commits#promoting-commits) to environments. As soon as your changes are commited or promoted, the dynamic audience will be updated in the environment and user membership will be evaluated in real-time.
 
-## Populating a static audience
+<Callout
+  type="info"
+  title="Additional filtering capabilities are coming soon."
+  text={
+    <>
+      Support for filtering by source event data and tenant or object data is on
+      the roadmap. If you're currently hitting a limitation with dynamic
+      audiences,{" "}
+      <a href="mailto:support@knock.app?subject=Dynamic audiences feedback">
+        send us your feedback
+      </a>
+      .
+    </>
+  }
+/>
+
+## Static audiences
 
 Before populating your static audience ensure that your user data has been [identified in Knock](/managing-recipients/identifying-recipients) and that you’ve configured and promoted any workflows you want to trigger with the Audience.
 
-### Supported reverse ETL vendors
+### Reverse ETL support
 
 Audiences can easily be synced from [Hightouch](/integrations/sources/hightouch#syncing-audiences-into-knock-from-hightouch) Models and [Census](/integrations/sources/census) Segments by configuring Knock as a sync destination. Click through to the integration-specific documentation for more information.
 
@@ -156,7 +187,7 @@ Note: The maximum size of a CSV upload is capped at 10MB.
 
 You can manually add existing users to an audience in the dashboard.
 
-## Using audiences with tenants
+## Audiences and tenants
 
 <Callout
   type="info"

--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -1,6 +1,6 @@
 ---
 title: Audiences
-description: Learn how to use Audiences to power your lifecycle marketing use cases.
+description: Learn how to use Audiences to power your lifecycle and transactional messaging.
 tags:
   [
     "dynamic audiences",
@@ -21,140 +21,36 @@ tags:
 section: Concepts
 ---
 
-An Audience is a user segment that you can use to target users for [workflows](/concepts/workflows), [guides](/in-app-ui/guides/overview), and [broadcasts](/concepts/broadcasts). Once you start creating audiences in Knock, you can use them to:
+An Audience is a user segment that you can use to target users for [workflows](/concepts/workflows), [guides](/in-app-ui/guides/overview), and [broadcasts](/concepts/broadcasts). Knock supports two types of audiences: static and dynamic. Dynamic audiences are maintained in real-time based on a set of defined conditions. Static audiences are mained via direct updates, either via a reverse ETL source such as Hightouch or Census, a CSV upload, the API, or manually in the Knock dashboard.
 
-- trigger workflows for lifecycle messaging (such as new user signups) and transactional messaging (such as payment method updates)
-- orchestrate branch and conditional logic within your workflows using audience membership (e.g. if a user is in a `paid users` audience, opt them out of the workflow)
-- target users for an [in-app guide](https://docs.knock.app/in-app-ui/guides/overview)
-- send a one-time message to a specific audience with a [broadcast](/concepts/broadcasts)
+Use audiences to:
 
-## Audience types
-
-<Callout
-  type="beta"
-  title="Dynamic audiences are currently in beta."
-  text={
-    <>
-      If you'd like early access, or this is blocking your adoption of Knock,
-      please{" "}
-      <a href="mailto:support@knock.app?subject=Dynamic audiences beta access">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
-There are two types of audiences in Knock:
-
-- **Static audiences.** Static audiences are created by manually adding users, either via a reverse ETL source such as Hightouch or Census, a CSV upload, the API, or manually in the Knock dashboard.
-- **Dynamic audiences.** Dynamic audiences are created through building a set of query rules on top of the [user data in Knock](/concepts/recipients).
+- [Trigger workflows](/send-notifications/triggering-workflows/audiences) for lifecycle messaging (such as new user signups) and transactional messaging (such as payment method updates).
+- Orchestrate branch and conditional logic within your workflows using audience membership (e.g. if a user is in a `paid users` audience, opt them out of the workflow).
+- Target users for an [in-app guide](https://docs.knock.app/in-app-ui/guides/overview).
+- Send a one-time message to a specific audience with a [broadcast](/concepts/broadcasts).
 
 ## Creating an audience
 
-Navigate to the **Audiences** page under the **Recipients** section on the Knock dashboard’s sidebar, then click “Create Audience” in the top right corner.
+To create an audience, navigate to the **Audiences** page under the **Recipients** section on the Knock dashboard’s sidebar, then click “Create Audience” in the top right corner. Determine whether the audience will be dynamic or static. Audience types cannot be changed after creation.
 
-When creating an audience, you must choose between a static or dynamic audience. You cannot change the type of audience after it has been created.
+### Dynamic audiences
 
-**Using audiences in environments**
-
-You can create an audience in any environment. For production-critical use cases, you can create an audience in your development environment, then promote it to production when you're ready to go live.
-
-Changes to audiences are version controlled and can be rolled back to prior versions.
-
-Learn more about [environments](/version-control/environments) and [versioning](/version-control/commits) in Knock.
-
-## Audiences and workflows
-
-### Triggering workflows
-
-Workflows can be configured to trigger for every new member added to an audience.
-
-Create or open the workflow you’d like to trigger for your audience, then open the workflow editor. Click on the “Trigger” step, then click “Edit trigger type” in the top right corner. Click “Audience“ and then select the audience you’d like this workflow to trigger from.
-
-<Image
-  src="/images/concepts/audiences/audience-trigger-type-config.png"
-  height={1846}
-  width={1330}
-  alt="Audience trigger type config in the workflow editor"
-  className="rounded-md border border-gray-200"
-/>
-
-Commit your workflow to your current environment. At this point, every time a user is added to the selected audience a workflow will be triggered with that user as a recipient.
-
-<Callout
-  type="info"
-  title="Remember: audiences are environment scoped."
-  isCentered
-  text={
-    <>
-      This means the workflow will run in the environment where the user was
-      added to the audience. If you use a production API key to add users to an
-      audience in production, your workflow will trigger in the production
-      environment.{" "}
-      <a href="/concepts/environments">Learn more about environments.</a>
-    </>
-  }
-/>
-
-### Audience conditions
-
-Audience membership can be checked in [branch](/designing-workflows/branch-function#adding-conditions-to-branches) and [step conditions](/designing-workflows/step-conditions). Create a condition, then select “Audience membership” as the type. When the condition is evaluated during workflow execution it will check if the recipient is a member of the selected audience.
-
-<Image
-  src="/images/concepts/audiences/condition-config.png"
-  alt="Audience condition type config in the workflow editor"
-  width={500}
-  height={334}
-  className="rounded-md mx-auto border border-gray-200"
-/>
-
-## Dynamic audiences
-
-<Callout
-  type="beta"
-  title="Note:"
-  text={
-    <>
-      Dynamic audiences are currently in beta. If you'd like early access, or
-      this is blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Dynamic audiences beta access">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
-Dynamic audiences are built by creating a set of query rules on top of the [user data in Knock](/concepts/recipients), expressed as [conditions](/concepts/conditions). You can build dynamic audiences using any of the properties available on your user objects, including string, number, list, and date properties. For a full reference of supported condition types and operators, see the [conditions docs](/concepts/conditions).
-
-<Callout
-  type="info"
-  title="Reserved properties are not available for dynamic audience conditions."
-  text={
-    <>
-      The reserved <code>created_at</code> and <code>updated_at</code>{" "}
-      properties on user objects cannot be used in dynamic audience conditions.
-      If you need to filter users by these values, store them as custom
-      properties on your user objects in Knock.
-    </>
-  }
-/>
+Dynamic audiences are built by creating a set of query rules on top of the [user data in Knock](/concepts/recipients), expressed as [conditions](/concepts/conditions). You can build dynamic audiences using the properties available on your user objects. For a full reference of supported condition types and operators, see the [conditions docs](/concepts/conditions).
 
 Knock will automatically update the dynamic audience in real-time as the [user data](/managing-recipients/identifying-recipients) in Knock changes, moving users in and out of the audience as their properties change. These changes are known as "membership events" and are used to trigger workflows.
 
-When building a dynamic audience, you will see a real-time preview of the audience members that match the query rules you've created on the right side of the screen. Remember, these are **users in the current environment** that match the query rules you've created.
+When building a dynamic audience, you will see a real-time preview of the audience members that match the query rules you’ve created on the right side of the screen. Remember, these are **users in the current environment** that match the query rules you’ve created.
 
-All changes to the dynamic audience are [versioned](/version-control/commits) and [promoted](/version-control/commits#promoting-commits) to environments. As soon as your changes are commited or promoted, the dynamic audience will be updated in the environment and user membership will be evaluated in real-time.
+Changes to dynamic audience are [versioned](/version-control/commits) and [promoted](/version-control/commits#promoting-commits) to environments. These changes must be made in your environment's `main` [branch](/version-control/branches).
 
 <Callout
   type="info"
   title="Additional filtering capabilities are coming soon."
   text={
     <>
-      Support for filtering by source event data and tenant or object data is on
-      the roadmap. If you're currently hitting a limitation with dynamic
-      audiences,{" "}
+      Support for filtering by event data and tenant or object data is on the
+      roadmap. If you’re currently hitting a limitation with dynamic audiences,{" "}
       <a href="mailto:support@knock.app?subject=Dynamic audiences feedback">
         send us your feedback
       </a>
@@ -163,39 +59,22 @@ All changes to the dynamic audience are [versioned](/version-control/commits) an
   }
 />
 
-## Static audiences
+### Static audiences
 
-Before populating your static audience ensure that your user data has been [identified in Knock](/managing-recipients/identifying-recipients) and that you’ve configured and promoted any workflows you want to trigger with the Audience.
+Static audiences are populated by adding users directly. You can populate a static audience in four ways:
 
-### Reverse ETL support
+- **Reverse ETL support.** Audiences can easily be synced from [Hightouch](/integrations/sources/hightouch#syncing-audiences-into-knock-from-hightouch) Models and [Census](/integrations/sources/census) Segments by configuring Knock as a sync destination. Click through to the integration-specific documentation for more information.
+- **Audiences API.** The Knock API can be used to sync audiences from any data warehouse or reverse ETL system. Create the audience in the Knock dashboard, then use the add and remove API operations to power your sync. The API is designed for batch processing and accepts payloads of up to 1,000 members at a time. For more information see the [audiences API docs](/api-reference/audiences).
+- **CSV upload.** You can upload a CSV of users to an audience. After uploading your CSV, you can map the CSV fields to the corresponding user fields in Knock. Knock will upsert the users as they are added to the audience and skip any users with malformed or missing IDs. The maximum size of a CSV upload is capped at 10MB.
+- **Manually.** You can manually add existing users to an audience in the dashboard.
 
-Audiences can easily be synced from [Hightouch](/integrations/sources/hightouch#syncing-audiences-into-knock-from-hightouch) Models and [Census](/integrations/sources/census) Segments by configuring Knock as a sync destination. Click through to the integration-specific documentation for more information.
+## Audiences and workflows
 
-### Audiences API
-
-The Knock API can be used to sync audiences from any data warehouse or reverse ETL system. Create the audience in the Knock dashboard, then use the add and remove API operations to power your sync.
-
-The API is designed for batch processing and accepts payloads of up to 1,000 members at a time. For more information see the [audiences API docs](/api-reference/audiences).
-
-### CSV upload
-
-You can upload a CSV of users to an audience. After uploading your CSV, you can map the CSV fields to the corresponding user fields in Knock. Knock will upsert the users as they are added to the audience and skip any users with malformed or missing IDs.
-
-Note: The maximum size of a CSV upload is capped at 10MB.
-
-### Manually
-
-You can manually add existing users to an audience in the dashboard.
+Audiences integrate with workflows in two key ways. You can configure a workflow to [trigger automatically whenever a user enters an audience](/send-notifications/triggering-workflows/audiences), enabling event-driven lifecycle messaging without additional API calls. You can also use audience membership as a condition in [branch](/designing-workflows/branch-function) and [step conditions](/designing-workflows/step-conditions) to gate logic based on which audiences a user belongs to at the time of execution.
 
 ## Audiences and tenants
 
-<Callout
-  type="info"
-  title="Note:"
-  text="Tenant targeting is currently only supported for static audiences."
-/>
-
-When adding users to an audience you can optionally include a tenant ID to power per-user, per-tenant workflows. A user can exist in an audience with multiple distinct tenants.
+enant targeting is currently only supported for static audiences. When adding users to static audience you can optionally include a tenant ID to power per-user, per-tenant workflows. A user can exist in an audience with multiple distinct tenants.
 
 <Image
   src="/images/concepts/audiences/audience-member-with-multiple-tenant-ids.png"
@@ -208,6 +87,8 @@ When adding users to an audience you can optionally include a tenant ID to power
 When a workflow triggers from an audience entry event, the tenant ID provided for the member will be passed along to the workflow trigger. If no tenant ID is provided in the API request, the workflow will run with no tenant data. If the same user is added with multiple distinct tenants, the workflow will trigger each time by default. To configure this behavior use [trigger frequency](/send-notifications/triggering-workflows#controlling-workflow-trigger-frequency) controls.
 
 Tenancy is also taken into account when checking audience membership. For a recipient to be considered a member of an audience during workflow execution, the tenant ID provided with the trigger data must match the user’s audience membership record. If no tenant ID was provided with the trigger, the user must have been added to the audience with no tenant ID.
+
+For more information about how audience membership is evaluated for guides eligibility, see the [guides documentation](/in-app-ui/guides/overview#working-with-tenants).
 
 ## Frequently asked questions
 
@@ -232,6 +113,9 @@ Tenancy is also taken into account when checking audience membership. For a reci
   </Accordion>
   <Accordion title="Can I use audiences on a branch?">
     While you can use an audience on a development [branch](/version-control/branches) to power workflows, broadcasts, and guides, you cannot make changes to an audience on a branch. You can only make changes to an audience on the main branch.
+  </Accordion>
+  <Accordion title="Are all user properties available in the audience builder?">
+    The reserved `created_at` and `updated_at` properties on user objects cannot be used in dynamic audience conditions. If you need to filter users by these values, store them as custom properties on your user objects in Knock.
   </Accordion>
   <Accordion title="How can I remove users from a static audience?">
     Users can be removed from a static audience in one of three ways:

--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -32,7 +32,7 @@ Use audiences to:
 
 ## Creating an audience
 
-To create an audience, navigate to the **Audiences** page under the **Recipients** section on the Knock dashboard’s sidebar, then click “Create Audience” in the top right corner. Determine whether the audience will be dynamic or static. Audience types cannot be changed after creation.
+To create an audience, navigate to the **Audiences** page under the **Recipients** section on the Knock dashboard’s sidebar, then click “Create audience” in the top right corner. Determine whether the audience will be dynamic or static. Audience types cannot be changed after creation.
 
 ### Dynamic audiences
 

--- a/content/concepts/audiences.mdx
+++ b/content/concepts/audiences.mdx
@@ -74,7 +74,7 @@ Audiences integrate with workflows in two key ways. You can configure a workflow
 
 ## Audiences and tenants
 
-enant targeting is currently only supported for static audiences. When adding users to static audience you can optionally include a tenant ID to power per-user, per-tenant workflows. A user can exist in an audience with multiple distinct tenants.
+When adding users to static audience you can optionally include a tenant ID to power per-user, per-tenant workflows. A user can exist in an audience with multiple distinct tenants. Currently, tenant targeting is only supported for static audiences, but support for dynamic audiences is coming soon.
 
 <Image
   src="/images/concepts/audiences/audience-member-with-multiple-tenant-ids.png"

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -143,8 +143,8 @@ You can use any of the following operators in condition comparisons:
 
     | Example condition | Evaluation |
     | --- | --- |
-    | `plan is equal_to pro` where `plan` is `pro` |  true |
-    | `plan is equal_to free` where `plan` is `free` |  false |
+    | `plan is equal_to pro` where `plan` is `"pro"` |  true |
+    | `plan is equal_to free` where `plan` is `"free"` |  false |
 
   </Accordion>
   <Accordion title="`not_equal_to`">
@@ -152,8 +152,8 @@ You can use any of the following operators in condition comparisons:
 
     | Example condition | Evaluation |
     | --- | --- |
-    | `plan is not_equal_to pro` where `plan` is `free` | true |
-    | `plan is not_equal_to pro` where `plan` is `pro` | false |
+    | `plan is not_equal_to pro` where `plan` is `"free"` | true |
+    | `plan is not_equal_to pro` where `plan` is `"pro"` | false |
 
   </Accordion>
   <Accordion title="`greater_than`">
@@ -238,7 +238,7 @@ You can use any of the following operators in condition comparisons:
     | Example condition | Evaluation |
     | --- | --- |
     | `name is empty` where `name` is `""` | true |
-    | `name is empty` where `name` is `alice` | false |
+    | `name is empty` where `name` is `"alice"` | false |
 
   </Accordion>
   <Accordion title="`not_empty`">
@@ -246,26 +246,28 @@ You can use any of the following operators in condition comparisons:
 
     | Example condition | Evaluation |
     | --- | --- |
-    | `name is not_empty` where `name` is `alice` | true |
+    | `name is not_empty` where `name` is `"alice"` | true |
     | `name is not_empty` where `name` is `""` | false |
 
   </Accordion>
   <Accordion title="`exists`">
-    True if the variable is set and not `null`. No argument needed.
+    True if the variable is set and not `null`. No argument needed. Note that a property set to an empty string or empty array is evaluated as existing. Use `not_empty` if you want to check for a meaningful value.
 
     | Example condition | Evaluation |
     | --- | --- |
-    | `metadata.plan exists` where `metadata.plan` is `pro` | true |
-    | `metadata.plan exists` where `metadata.plan` is `null` | false |
+    | `plan exists` where `plan` is `"pro"` | true |
+    | `plan exists` where `plan` is `""` | true |
+    | `plan exists` where `plan` is `null` | false |
 
   </Accordion>
   <Accordion title="`not_exists`">
-    True if the variable is not set or is `null`. No argument needed.
+    True if the variable is not set or is `null`. No argument needed. Note that a property set to an empty string or empty array is evaluated as not existing. Use `empty` if you want to check for a missing or empty value.
 
     | Example condition | Evaluation |
     | --- | --- |
-    | `metadata.plan not_exists` where `metadata.plan` is `null` | true |
-    | `metadata.plan not_exists` where `metadata.plan` is `pro` | false |
+    | `plan not_exists` where `plan` is `null` | true |
+    | `plan not_exists` where `plan` is `"pro"` | false |
+    | `plan not_exists` where `plan` is `""` | false |
 
   </Accordion>
   <Accordion title="`is_timestamp_before`">

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -91,7 +91,7 @@ Static arguments can be any of the following JSON literals:
 - Booleans (`true`, `false`)
 - `null`
 
-Plus arrays of any of the above.
+Plus lists of any of the above.
 
 #### Dynamic arguments
 
@@ -193,11 +193,11 @@ You can use any of the following operators in condition comparisons:
 
   </Accordion>
   <Accordion title="`contains`">
-True if the argument appears in the variable. 
-- When one value is text and one is a list, true if the text is an item in the list. 
-- When both values are text, true if the argument is a substring of the variable. 
-- When both values are lists, true if they share any items in common. To check whether one list fully contains the other, use `contains_all`.
+    True if the argument appears in the variable.
 
+    - When one value is text and one is a list, true if the text is an item in the list.
+    - When both values are text, true if the argument is a substring of the variable.
+    - When both values are lists, true if they share any items in common. To check whether one list fully contains the other, use `contains_all`.
 
     | Example condition                                            | Evaluation |
     | ------------------------------------------------------------ | ---------- |
@@ -219,7 +219,7 @@ True if the argument appears in the variable.
 
   </Accordion>
   <Accordion title="`contains_all`">
-    True if all argument values are present in the variable. Arrays only.
+    True if all argument values are present in the variable. Lists only.
 
     | Example condition | Evaluation |
     | --- | --- |
@@ -228,7 +228,7 @@ True if the argument appears in the variable.
 
   </Accordion>
   <Accordion title="`not_contains_all`">
-    True if not all argument values are present in the variable. Arrays only.
+    True if not all argument values are present in the variable. Lists only.
 
     | Example condition | Evaluation |
     | --- | --- |
@@ -255,7 +255,7 @@ True if the argument appears in the variable.
 
   </Accordion>
   <Accordion title="`exists`">
-    True if the variable is set and not `null`. No argument needed. Note that a property set to an empty string or empty array is evaluated as existing. Use `not_empty` if you want to check for a meaningful value.
+    True if the variable is set and not `null`. No argument needed. Note that a property set to an empty string or empty list is evaluated as existing. Use `not_empty` if you want to check for a meaningful value.
 
     | Example condition | Evaluation |
     | --- | --- |
@@ -265,7 +265,7 @@ True if the argument appears in the variable.
 
   </Accordion>
   <Accordion title="`not_exists`">
-    True if the variable is not set or is `null`. No argument needed. Note that a property set to an empty string or empty array is evaluated as not existing. Use `empty` if you want to check for a missing or empty value.
+    True if the variable is not set or is `null`. No argument needed. Note that a property set to an empty string or empty list is evaluated as not existing. Use `empty` if you want to check for a missing or empty value.
 
     | Example condition | Evaluation |
     | --- | --- |

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -137,36 +137,165 @@ The timestamp operators (`is_timestamp_before`, `is_timestamp_on_or_after`, and 
 
 You can use any of the following operators in condition comparisons:
 
-| Operator                   | Description                                                                                                                                         |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `equal_to`                 | `==`                                                                                                                                                |
-| `not_equal_to`             | `!=`                                                                                                                                                |
-| `greater_than`             | `>`                                                                                                                                                 |
-| `greater_than_or_equal_to` | `>=`                                                                                                                                                |
-| `less_than`                | `<`                                                                                                                                                 |
-| `less_than_or_equal_to`    | `<=`                                                                                                                                                |
-| `contains`                 | Checks whether `argument` is in `variable` (works with strings and lists)                                                                           |
-| `contains_all`             | Checks whether all `argument` values are present in `variable` (for comparing lists)                                                                |
-| `not_contains`             | Checks whether `argument` is not in `variable` (works with strings and lists)                                                                       |
-| `not_contains_all`         | Checks whether all `argument` values are not present in `variable` (for comparing lists)                                                            |
-| `empty`                    | Checks whether `variable` is in `["", null, []]`. If the variable is not provided at the path, Knock treats it as empty, so this returns true.      |
-| `not_empty`                | Checks whether `variable` is not in `["", null, []]`. If the variable is not provided at the path, Knock treats it as empty, so this returns false. |
-| `exists`                   | Checks whether `variable` is provided and has a value that is not `null`                                                                            |
-| `not_exists`               | Checks whether `variable` is not provided or has a `null` value                                                                                     |
-| `is_timestamp_before`      | Checks whether `variable` is a timestamp before the `argument` value                                                                                |
-| `is_timestamp_on_or_after` | Checks whether `variable` is a timestamp on or after the `argument` value                                                                           |
-| `is_timestamp_between`     | Checks whether `variable` is a timestamp between the `argument`'s start and end values                                                              |
+<AccordionGroup>
+  <Accordion title="`equal_to`">
+    True if the variable equals the argument (`==`).
 
-<Callout
-  type="info"
-  text={
-    <>
-      The <code>empty</code>, <code>not_empty</code>, <code>exists</code>, and{" "}
-      <code>not_exists</code> operators do not require an argument value. Knock
-      checks for the absence of data at the variable path.
-    </>
-  }
-/>
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `plan is equal_to pro` where `plan` is `pro` |  true |
+    | `plan is equal_to free` where `plan` is `free` |  false |
+
+  </Accordion>
+  <Accordion title="`not_equal_to`">
+    True if the variable does not equal the argument (`!=`).
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `plan is not_equal_to pro` where `plan` is `free` | true |
+    | `plan is not_equal_to pro` where `plan` is `pro` | false |
+
+  </Accordion>
+  <Accordion title="`greater_than`">
+    True if the variable is greater than the argument (`>`).
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `age is greater_than 18` where `age` is `21` | true |
+    | `age is greater_than 18` where `age` is `18` | false |
+
+  </Accordion>
+  <Accordion title="`greater_than_or_equal_to`">
+    True if the variable is greater than or equal to the argument (`>=`).
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `age is greater_than_or_equal_to 18` where `age` is `18` | true |
+    | `age is greater_than_or_equal_to 18` where `age` is `17` | false |
+
+  </Accordion>
+  <Accordion title="`less_than`">
+    True if the variable is less than the argument (`<`).
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `score is less_than 50` where `score` is `49` | true |
+    | `score is less_than 50` where `score` is `50` | false |
+
+  </Accordion>
+  <Accordion title="`less_than_or_equal_to`">
+    True if the variable is less than or equal to the argument (`<=`).
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `score is less_than_or_equal_to 50` where `score` is `50` | true |
+    | `score is less_than_or_equal_to 50` where `score` is `51` | false |
+
+  </Accordion>
+  <Accordion title="`contains`">
+    True if the argument appears in the variable. For text, checks whether the argument is a substring of the variable. For lists, checks whether the argument is an item in the list. When both values are lists, true if they share any items in common. To check whether one list fully contains the other, use `contains_all`.
+
+    | Example condition                                            | Evaluation |
+    | ------------------------------------------------------------ | ---------- |
+    | `role contains engineer` where `role` is `"senior engineer"` | true       |
+    | `role contains engineer` where `role` is `"designer"`    | false      |
+    | `tags contains vip` where `tags` is `["vip", "beta"]`    | true       |
+    | `tags contains vip` where `tags` is `["beta"]`           | false      |
+
+  </Accordion>
+  <Accordion title="`not_contains`">
+    True if the argument does not appear in the variable. For text, checks whether the argument is not a substring of the variable. For lists, checks whether the argument is not an item in the list. When both values are lists, true if they share no items in common.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `role not_contains engineer` where `role` is `"designer"` | true |
+    | `role not_contains engineer` where `role` is `"senior engineer"` | false |
+    | `tags not_contains vip` where `tags` is `["beta"]` | true |
+    | `tags not_contains vip` where `tags` is `["vip", "beta"]` | false |
+
+  </Accordion>
+  <Accordion title="`contains_all`">
+    True if all argument values are present in the variable. Arrays only.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `roles contains_all ["admin", "editor"]` where `roles` is `["admin", "editor", "viewer"]` | true |
+    | `roles contains_all ["admin", "editor"]` where `roles` is `["admin"]` | false |
+
+  </Accordion>
+  <Accordion title="`not_contains_all`">
+    True if not all argument values are present in the variable. Arrays only.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `roles not_contains_all ["admin", "editor"]` where `roles` is `["admin"]` | true |
+    | `roles not_contains_all ["admin", "editor"]` where `roles` is `["admin", "editor"]` | false |
+
+  </Accordion>
+  <Accordion title="`empty`">
+    True if the variable is `""`, `null`, `[]`, or not set. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `name is empty` where `name` is `""` | true |
+    | `name is empty` where `name` is `alice` | false |
+
+  </Accordion>
+  <Accordion title="`not_empty`">
+    True if the variable has a non-empty, non-null value. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `name is not_empty` where `name` is `alice` | true |
+    | `name is not_empty` where `name` is `""` | false |
+
+  </Accordion>
+  <Accordion title="`exists`">
+    True if the variable is set and not `null`. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `metadata.plan exists` where `metadata.plan` is `pro` | true |
+    | `metadata.plan exists` where `metadata.plan` is `null` | false |
+
+  </Accordion>
+  <Accordion title="`not_exists`">
+    True if the variable is not set or is `null`. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `metadata.plan not_exists` where `metadata.plan` is `null` | true |
+    | `metadata.plan not_exists` where `metadata.plan` is `pro` | false |
+
+  </Accordion>
+  <Accordion title="`is_timestamp_before`">
+    True if the variable timestamp is before the argument.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `trial_ends_at is is_timestamp_before 7 days from now` where `trial_ends_at` is `5 days from now` | true |
+    | `trial_ends_at is is_timestamp_before 7 days from now` where `trial_ends_at` is `10 days from now` | false |
+
+  </Accordion>
+  <Accordion title="`is_timestamp_on_or_after`">
+    True if the variable timestamp is on or after the argument.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `activated_at is is_timestamp_on_or_after 30 days ago` where `activated_at` is `10 days ago` | true |
+    | `activated_at is is_timestamp_on_or_after 30 days ago` where `activated_at` is `60 days ago` | false |
+
+  </Accordion>
+  <Accordion title="`is_timestamp_between`">
+    True if the variable timestamp falls between the argument's start and end values. Does not support relative timestamps — use absolute dates or dynamic variables.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `created_at is is_timestamp_between ["2025-01-01", "2025-12-31"]` where `created_at` is `2025-06-15` | true |
+    | `created_at is is_timestamp_between ["2025-01-01", "2025-12-31"]` where `created_at` is `2024-12-31` | false |
+
+  </Accordion>
+</AccordionGroup>
 
 ### Conditions scope
 

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -193,7 +193,11 @@ You can use any of the following operators in condition comparisons:
 
   </Accordion>
   <Accordion title="`contains`">
-    True if the argument appears in the variable. For text, checks whether the argument is a substring of the variable. For lists, checks whether the argument is an item in the list. When both values are lists, true if they share any items in common. To check whether one list fully contains the other, use `contains_all`.
+True if the argument appears in the variable. 
+- When one value is text and one is a list, true if the text is an item in the list. 
+- When both values are text, true if the argument is a substring of the variable. 
+- When both values are lists, true if they share any items in common. To check whether one list fully contains the other, use `contains_all`.
+
 
     | Example condition                                            | Evaluation |
     | ------------------------------------------------------------ | ---------- |

--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -144,7 +144,7 @@ You can use any of the following operators in condition comparisons:
     | Example condition | Evaluation |
     | --- | --- |
     | `plan is equal_to pro` where `plan` is `"pro"` |  true |
-    | `plan is equal_to free` where `plan` is `"free"` |  false |
+    | `plan is equal_to pro` where `plan` is `"free"` |  false |
 
   </Accordion>
   <Accordion title="`not_equal_to`">
@@ -265,7 +265,7 @@ You can use any of the following operators in condition comparisons:
 
   </Accordion>
   <Accordion title="`not_exists`">
-    True if the variable is not set or is `null`. No argument needed. Note that a property set to an empty string or empty list is evaluated as not existing. Use `empty` if you want to check for a missing or empty value.
+    True if the variable is not set or is `null`. No argument needed. Note that a property set to an empty string or empty list is evaluated as existing. Use `empty` if you want to check for a missing or empty value.
 
     | Example condition | Evaluation |
     | --- | --- |

--- a/content/in-app-ui/flutter/sdk/quick-start.mdx
+++ b/content/in-app-ui/flutter/sdk/quick-start.mdx
@@ -62,15 +62,13 @@ knock.dispose();
       </a>
       ), obtain the device token in your app, then register it with <a href="/in-app-ui/flutter/sdk/reference#registertokenforchannel">
         <code>registerTokenForChannel</code>
-      </a>. See the README{" "}
-      <a
+      </a>. See the README <a
         href="https://github.com/knocklabs/knock-flutter/blob/main/README.md#push-notifications"
         target="_blank"
         rel="noopener"
       >
         push notifications
-      </a>{" "}
-      section for patterns and caveats.
+      </a> section for patterns and caveats.
     </>
   }
 />

--- a/content/send-notifications/triggering-workflows/audiences.mdx
+++ b/content/send-notifications/triggering-workflows/audiences.mdx
@@ -5,17 +5,36 @@ tags: ["trigger", "audience"]
 section: Send notifications
 ---
 
-Audience workflow triggers execute a workflow run when a user joins a specific audience.
+[Audience](/concepts/audiences) workflow triggers execute a workflow run when a user joins a specific audience. An audience consists of users who share a common characteristic, such as users on a paid plan or users who made a purchase in the past 30 days.
 
-An audience consists of users who share a common characteristic, such as users on a paid plan or users who made a purchase in the past 30 days.
-
-To use audience triggers, you need an [audience](/concepts/audiences) created in Knock. Create an audience in the "Audiences" section of the dashboard.
+To use audience triggers, you need an audience created in Knock. [Create an audience](/concepts/audiences#creating-an-audience) in the **Audiences** section of the dashboard.
 
 ## Configuring an audience trigger
 
-Configure an audience trigger by selecting "Audience" trigger type in the workflow builder and selecting your target audience.
+Create or open the workflow you'd like to trigger for your audience, then open the workflow editor. Click on the "Trigger" step, then click "Edit trigger type" in the top right corner. Click "Audience" and then select the audience you'd like this workflow to trigger from.
 
-Remember: you must have an audience created in Knock before you can use it to trigger workflows.
+<Image
+  src="/images/concepts/audiences/audience-trigger-type-config.png"
+  height={1846}
+  width={1330}
+  alt="Audience trigger type config in the workflow editor"
+/>
+
+Commit your workflow to your current environment. At this point, every time a user is added to the selected audience a workflow will be triggered with that user as a recipient.
+
+<Callout
+  type="info"
+  title="Audiences are environment scoped."
+  isCentered
+  text={
+    <>
+      The workflow will run in the environment where the user was added to the
+      audience. If you use a production API key to add users to an audience in
+      production, your workflow will trigger in the production environment.{" "}
+      <a href="/concepts/environments">Learn more about environments.</a>
+    </>
+  }
+/>
 
 ## Frequently asked questions
 


### PR DESCRIPTION
### Summary
- Migrates dynamic audiences documentation from internal Notion doc to public docs.
- Significantly restructures `content/concepts/audiences.mdx` for clarity and flow, elevating visibility of dynamic audiences. 
- Expands `content/send-notifications/triggering-workflows/audiences.mdx` with setup instructions previously missing and remove duplicative content from `content/concepts/audiences.mdx`
- Rewrites and restructures `content/concepts/conditions.mdx` operators section for usability

### Changes
#### `content/concepts/audiences.mdx`
  - Collapsed separate `## Dynamic audiences` and `## Static audiences` top-level sections into `###` subsections under a unified `## Creating audiences` section
  - Added FAQ entry about property limitation: "Are all user properties available in the audience builder?"
  - Converted the static audience population methods into a bold-intro bullet list
  - Collapsed `## Audiences and workflows` subsections into a single paragraph linking out to the triggering workflows and step conditions pages
  - Removed stale references about needing to identify users before creating audiences
  - Removed beta callouts 

#### `content/send-notifications/triggering-workflows/audiences.mdx`
  - Added audience trigger configuration instructions / content here from concepts page

#### `content/concepts/conditions.mdx`
  - Replaced flat operators table with accordions, each with a plain-English description and an "Example condition / Evaluation" table
  - Added missing `is_between` numeric range operator (present in UI but undocumented)
  - `contains`, `not_contains`, `exists`, `not_exists`, `empty`, and `not_empty`: added additional context based on recent confusion