### PR TITLE
chore: fix code styling issue on API reference

### DIFF
--- a/content/__api-reference/content.mdx
+++ b/content/__api-reference/content.mdx
@@ -382,15 +382,7 @@ Knock uses standard <a href="https://developer.mozilla.org/en-US/Web/HTTP/Status
 <ContentColumn> 
 <div className="w-full">
 
-<span className="mb-6">
-  {"Here's a list of common "}
-  <span className="bg-code-background text-code rounded text-sm font-normal py-0.75 px-1.5 font-mono inline-block border-1 border-gray-200">
-    4xx
-  </span>
-  {
-    " error codes you may encounter while working with the Knock API. We also provide additional context on how to resolve them."
-  }
-</span>
+Here's a list of common `4xx` error codes you may encounter while working with the Knock API. We also provide additional context on how to resolve them.
 
 <ErrorExample
   title="actor_missing"


### PR DESCRIPTION
### Description

This PR fixes a weird styling issue in the API reference:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/09010569-3cc3-4d04-83f9-53b856059164" />
<br/>

The update re-writes this description in markdown and just uses `code` styling, which applies the styles we use elsewhere:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/45175dc6-31da-4adc-a122-4f37afeb2a5d" />
