### PR TITLE
feat: fix quick-start navigation on land page - avoid redirection

### DIFF
--- a/content/tutorials/overview.mdx
+++ b/content/tutorials/overview.mdx
@@ -50,7 +50,7 @@ section: Tutorials
   <ContentCard
     title="Quick start"
     description="Quickly get up and running with Knock."
-    href="/getting-started/quick-start"
+    href="/getting-started/quick-start/general"
     icon={"Rabbit"}
   />
 </ResponsiveThreeColumn>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -92,7 +92,7 @@ export default function Home() {
             <ContentCard
               title="Quick start"
               description="Integrate Knock with your backend web app and send your first notification."
-              href="/getting-started/quick-start"
+              href="/getting-started/quick-start/general"
               icon={Rabbit}
             />
             <ContentCard


### PR DESCRIPTION
### Description

Quick Start page not loading when clicked from link

### Screenshots

https://github.com/user-attachments/assets/fb0507a0-caf1-499e-9cfc-761d144b8926

### So what I found:

Next router handles the redirection of _next/data requests inconsistently between environments. In both `next dev` and `next start` local environments, the router falls back to a full-page navigation when the fetch is first redirected. (it looses SPA but works basically).

In production, this fallback is not happening; instead, a client-side exception is thrown.

This PR sidesteps the inconsistency by updating the **card links** to the legit destination url directly, avoiding the redirect. The root cause could be on Vercel's or Nextjs's side IMO. **Maybe just a simple cache thing** too 🤷‍♂️

### (Possible) Todos:

Delete [content/getting-started/quick-start.mdx](https://github.com/knocklabs/docs/blob/main/content/getting-started/quick-start.mdx) as it seems to be the outdated/deprecated version of [content/getting-started/quick-start/general.mdx](https://github.com/knocklabs/docs/blob/main/content/getting-started/quick-start/general.mdx). As well as its redirection defined in [next.config.js](https://github.com/knocklabs/docs/blob/main/next.config.js#L637-L639)