### PR TITLE
fix(kno-13178): update incorrect in_app_feed values in CLI reference

### DIFF
--- a/content/cli/workflow.mdx
+++ b/content/cli/workflow.mdx
@@ -156,7 +156,7 @@ The command will create a new workflow directory in your local file system. By d
   <Attribute
     name="--steps"
     type="string"
-    description="A comma-separated list of step types to include in the workflow (e.g., 'email,sms,in_app_feed'). If not provided, you will be prompted to select steps interactively."
+    description="A comma-separated list of step types to include in the workflow (e.g., 'email,sms,in-app-feed'). If not provided, you will be prompted to select steps interactively."
   />
   <Attribute
     name="--template"
@@ -187,7 +187,7 @@ knock workflow new --key=my-workflow
 ```
 
 ```bash title="Create a workflow with specific steps"
-knock workflow new --key=my-workflow --steps=email,sms,in_app_feed
+knock workflow new --key=my-workflow --steps=email,sms,in-app-feed
 ```
 
 ```bash title="Create a workflow from a template"


### PR DESCRIPTION
### Description

This PR updates invalid flag values of `in_app_feed` in the CLI reference to the correct value, `in-app-feed`. I validated the fix against the `@knocklabs/knock-cli` source code. 