### PR TITLE
fix(kno-13053): update JSX attribute descriptions to markdown strings

### DIFF
--- a/content/in-app-ui/expo/sdk/reference.mdx
+++ b/content/in-app-ui/expo/sdk/reference.mdx
@@ -33,19 +33,7 @@ Accepts `KnockProviderProps`
   <Attribute
     name="userToken"
     type="string"
-    description={
-      <span>
-        A JWT that identifies the authenticated user, signed with the private
-        key provided in the Knock dashboard. Required to secure your production
-        environment.{" "}
-        <a
-          href="https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security"
-          target="_blank"
-        >
-          Learn more.
-        </a>
-      </span>
-    }
+    description="A JWT that identifies the authenticated user, signed with the private key provided in the Knock dashboard. Required to secure your production environment. [Learn more.](https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security)"
   />
   <Attribute
     name="host"

--- a/content/in-app-ui/react-native/sdk/reference.mdx
+++ b/content/in-app-ui/react-native/sdk/reference.mdx
@@ -33,19 +33,7 @@ Accepts `KnockProviderProps`
   <Attribute
     name="userToken"
     type="string"
-    description={
-      <span>
-        A JWT that identifies the authenticated user, signed with the private
-        key provided in the Knock dashboard. Required to secure your production
-        environment.{" "}
-        <a
-          href="https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security"
-          target="_blank"
-        >
-          Learn more.
-        </a>
-      </span>
-    }
+    description="A JWT that identifies the authenticated user, signed with the private key provided in the Knock dashboard. Required to secure your production environment. [Learn more.](https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security)"
   />
   <Attribute
     name="host"


### PR DESCRIPTION
### Description

A previous update to the `Attribute` component was made to support markdown syntax on the `description`, because we were previously rendering things that were intended to be `code`-styled as ` literals.

There were two JSX descriptions that slipped through the cracks, and because they are invalid they just aren't rendering right now. This PR updates them to markdown syntax so that they will be displayed.
