### PR TITLE
fix(kno-13176): update inaccurate TLD on mAPI docs

### DIFF
--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -31,7 +31,7 @@ To preview a template, you [use the preview template endpoint exposed by the man
 Using the endpoint, you pass through details about the `recipient`, `actor`, `tenant`, and any other data variables that are used within the template. The endpoint will return a JSON object with fully rendered template generated using the data you provided. It will be the same as previewing the template in the Knock dashboard.
 
 ```bash title="An example request to preview a template"
-curl -X POST https://control.knock.com/v1/workflows/my-workflow/steps/my-step/preview_template \
+curl -X POST https://control.knock.app/v1/workflows/my-workflow/steps/my-step/preview_template \
   -H "Authorization: Bearer $SERVICE_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"recipient": "chris", "data": {"project_name": "My Project"}}'


### PR DESCRIPTION
### Description

Updates a reference of `control.knock.com` -> `control.knock.app` on the management API page under Developer tools.