### PR TITLE
chore(KNO-12965): Move deduplication by default up on subscriptions page

### DIFF
--- a/content/concepts/subscriptions.mdx
+++ b/content/concepts/subscriptions.mdx
@@ -90,6 +90,13 @@ await knock.workflows.trigger("alert-workflow", {
 });
 ```
 
+#### Deduplication by default
+
+Knock always deduplicates recipients when executing a notification fan out, including for workflow triggers with subscriptions. Knock will ensure your notification workflow is executed only once for each unique recipient in the following cases:
+
+- When the recipient appears both in the initial trigger and as a subscriber to one of your objects.
+- When the recipient appears multiple times within a nested subscription hierarchy.
+
 ### Retrieving subscriptions for an object
 
 You can retrieve a paginated list of subscriptions for an object, which will return the `recipient` subscribed as well.
@@ -172,13 +179,6 @@ Once you've established a nested hierarchy like the above, it's also possible to
     </>
   }
 />
-
-## Deduplication by default
-
-Knock always deduplicates recipients when executing a notification fan out, including for workflow triggers with subscriptions. Knock will ensure your notification workflow is executed only once for each unique recipient in the following cases:
-
-- When the recipient appears both in the initial trigger and as a subscriber to one of your objects.
-- When the recipient appears multiple times within a nested subscription hierarchy.
 
 ## Frequently asked questions
 

--- a/content/in-app-ui/flutter/sdk/quick-start.mdx
+++ b/content/in-app-ui/flutter/sdk/quick-start.mdx
@@ -62,15 +62,13 @@ knock.dispose();
       </a>
       ), obtain the device token in your app, then register it with <a href="/in-app-ui/flutter/sdk/reference#registertokenforchannel">
         <code>registerTokenForChannel</code>
-      </a>. See the README{" "}
-      <a
+      </a>. See the README <a
         href="https://github.com/knocklabs/knock-flutter/blob/main/README.md#push-notifications"
         target="_blank"
         rel="noopener"
       >
         push notifications
-      </a>{" "}
-      section for patterns and caveats.
+      </a> section for patterns and caveats.
     </>
   }
 />


### PR DESCRIPTION
### Description

Received customer feedback that this was previously a bit buried on the subscriptions page. This PR moves the deduplication by default information up and under the "Triggering a workflow for all subscribers" section. 

https://docs-git-rt-kno-12965-move-dedeup-info-knocklabs.vercel.app/concepts/subscriptions#deduplication-by-default

### Tasks

[KNO-12965](https://linear.app/knock/issue/KNO-12965/docs-surface-deduplication-behavior-on-subscriptions-page-and-clarify)
