### PR TITLE
fix(kno-13180): update incorrect Android SDK method names

### DIFF
--- a/content/in-app-ui/android/sdk/reference.mdx
+++ b/content/in-app-ui/android/sdk/reference.mdx
@@ -216,7 +216,7 @@ Updates the channel data for the current user on the channel specified with `cha
 
 ### `Knock.shared.getCurrentDeviceToken()`
 
-Returns the FCM device token that was set from the Knock.shared.registerTokenForAPNS.
+Returns the FCM device token that was set from the Knock.shared.registerTokenForFCM.
 If you use our KnockMessagingService, the token registration will be handled for you automatically.
 
 **Returns** `String?`
@@ -247,7 +247,7 @@ You can learn more about FCM [here](https://firebase.google.com/docs/cloud-messa
 
 **Returns**: `ChannelData`
 
-### `Knock.shared.unregisterTokenForAPNS()`
+### `Knock.shared.unregisterTokenForFCM()`
 
 Unregisters the current deviceId associated to the user so that the device will no longer receive remote push notifications for the provided channelId.
 


### PR DESCRIPTION
### Description

Our Android SDK reference docs currently mention `registerTokenForAPNS` and `unregisterTokenForAPNS` methods. This PR corrects them to `...FCM`. The fix has been confirmed against the `knock-android` source code.