### PR TITLE
Update CLI pull/push examples to use ./.knock directory

### DIFF
--- a/content/cli/resources.mdx
+++ b/content/cli/resources.mdx
@@ -77,7 +77,7 @@ Resources will be grouped by resource type within subdirectories of the target d
 <ExampleColumn>
 
 ```bash title="Pull all resources"
-knock pull --knock-dir=./knock
+knock pull --knock-dir=./.knock
 ```
 
 </ExampleColumn>
@@ -119,7 +119,7 @@ Resources will be pushed to the target directory path set either by your `knock.
 <ExampleColumn>
 
 ```bash title="Push all resources"
-knock push --knock-dir=./knock
+knock push --knock-dir=./.knock
 ```
 
 </ExampleColumn>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Updates the CLI reference documentation to use `./.knock` instead of `./knock` in the `knock pull` and `knock push` example commands. This ensures the examples match the default directory created by `knock init`.

**Changes:**
- Updated `knock pull --knock-dir=./knock` to `knock pull --knock-dir=./.knock`
- Updated `knock push --knock-dir=./knock` to `knock push --knock-dir=./.knock`

### Screenshots

**Pull all resources example:**
[Pull all resources example showing ./.knock path](https://cursor.com/agents/bc-7521fbb4-97cd-46b9-9e49-a78c576dff9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_pull_example_verified.webp)

**Push all resources example:**
[Push all resources example showing ./.knock path](https://cursor.com/agents/bc-7521fbb4-97cd-46b9-9e49-a78c576dff9e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_push_example_verified.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13127](https://linear.app/knock/issue/KNO-13127/update-cli-reference-pull-example-to-use-knock)

<div><a href="https://cursor.com/agents/bc-7521fbb4-97cd-46b9-9e49-a78c576dff9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7521fbb4-97cd-46b9-9e49-a78c576dff9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

