### PR TITLE
docs: clarify that event-triggered workflows can still be triggered via API

### DIFF
--- a/content/send-notifications/triggering-workflows/events.mdx
+++ b/content/send-notifications/triggering-workflows/events.mdx
@@ -22,6 +22,13 @@ From the Trigger step sidebar, if you have events connected to Knock you'll see 
 ## Frequently asked questions
 
 <AccordionGroup>
+  <Accordion title="Can I still trigger a workflow via API if it has an event trigger configured?">
+    Yes. Configuring an event trigger does not prevent you from triggering the
+    workflow via the [API](/send-notifications/triggering-workflows/api). Both
+    trigger methods work independently, so you can use event triggers to
+    automate notifications from external sources while still calling the API
+    directly when needed.
+  </Accordion>
   <Accordion title="Can I trigger a workflow for multiple recipients from a single event?">
     Yes, it's possible to override the default behavior of a source event
     trigger to point the trigger to a property on the event that resolves to a

--- a/content/send-notifications/triggering-workflows/overview.mdx
+++ b/content/send-notifications/triggering-workflows/overview.mdx
@@ -12,6 +12,8 @@ Knock executes workflow runs when workflows are triggered. A workflow can be tri
 - On a [recurring, or one-off schedule](/send-notifications/triggering-workflows/schedules)
 - When a user becomes [a member of an audience](/send-notifications/triggering-workflows/audiences)
 
+These trigger methods are not mutually exclusive. For example, a workflow with an event trigger configured can still be triggered via the API, and vice versa.
+
 <Callout
   type="info"
   title="Note:"


### PR DESCRIPTION
### Description

This PR clarifies that workflows with event triggers configured can still be triggered via the API. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Screenshots

**Events page FAQ (expanded):**
[Events page FAQ showing the answer that configuring an event trigger does not prevent API triggering](https://cursor.com/agents/bc-ceaa4e9a-f3ec-488d-8b55-aa88ba6cc3ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevents_faq_api_trigger.webp)

**Overview page with clarifying text:**
[Overview page showing the clarifying text that trigger methods are not mutually exclusive](https://cursor.com/agents/bc-ceaa4e9a-f3ec-488d-8b55-aa88ba6cc3ec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview_trigger_methods.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13025](https://linear.app/knock/issue/KNO-13025/this-is-an-incorrect-answer-iirc-api-trigger-still-works-when-an-event)

<div><a href="https://cursor.com/agents/bc-ceaa4e9a-f3ec-488d-8b55-aa88ba6cc3ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceaa4e9a-f3ec-488d-8b55-aa88ba6cc3ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

