### PR TITLE
chore(KNO-13084): Add info on requesting additional scopes for useSlackAuth

### DIFF
--- a/content/integrations/chat/slack/sending-a-direct-message.mdx
+++ b/content/integrations/chat/slack/sending-a-direct-message.mdx
@@ -173,6 +173,14 @@ To use this feature, you must request the <a href="https://api.slack.com/scopes/
 />
 ```
 
+If you're using the `useSlackAuth` [hook](/in-app-ui/react/sdk/hooks/use-slack-auth) directly instead of `SlackAuthButton`, pass the scopes via the `additionalScopes` option:
+
+```javascript title="Requesting the users:read and users:read.email scopes with the useSlackAuth hook"
+const { buildSlackAuthUrl } = useSlackAuth(slackClientId, redirectUrl, {
+  additionalScopes: ["users:read", "users:read.email"],
+});
+```
+
 <Callout
   type="warning"
   title="Important:"


### PR DESCRIPTION
### Description

In the ["Enabling email-based user ID resolution"](https://docs.knock.app/integrations/chat/slack/sending-a-direct-message#enabling-email-based-user-id-resolution) section of the docs, we currently only show the SlackAuthButton example for adding the additional scopes. The gap is that customers using useSlackAuth directly (without SlackKit components) have no guidance on how to pass those scopes. It is important that they do this, as re-auth requests won't work for already connected tenants without these additional scopes (they instead would need to reinstall the app).

https://docs-git-rt-kno-13084-add-useslackauth-steps-knocklabs.vercel.app/integrations/chat/slack/sending-a-direct-message#enabling-email-based-user-id-resolution

### Tasks

[KNO-13084](https://linear.app/knock/issue/KNO-13084/docs-update-slack-email-based-user-id-resolution-steps)
