### PR TITLE
fix(kno-11552): undefined breadcrumbs

### DIFF
--- a/lib/content.ts
+++ b/lib/content.ts
@@ -37,16 +37,18 @@ export function getInAppSidebar(
         title: selectedSdkContent.title,
         path: `/in-app-ui/${selectedSdkContent.value}`,
       },
-      {
-        slug: `${section?.slug}`,
-        title: section?.title,
-        path: `${section?.slug}`,
-      },
-      {
-        slug: `${section?.slug}${page?.slug}`,
-        title: page?.title,
-        path: `${section?.slug}${page?.slug}`,
-      },
+      ...(section?.slug && section?.title
+        ? [{ slug: section.slug, title: section.title, path: section.slug }]
+        : []),
+      ...(section?.slug && page?.slug && page?.title
+        ? [
+            {
+              slug: `${section.slug}${page.slug}`,
+              title: page.title,
+              path: `${section.slug}${page.slug}`,
+            },
+          ]
+        : []),
     ],
   };
 }


### PR DESCRIPTION
### Description

Certain nested pages in our docs are show `undefined` and `undefinedundefined` in the breadcrumbs rather than the actual path of the pages. Some examples:

- /in-app-ui/android/sdk/overview
- /in-app-ui/android/sdk/quick-start
- /in-app-ui/android/components

**Here's what it looks like:**
<img width="550" alt="image" src="https://github.com/user-attachments/assets/145317ee-54a0-4574-8370-4d80bd06e5e1" />
<br/>
This fix prevents "undefined" strings from appearing in breadcrumbs. Previously, `getInAppSidebar` always returned 4 breadcrumb items, even when `section` or `page` weren't found — template literals like `${section?.slug}` would produce the string `"undefined"` rather than nothing. The fix conditionally spreads the section and page breadcrumb entries only when their `slug` and `title` are actually defined.

**With the update:**
<img width="550" alt="image" src="https://github.com/user-attachments/assets/cfe1a428-0984-4c6a-a86a-4ae54d5daf1b" />
