### PR TITLE
fix(kno-13177): update incorrect agent toolkit imports

### DIFF
--- a/content/developer-tools/agent-toolkit/getting-started.mdx
+++ b/content/developer-tools/agent-toolkit/getting-started.mdx
@@ -48,9 +48,9 @@ const result = await generateText({
 
 ```typescript title="Usage with the OpenAI SDK"
 import OpenAI from "openai";
-import { createToolkit } from "@knocklabs/agent-toolkit/openai";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/openai";
 
-const toolkit = await createToolkit();
+const toolkit = await createKnockToolkit();
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY!,
@@ -97,13 +97,13 @@ const messages = [
 ## Usage with the LangChain framework
 
 ```typescript title="Usage with the LangChain framework"
-import { createToolkit } from "@knocklabs/agent-toolkit/langchain";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/langchain";
 import { ChatOpenAI } from "@langchain/openai";
 import type { ChatPromptTemplate } from "@langchain/core/prompts";
 import { pull } from "langchain/hub";
 import { AgentExecutor, createStructuredChatAgent } from "langchain/agents";
 
-const toolkit = await createToolkit();
+const toolkit = await createKnockToolkit();
 
 const llm = new ChatOpenAI({
   model: "gpt-4o",

--- a/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
+++ b/content/developer-tools/agent-toolkit/human-in-the-loop-flows.mdx
@@ -54,9 +54,9 @@ The Knock Agent Toolkit exposes a set of helper methods that you can use to powe
 The `requiresHumanInput` helper method allows you to wrap a tool in requiring human input to proceed. When a tool is wrapped with this method, when the LLM tries to invoke the call it will instead delegate the tool call to Knock, passing the tool execution context to the Knock workflow.
 
 ```typescript title="Wrap tool in requiring input"
-import { createToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
 
-const toolkit = await createToolkit();
+const toolkit = await createKnockToolkit();
 
 const { classifyWork: classifyToolRequiringInput } = toolkit.requireHumanInput(
   { classifyWork },
@@ -87,9 +87,9 @@ Calling `requireHumanInput` will return a new tool that you pass in place of the
 The `handleMessageInteracted` helper method allows you to handle an incoming `message.interacted` event from Knock and determine if there's an interaction with the message that should be handled by your agent workflow.
 
 ```typescript title="Handling an incoming interaction"
-import { createToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
 
-const toolkit = await createToolkit();
+const toolkit = await createKnockToolkit();
 
 function handleIncomingInteraction(event) {
   const interactionEvent = toolkit.handleMessageInteracted(event);
@@ -111,9 +111,9 @@ The `resumeToolExecution` helper method allows you to resume tool execution afte
 You pass the `resumeToolExecution` method the `DeferredToolCallInteractionResult` that you've received from Knock via the `handleMessageInteracted` method. Here's an example of how you might use this method:
 
 ```typescript title="Resuming tool execution"
-import { createToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
 
-const toolkit = await createToolkit();
+const toolkit = await createKnockToolkit();
 
 function handleIncomingInteraction(event) {
   const interactionEvent = toolkit.handleMessageInteracted(event);
@@ -150,9 +150,9 @@ This example shows you how to set up an approval flow that sends an in-app notif
     The Agent Toolkit exposes a `requiresHumanInput` helper that you can use to wrap a tool call as one that requires human input to proceed.
  
     ```typescript title="Wrap a tool as requiring human input"
-    import { createToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
+    import { createKnockToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
 
-    const toolkit = await createToolkit();
+    const toolkit = await createKnockToolkit();
 
     const { classificationTool: wrappedClassificationTool } = toolkit.requiresHumanInput({ classificationTool }, {
       // The workflow to use to send the approval request
@@ -175,12 +175,12 @@ This example shows you how to set up an approval flow that sends an in-app notif
     You'll use this method to handle the incoming interaction event and to resume your agent's execution. Depending on which agent framework you're using, you'll need to implement this handler differently. We've left this example fairly abstract as a result.
 
     ```typescript title="Handling the response and resuming tool execution"
-    import { createToolkit, handleMessageInteracted } from "@knocklabs/agent-toolkit/ai-sdk";
+    import { createKnockToolkit, handleMessageInteracted } from "@knocklabs/agent-toolkit/ai-sdk";
 
     const handleMessageInteracted = async (event: MessageInteractedEvent) => {
       const agent = await getAgentInstance();
 
-      const toolkit = await createToolkit();
+      const toolkit = await createKnockToolkit();
 
       const interactionEvent = toolkit.handleMessageInteracted(event);
 

--- a/content/developer-tools/agent-toolkit/overview.mdx
+++ b/content/developer-tools/agent-toolkit/overview.mdx
@@ -72,9 +72,9 @@ For example, you can use Agent Toolkit to create a workflow that allows a person
 The toolkit exposes wrappers for requiring asynchronous human input. When wrapped, your tools will first delegate to Knock to trigger a workflow that you define, then asynchronously continue tool execution once you have received a response from a human.
 
 ```typescript title="Wrapping a tool as requiring human input"
-import { createToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
+import { createKnockToolkit } from "@knocklabs/agent-toolkit/ai-sdk";
 
-const toolkit = createToolkit();
+const toolkit = createKnockToolkit();
 
 const classifyToolRequiringInput = toolkit.requireHumanInput(classifyWork, {
   workflow: "approve-classification",

--- a/content/developer-tools/agent-toolkit/providing-context.mdx
+++ b/content/developer-tools/agent-toolkit/providing-context.mdx
@@ -13,10 +13,10 @@ The Knock Agent Toolkit allows you to pass context on initialization to automati
 
 ## Setting context
 
-You can set context on the `createToolkit` method.
+You can set context on the `createKnockToolkit` method.
 
 ```typescript
-const toolkit = await createToolkit({
+const toolkit = await createKnockToolkit({
   userId: "user_123",
   tenantId: "tenant_123",
 });

--- a/content/developer-tools/agent-toolkit/working-with-environments.mdx
+++ b/content/developer-tools/agent-toolkit/working-with-environments.mdx
@@ -13,7 +13,7 @@ By default, the toolkit will operate in the `development` environment for all mu
 If you want to constrain your agent to operate in a specific Knock environment, you can set the environment on initialization. By default this will be the `development` environment.
 
 ```typescript
-const toolkit = await createToolkit({
+const toolkit = await createKnockToolkit({
   environment: "production",
 });
 ```


### PR DESCRIPTION
### Description

Some agent toolkit code examples were incorrectly importing `createToolkit` instead of `createKnockToolkit`. This PR updates the examples. I've verified the updates against the `@knocklabs/agent-toolkit` source code.