### PR TITLE
fix(kno-13179): update all Go SDK examples to compile properly with v1.x SDK

### DIFF
--- a/content/developer-tools/migration-guides/go.mdx
+++ b/content/developer-tools/migration-guides/go.mdx
@@ -182,8 +182,8 @@ response, err := client.Workflows.Trigger(
     "dinosaurs-loose",
     knock.WorkflowTriggerParams{
         Recipients: knock.F([]knock.RecipientRequestUnionParam{
-            knock.RecipientRequestUnionParamString("jhammond"),
-            knock.RecipientRequestUnionParamString("agrant"),
+            shared.UnionString("jhammond"),
+            shared.UnionString("agrant"),
         }),
         Data: knock.F(map[string]interface{}{
             "type": "trex",

--- a/content/developer-tools/type-safety.mdx
+++ b/content/developer-tools/type-safety.mdx
@@ -330,6 +330,7 @@ import (
     "context"
     "github.com/knocklabs/knock-go"
     "github.com/knocklabs/knock-go/option"
+    "github.com/knocklabs/knock-go/shared"
 )
 
 func main() {
@@ -354,12 +355,10 @@ func main() {
     json.Unmarshal(jsonData, &data)
 
     _, err := client.Workflows.Trigger(context.Background(), "comment-created", knock.WorkflowTriggerParams{
-        Recipients: []knock.WorkflowTriggerParamsRecipientUnion{
-            knock.WorkflowTriggerParamsRecipientUnion{
-                OfString: knock.String("user_789"),
-            },
-        },
-        Data: data, // ✅ Type-safe!
+        Recipients: knock.F([]knock.RecipientRequestUnionParam{
+            shared.UnionString("user_789"),
+        }),
+        Data: knock.F(data), // ✅ Type-safe!
     })
 }
 ```

--- a/data/code/api/idempotency.ts
+++ b/data/code/api/idempotency.ts
@@ -126,20 +126,18 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTriggerParams{
-	Recipients: param.New([]string{"1", "2"}),
-	Data: param.New(map[string]interface{}{
-		"project_name": "My Project",
-	}),
-	Actor:           param.New("3"),
-	CancellationKey: param.New("cancel_123"),
-	Tenant:          param.New("jurassic_world_employees"),
+	Recipients:      knock.F([]knock.RecipientRequestUnionParam{shared.UnionString("1"), shared.UnionString("2")}),
+	Data:            knock.F(map[string]interface{}{"project_name": "My Project"}),
+	Actor:           knock.F[knock.RecipientRequestUnionParam](shared.UnionString("3")),
+	CancellationKey: knock.F("cancel_123"),
+	Tenant:          knock.F[knock.InlineTenantRequestUnionParam](shared.UnionString("jurassic_world_employees")),
 }, option.WithIdempotencyKey("123"))
 `,
   java: `

--- a/data/code/messages/get-activities.ts
+++ b/data/code/messages/get-activities.ts
@@ -79,7 +79,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
@@ -87,12 +86,12 @@ knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 // List activities with pagination
 activities, _ := knockClient.Messages.ListActivities(ctx, message.ID, knock.MessageListActivitiesParams{
-	PageSize: param.New(10),
+	PageSize: knock.F(int64(10)),
 })
 
 // Auto-paging version
 activitiesPager := knockClient.Messages.ListActivitiesAutoPaging(ctx, message.ID, knock.MessageListActivitiesParams{
-	PageSize: param.New(10),
+	PageSize: knock.F(int64(10)),
 })
 
 // Iterate through activities

--- a/data/code/messages/get-events.ts
+++ b/data/code/messages/get-events.ts
@@ -79,7 +79,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
@@ -87,12 +86,12 @@ knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 // List events with pagination
 events, _ := knockClient.Messages.ListEvents(ctx, message.ID, knock.MessageListEventsParams{
-	PageSize: param.New(10),
+	PageSize: knock.F(int64(10)),
 })
 
 // Auto-paging version
 eventsPager := knockClient.Messages.ListEventsAutoPaging(ctx, message.ID, knock.MessageListEventsParams{
-	PageSize: param.New(10),
+	PageSize: knock.F(int64(10)),
 })
 
 // Iterate through events

--- a/data/code/messages/list.ts
+++ b/data/code/messages/list.ts
@@ -91,7 +91,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
@@ -99,14 +98,14 @@ knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 // List messages with pagination
 messages, _ := knockClient.Messages.List(ctx, knock.MessageListParams{
-	PageSize: param.New(20),
-	Tenant:   param.New("my-tenant"),
+	PageSize: knock.F(int64(20)),
+	Tenant:   knock.F("my-tenant"),
 })
 
 // Auto-paging version
 messagesPager := knockClient.Messages.ListAutoPaging(ctx, knock.MessageListParams{
-	PageSize: param.New(20),
-	Tenant:   param.New("my-tenant"),
+	PageSize: knock.F(int64(20)),
+	Tenant:   knock.F("my-tenant"),
 })
 
 // Iterate through messages

--- a/data/code/objects/messages.ts
+++ b/data/code/objects/messages.ts
@@ -106,23 +106,23 @@ $client->objects()->getMessages('projects', 'project-1', [
 import (
 	"context"
 
-	"github.com/stainless-sdks/knock-go"
-	"github.com/stainless-sdks/knock-go/option"
+	"github.com/knocklabs/knock-go"
+	"github.com/knocklabs/knock-go/option"
 )
 
 ctx := context.Background()
 client := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 // List messages with pagination
-messages, _ := client.Messages.List(ctx, knock.MessageListParams{
-	PageSize: param.New(20),
-	Tenant:   param.New("my-tenant"),
+messages, _ := client.Objects.ListMessages(ctx, "projects", project.ID, knock.ObjectListMessagesParams{
+	PageSize: knock.F(int64(20)),
+	Tenant:   knock.F("my-tenant"),
 })
 
 // Auto-paging version
-messagesPager := client.Messages.ListAutoPaging(ctx, knock.MessageListParams{
-	PageSize: param.New(20),
-	Tenant:   param.New("my-tenant"),
+messagesPager := client.Objects.ListMessagesAutoPaging(ctx, "projects", project.ID, knock.ObjectListMessagesParams{
+	PageSize: knock.F(int64(20)),
+	Tenant:   knock.F("my-tenant"),
 })
 
 // Iterate through messages

--- a/data/code/objects/set-channel-data-discord-bot.ts
+++ b/data/code/objects/set-channel-data-discord-bot.ts
@@ -144,15 +144,14 @@ client := knock.NewClient(option.WithAPIKey("sk_12345"))
 // Find this value in your Knock dashboard under Integrations > Channels
 knockDiscordChannelID := "7f1b3d5a-9c8e-4f2d-b6a7-3e2c8d9f0e1b"
 
-channelData, _ := client.Objects.SetChannelData(ctx, &knock.SetObjectChannelDataRequest{
-	Collection: "projects",
-	ObjectID:   "project-1",
-	ChannelID:  knockDiscordChannelID,
-	Data: knock.DiscordChannelDataParam{
-		Connections: param.New([]knock.DiscordChannelDataConnectionsUnionParam{
-			knock.DiscordChannelDataConnectionsDiscordChannelConnectionParam{
-				ChannelID: param.New("channel-id-from-discord"),
-			},
+channelData, _ := client.Objects.SetChannelData(ctx, "projects", "project-1", knockDiscordChannelID, knock.ObjectSetChannelDataParams{
+	ChannelDataRequest: knock.ChannelDataRequestParam{
+		Data: knock.F[knock.ChannelDataRequestDataUnionParam](knock.DiscordChannelDataParam{
+			Connections: knock.F([]knock.DiscordChannelDataConnectionsUnionParam{
+				knock.DiscordChannelDataConnectionsDiscordChannelConnectionParam{
+					ChannelID: knock.F("channel-id-from-discord"),
+				},
+			}),
 		}),
 	},
 })

--- a/data/code/objects/set-channel-data-discord-webhook.ts
+++ b/data/code/objects/set-channel-data-discord-webhook.ts
@@ -150,17 +150,16 @@ client := knock.NewClient(option.WithAPIKey("sk_12345"))
 // Find this value in your Knock dashboard under Integrations > Channels
 knockDiscordChannelID := "7f1b3d5a-9c8e-4f2d-b6a7-3e2c8d9f0e1b"
 
-channelData, _ := client.Objects.SetChannelData(ctx, &knock.SetObjectChannelDataRequest{
-	Collection: "projects",
-	ObjectID:   "project-1",
-	ChannelID:  knockDiscordChannelID,
-	Data: knock.DiscordChannelDataParam{
-		Connections: param.New([]knock.DiscordChannelDataConnectionsUnionParam{
-			knock.DiscordChannelDataConnectionsDiscordIncomingWebhookConnectionParam{
-				IncomingWebhook: param.New(knock.DiscordChannelDataConnectionsDiscordIncomingWebhookConnectionIncomingWebhookParam{
-					URL: param.New("url-from-discord"),
-				}),
-			},
+channelData, _ := client.Objects.SetChannelData(ctx, "projects", "project-1", knockDiscordChannelID, knock.ObjectSetChannelDataParams{
+	ChannelDataRequest: knock.ChannelDataRequestParam{
+		Data: knock.F[knock.ChannelDataRequestDataUnionParam](knock.DiscordChannelDataParam{
+			Connections: knock.F([]knock.DiscordChannelDataConnectionsUnionParam{
+				knock.DiscordChannelDataConnectionsDiscordIncomingWebhookConnectionParam{
+					IncomingWebhook: knock.F(knock.DiscordChannelDataConnectionsDiscordIncomingWebhookConnectionIncomingWebhookParam{
+						URL: knock.F("url-from-discord"),
+					}),
+				},
+			}),
 		}),
 	},
 })

--- a/data/code/objects/set-channel-data-ms-teams.ts
+++ b/data/code/objects/set-channel-data-ms-teams.ts
@@ -150,17 +150,16 @@ client := knock.NewClient(option.WithAPIKey("sk_12345"))
 // Find this value in your Knock dashboard under Integrations > Channels
 knockTeamsChannelID := "9e8d7c6b-5a4f-3e2d-1c0b-9a8b7c6d5e4f"
 
-channelData, _ := client.Objects.SetChannelData(ctx, &knock.SetObjectChannelDataRequest{
-	Collection: "projects",
-	ObjectID:   "project-1",
-	ChannelID:  knockTeamsChannelID,
-	Data: knock.MsTeamsChannelDataParam{
-		Connections: param.New([]knock.MsTeamsChannelDataConnectionsUnionParam{
-			knock.MsTeamsChannelDataConnectionsMsTeamsIncomingWebhookConnectionParam{
-				IncomingWebhook: param.New(knock.MsTeamsChannelDataConnectionsMsTeamsIncomingWebhookConnectionIncomingWebhookParam{
-					URL: param.New("url-from-teams"),
-				}),
-			},
+channelData, _ := client.Objects.SetChannelData(ctx, "projects", "project-1", knockTeamsChannelID, knock.ObjectSetChannelDataParams{
+	ChannelDataRequest: knock.ChannelDataRequestParam{
+		Data: knock.F[knock.ChannelDataRequestDataUnionParam](knock.MsTeamsChannelDataParam{
+			Connections: knock.F([]knock.MsTeamsChannelDataConnectionsUnionParam{
+				knock.MsTeamsChannelDataConnectionsMsTeamsIncomingWebhookConnectionParam{
+					IncomingWebhook: knock.F(knock.MsTeamsChannelDataConnectionsMsTeamsIncomingWebhookConnectionIncomingWebhookParam{
+						URL: knock.F("url-from-teams"),
+					}),
+				},
+			}),
 		}),
 	},
 })

--- a/data/code/objects/set-channel-data-slack.ts
+++ b/data/code/objects/set-channel-data-slack.ts
@@ -147,15 +147,14 @@ client := knock.NewClient(option.WithAPIKey("sk_12345"))
 // Find this value in your Knock dashboard under Integrations > Channels
 knockSlackChannelID := "8209f26c-62a5-461d-95e2-a5716a26e652"
 
-channelData, _ := client.Objects.SetChannelData(ctx, &knock.SetObjectChannelDataRequest{
-	Collection: "projects",
-	ObjectID:   "project-1",
-	ChannelID:  knockSlackChannelID,
-	Data: knock.SlackChannelDataParam{
-		Connections: param.New([]knock.SlackChannelDataConnectionsUnionParam{
-			knock.SlackChannelDataConnectionsSlackIncomingWebhookConnectionParam{
-				URL: param.New("url-from-slack"),
-			},
+channelData, _ := client.Objects.SetChannelData(ctx, "projects", "project-1", knockSlackChannelID, knock.ObjectSetChannelDataParams{
+	ChannelDataRequest: knock.ChannelDataRequestParam{
+		Data: knock.F[knock.ChannelDataRequestDataUnionParam](knock.SlackChannelDataParam{
+			Connections: knock.F([]knock.SlackChannelDataConnectionsUnionParam{
+				knock.SlackChannelDataConnectionsSlackIncomingWebhookConnectionParam{
+					URL: knock.F("url-from-slack"),
+				},
+			}),
 		}),
 	},
 })

--- a/data/code/objects/set-preferences.ts
+++ b/data/code/objects/set-preferences.ts
@@ -154,28 +154,28 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
+	"github.com/knocklabs/knock-go/shared"
 )
 
 ctx := context.Background()
 client := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-preferenceSet, _ := client.Objects.SetPreferences(ctx, &knock.SetObjectPreferencesRequest{
-	Collection: "projects",
-	ObjectID:   "project-1",
-	ID:         "default",
-	ChannelTypes: param.New(knock.PreferenceSetChannelTypesParam{
-		Email: param.New(true),
-		SMS:   param.New(false),
-	}),
-	Workflows: param.New(map[string]knock.PreferenceSetRequestWorkflowsUnionParam{
-		"dinosaurs-loose": knock.PreferenceSetRequestWorkflowsPreferenceSetWorkflowCategorySettingObjectParam{
-			ChannelTypes: param.New(knock.PreferenceSetChannelTypesParam{
-				Email:     param.New(false),
-				InAppFeed: param.New(true),
-				SMS:       param.New(true),
-			}),
-		},
-	}),
+preferenceSet, _ := client.Objects.SetPreferences(ctx, "projects", "project-1", "default", knock.ObjectSetPreferencesParams{
+	PreferenceSetRequest: knock.PreferenceSetRequestParam{
+		ChannelTypes: knock.F(knock.PreferenceSetChannelTypesParam{
+			Email: knock.F[knock.PreferenceSetChannelTypesEmailUnionParam](shared.UnionBool(true)),
+			SMS:   knock.F[knock.PreferenceSetChannelTypesSMSUnionParam](shared.UnionBool(false)),
+		}),
+		Workflows: knock.F(map[string]knock.PreferenceSetRequestWorkflowsUnionParam{
+			"dinosaurs-loose": knock.PreferenceSetRequestWorkflowsPreferenceSetWorkflowCategorySettingObjectParam{
+				ChannelTypes: knock.F(knock.PreferenceSetChannelTypesParam{
+					Email:     knock.F[knock.PreferenceSetChannelTypesEmailUnionParam](shared.UnionBool(false)),
+					InAppFeed: knock.F[knock.PreferenceSetChannelTypesInAppFeedUnionParam](shared.UnionBool(true)),
+					SMS:       knock.F[knock.PreferenceSetChannelTypesSMSUnionParam](shared.UnionBool(true)),
+				}),
+			},
+		}),
+	},
 })
 `,
   java: `

--- a/data/code/tenants/list.ts
+++ b/data/code/tenants/list.ts
@@ -90,7 +90,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
@@ -98,14 +97,14 @@ knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 // List tenants with pagination
 tenants, _ := knockClient.Tenants.List(ctx, knock.TenantListParams{
-	PageSize: param.New(20),
-	Name:     param.New("Tenant 1"),
+	PageSize: knock.F(int64(20)),
+	Name:     knock.F("Tenant 1"),
 })
 
 // Auto-paging version
 tenantsPager := knockClient.Tenants.ListAutoPaging(ctx, knock.TenantListParams{
-	PageSize: param.New(20),
-	Name:     param.New("Tenant 1"),
+	PageSize: knock.F(int64(20)),
+	Name:     knock.F("Tenant 1"),
 })
 
 // Iterate through tenants

--- a/data/code/tenants/set.ts
+++ b/data/code/tenants/set.ts
@@ -123,21 +123,20 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 tenant, _ := knockClient.Tenants.Set(ctx, "tenant-1", knock.TenantSetParams{
-	Name: param.New("Tenant 1"),
-	Settings: param.New(map[string]interface{}{
-		"branding": map[string]interface{}{
-			"primary_color":          "#33FF5B",
-			"primary_color_contrast": "#ffffff",
-			"logo_url":               "https://www.example.com/path-to-logo-asset-url",
-			"icon_url":               "https://www.example.com/path-to-icon-asset-url",
-		},
+	Name: knock.F("Tenant 1"),
+	Settings: knock.F(knock.TenantSetParamsSettings{
+		Branding: knock.F(knock.TenantSetParamsSettingsBranding{
+			PrimaryColor:         knock.F("#33FF5B"),
+			PrimaryColorContrast: knock.F("#ffffff"),
+			LogoURL:              knock.F("https://www.example.com/path-to-logo-asset-url"),
+			IconURL:              knock.F("https://www.example.com/path-to-icon-asset-url"),
+		}),
 	}),
 })
 `,

--- a/data/code/users/bulk-delete.ts
+++ b/data/code/users/bulk-delete.ts
@@ -52,11 +52,17 @@ $client = new Client('sk_12345');
 $client->users()->bulkDelete(['user-1', 'user-2']);
 `,
   go: `
+import (
+  "context"
+
+  "github.com/knocklabs/knock-go"
+  "github.com/knocklabs/knock-go/option"
+)
 ctx := context.Background()
-knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
+knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Users.Bulk.Delete(ctx, knock.UserBulkDeleteParams{
-  UserIDs: param.Strings([]string{"user-1", "user-2"}),
+  UserIDs: knock.F([]string{"user-1", "user-2"}),
 })
 `,
   java: `

--- a/data/code/users/bulk-identify.ts
+++ b/data/code/users/bulk-identify.ts
@@ -124,20 +124,26 @@ $client->users()->bulkIdentify([
 ]);
 `,
   go: `
+import (
+  "context"
+
+  "github.com/knocklabs/knock-go"
+  "github.com/knocklabs/knock-go/option"
+)
 ctx := context.Background()
-knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
+knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Users.Bulk.Identify(ctx, knock.UserBulkIdentifyParams{
-  Users: param.Raw([]map[string]interface{}{
+  Users: knock.F([]knock.InlineIdentifyUserRequestParam{
     {
-      "id":    "1",
-      "name":  "John Hammond",
-      "email": "jhammond@ingen.net",
+      ID:    knock.F("1"),
+      Name:  knock.F("John Hammond"),
+      Email: knock.F("jhammond@ingen.net"),
     },
     {
-      "id":    "2",
-      "name":  "Ellie Sattler",
-      "email": "esattler@ingen.net",
+      ID:    knock.F("2"),
+      Name:  knock.F("Ellie Sattler"),
+      Email: knock.F("esattler@ingen.net"),
     },
   }),
 })

--- a/data/code/users/bulk-set-preferences.ts
+++ b/data/code/users/bulk-set-preferences.ts
@@ -106,13 +106,19 @@ $client->users()->bulkSetPreferences([
 ]);
 `,
   go: `
+import (
+  "context"
+
+  "github.com/knocklabs/knock-go"
+  "github.com/knocklabs/knock-go/option"
+)
 ctx := context.Background()
-knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
+knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Users.Bulk.SetPreferences(ctx, knock.UserBulkSetPreferencesParams{
-  UserIDs: param.Strings([]string{"jhammond", "dnedry"}),
+  UserIDs: knock.F([]string{"jhammond", "dnedry"}),
   Preferences: knock.PreferenceSetRequestParam{
-    ChannelTypes: param.Raw(map[string]interface{}{
+    ChannelTypes: knock.Raw[knock.PreferenceSetChannelTypesParam](map[string]interface{}{
       "email": true,
       "sms":   false,
     }),

--- a/data/code/users/delete.ts
+++ b/data/code/users/delete.ts
@@ -43,8 +43,14 @@ $client = new Client('sk_12345');
 $client->users()->delete($user->id());
 `,
   go: `
+import (
+  "context"
+
+  "github.com/knocklabs/knock-go"
+  "github.com/knocklabs/knock-go/option"
+)
 ctx := context.Background()
-knockClient, _ := knock.NewClient(knock.WithAccessToken("sk_12345"))
+knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Users.Delete(ctx, user.ID)
 `,

--- a/data/code/users/identify-channel-data.ts
+++ b/data/code/users/identify-channel-data.ts
@@ -114,7 +114,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
@@ -124,9 +123,9 @@ apnsChannelId := "some-channel-id-from-knock"
 
 user, _ := knockClient.Users.Update(ctx, "1", knock.UserUpdateParams{
   IdentifyUserRequest: knock.IdentifyUserRequestParam{
-    Name:  param.String("John Hammond"),
-    Email: param.String("jhammond@ingen.net"),
-    ChannelData: param.Raw(map[string]interface{}{
+    Name:  knock.String("John Hammond"),
+    Email: knock.String("jhammond@ingen.net"),
+    ChannelData: knock.Raw[knock.InlineChannelDataRequestParam](map[string]interface{}{
       apnsChannelId: map[string]interface{}{
         "tokens": []string{"apns-push-token"},
       },

--- a/data/code/users/identify.ts
+++ b/data/code/users/identify.ts
@@ -75,15 +75,14 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 user, _ := knockClient.Users.Update(ctx, "1", knock.UserUpdateParams{
   IdentifyUserRequest: knock.IdentifyUserRequestParam{
-    Name:  param.String("John Hammond"),
-    Email: param.String("jhammond@ingen.net"),
+    Name:  knock.String("John Hammond"),
+    Email: knock.String("jhammond@ingen.net"),
   },
 })
 `,

--- a/data/code/users/merge.ts
+++ b/data/code/users/merge.ts
@@ -57,13 +57,12 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 result, _ := knockClient.Users.Merge(ctx, user.ID, knock.UserMergeParams{
-  FromUserID: param.String("user-to-merge-from"),
+  FromUserID: knock.String("user-to-merge-from"),
 })
 `,
   java: `

--- a/data/code/users/messages.ts
+++ b/data/code/users/messages.ts
@@ -98,14 +98,13 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 messages, _ := knockClient.Users.ListMessages(ctx, user.ID, knock.UserListMessagesParams{
-  PageSize: param.Int64(20),
-  Tenant:   param.String("my_tenant"),
+  PageSize: knock.F(int64(20)),
+  Tenant:   knock.String("my_tenant"),
 })
 `,
   java: `

--- a/data/code/users/set-channel-data-aws-sns.ts
+++ b/data/code/users/set-channel-data-aws-sns.ts
@@ -64,14 +64,13 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 channelData, _ := knockClient.Users.SetChannelData(ctx, user.ID, "8209f26c-62a5-461d-95e2-a5716a26e652", knock.UserSetChannelDataParams{
   ChannelDataRequest: knock.ChannelDataRequestParam{
-    Data: param.Raw(map[string]interface{}{
+    Data: knock.Raw[knock.ChannelDataRequestDataUnionParam](map[string]interface{}{
       "target_arns": []string{snsEndpointArn},
     }),
   },

--- a/data/code/users/set-channel-data-devices.ts
+++ b/data/code/users/set-channel-data-devices.ts
@@ -114,7 +114,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 
 ctx := context.Background()
@@ -125,7 +124,7 @@ apnsChannelId := "8209f26c-62a5-461d-95e2-a5716a26e652"
 
 _, _ = knockClient.Users.SetChannelData(ctx, user.ID, apnsChannelId, knock.UserSetChannelDataParams{
   ChannelDataRequest: knock.ChannelDataRequestParam{
-    Data: param.Raw(map[string]interface{}{
+    Data: knock.Raw[knock.ChannelDataRequestDataUnionParam](map[string]interface{}{
       "devices": []map[string]interface{}{
         {"token": "user_device_token_1", "locale": "en-US", "timezone": "America/New_York"},
         {"token": "user_device_token_2"},

--- a/data/code/users/set-channel-data-one-signal.ts
+++ b/data/code/users/set-channel-data-one-signal.ts
@@ -64,14 +64,13 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 channelData, _ := knockClient.Users.SetChannelData(ctx, user.ID, "5a88728a-3ecb-400d-ba6f-9c0956ab252f", knock.UserSetChannelDataParams{
   ChannelDataRequest: knock.ChannelDataRequestParam{
-    Data: param.Raw(map[string]interface{}{
+    Data: knock.Raw[knock.ChannelDataRequestDataUnionParam](map[string]interface{}{
       "player_ids": []string{oneSignalPlayerId},
     }),
   },

--- a/data/code/users/set-channel-data-push.ts
+++ b/data/code/users/set-channel-data-push.ts
@@ -64,14 +64,13 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 channelData, _ := knockClient.Users.SetChannelData(ctx, user.ID, "5a88728a-3ecb-400d-ba6f-9c0956ab252f", knock.UserSetChannelDataParams{
   ChannelDataRequest: knock.ChannelDataRequestParam{
-    Data: param.Raw(map[string]interface{}{
+    Data: knock.Raw[knock.ChannelDataRequestDataUnionParam](map[string]interface{}{
       "tokens": []string{apnsToken},
     }),
   },

--- a/data/code/users/set-channel-data.ts
+++ b/data/code/users/set-channel-data.ts
@@ -91,7 +91,6 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
@@ -101,7 +100,7 @@ apnsChannelId := "8209f26c-62a5-461d-95e2-a5716a26e652"
 
 channelData, _ := knockClient.Users.SetChannelData(ctx, user.ID, apnsChannelId, knock.UserSetChannelDataParams{
   ChannelDataRequest: knock.ChannelDataRequestParam{
-    Data: param.Raw(map[string]interface{}{
+    Data: knock.Raw[knock.ChannelDataRequestDataUnionParam](map[string]interface{}{
       "tokens": []string{userDeviceToken},
     }),
   },

--- a/data/code/users/set-preferences-per-tenant.ts
+++ b/data/code/users/set-preferences-per-tenant.ts
@@ -115,29 +115,26 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-preferenceSetRequest := &knock.PreferenceSetRequestParam{
-  ChannelTypes: map[string]interface{}{
-    "email": true,
-    "sms":   false,
-  },
-  Workflows: map[string]interface{}{
-    "dinosaurs-loose": map[string]interface{}{
-      "channel_types": map[string]interface{}{
-        "email":       false,
-        "in_app_feed": true,
-        "sms":         true,
+preferenceSet, _ := knockClient.Users.SetPreferences(ctx, user.ID, tenant.ID, knock.UserSetPreferencesParams{
+  PreferenceSetRequest: knock.PreferenceSetRequestParam{
+    ChannelTypes: knock.Raw[knock.PreferenceSetChannelTypesParam](map[string]interface{}{
+      "email": true,
+      "sms":   false,
+    }),
+    Workflows: knock.Raw[map[string]knock.PreferenceSetRequestWorkflowsUnionParam](map[string]interface{}{
+      "dinosaurs-loose": map[string]interface{}{
+        "channel_types": map[string]interface{}{
+          "email":       false,
+          "in_app_feed": true,
+          "sms":         true,
+        },
       },
-    },
+    }),
   },
-}
-
-preferenceSet, _ := knockClient.Users.SetPreferences(ctx, user.ID, tenant.ID, &knock.UserSetPreferencesParams{
-  PreferenceSetRequest: *preferenceSetRequest,
 })
   `,
   java: `

--- a/data/code/users/set-preferences-with-conditions.ts
+++ b/data/code/users/set-preferences-with-conditions.ts
@@ -118,27 +118,24 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-preferenceSetRequest := &knock.PreferenceSetRequestParam{
-  Workflows: map[string]interface{}{
-    "dinosaurs-loose": map[string]interface{}{
-      "conditions": []map[string]interface{}{
-        {
-          "variable":  "recipient.muted_alert_ids",
-          "operator":  "not_contains",
-          "argument":  "data.alert_id",
+preferenceSet, _ := knockClient.Users.SetPreferences(ctx, user.ID, "default", knock.UserSetPreferencesParams{
+  PreferenceSetRequest: knock.PreferenceSetRequestParam{
+    Workflows: knock.Raw[map[string]knock.PreferenceSetRequestWorkflowsUnionParam](map[string]interface{}{
+      "dinosaurs-loose": map[string]interface{}{
+        "conditions": []map[string]interface{}{
+          {
+            "variable": "recipient.muted_alert_ids",
+            "operator": "not_contains",
+            "argument": "data.alert_id",
+          },
         },
       },
-    },
+    }),
   },
-}
-
-preferenceSet, _ := knockClient.Users.SetPreferences(ctx, user.ID, "default", &knock.UserSetPreferencesParams{
-  PreferenceSetRequest: *preferenceSetRequest,
 })
   `,
   java: `

--- a/data/code/users/set-preferences.ts
+++ b/data/code/users/set-preferences.ts
@@ -141,18 +141,17 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 preferenceSet, _ := knockClient.Users.SetPreferences(ctx, user.ID, "default", knock.UserSetPreferencesParams{
   PreferenceSetRequest: knock.PreferenceSetRequestParam{
-    ChannelTypes: param.Raw(map[string]interface{}{
+    ChannelTypes: knock.Raw[knock.PreferenceSetChannelTypesParam](map[string]interface{}{
       "email": true,
       "sms":   false,
     }),
-    Workflows: param.Raw(map[string]interface{}{
+    Workflows: knock.Raw[map[string]knock.PreferenceSetRequestWorkflowsUnionParam](map[string]interface{}{
       "dinosaurs-loose": map[string]interface{}{
         "channel_types": map[string]interface{}{
           "email":       false,

--- a/data/code/workflows/cancel-with-recipients.ts
+++ b/data/code/workflows/cancel-with-recipients.ts
@@ -67,17 +67,17 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowCancelParams{
-  CancellationKey: userInvite.ID,
-  Recipients: []knock.RecipientReferenceUnionParam{"user_1", "user_2"},
+  CancellationKey: knock.F(userInvite.ID),
+  Recipients:      knock.F([]knock.RecipientReferenceUnionParam{shared.UnionString("user_1"), shared.UnionString("user_2")}),
 }
 
-result, _ := knockClient.Workflows.Cancel(ctx, "new-user-invited", params)
+_ = knockClient.Workflows.Cancel(ctx, "new-user-invited", params)
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/cancel.ts
+++ b/data/code/workflows/cancel.ts
@@ -70,10 +70,10 @@ ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowCancelParams{
-  CancellationKey: userInvite.ID,
+  CancellationKey: knock.F(userInvite.ID),
 }
 
-result, _ := knockClient.Workflows.Cancel(ctx, "new-user-invited", params)
+_ = knockClient.Workflows.Cancel(ctx, "new-user-invited", params)
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/playground.ts
+++ b/data/code/workflows/playground.ts
@@ -125,17 +125,17 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Recipients: []knock.RecipientRequestUnionParam{"1", "2"},
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Actor: "3",
-  CancellationKey: "cancel_123",
-  Tenant: "jurassic_world_employees",
+  Recipients:      knock.F([]knock.RecipientRequestUnionParam{shared.UnionString("1"), shared.UnionString("2")}),
+  Data:            knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Actor:           knock.F[knock.RecipientRequestUnionParam](shared.UnionString("3")),
+  CancellationKey: knock.F("cancel_123"),
+  Tenant:          knock.F[knock.InlineTenantRequestUnionParam](shared.UnionString("jurassic_world_employees")),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger-with-actor.ts
+++ b/data/code/workflows/trigger-with-actor.ts
@@ -99,27 +99,26 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-params := knock.WorkflowTriggerParams{
-  Actor: comment.Author.ID,
-  Data: map[string]interface{}{
+recipients := make([]knock.RecipientRequestUnionParam, len(followerIds))
+for i, id := range followerIds {
+  recipients[i] = shared.UnionString(id)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTriggerParams{
+  Actor: knock.F[knock.RecipientRequestUnionParam](shared.UnionString(comment.Author.ID)),
+  Data: knock.F(map[string]interface{}{
     "document_id":   document.ID,
     "document_name": document.Name,
     "comment_id":    comment.ID,
     "comment_text":  comment.Text,
-  },
-  Recipients: make([]knock.RecipientRequestUnionParam, len(followerIds)),
-}
-
-for i, f := range followerIds {
-  params.Recipients[i] = f
-}
-
-result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)
+  }),
+  Recipients: knock.F(recipients),
+})
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/trigger-with-attachment.ts
+++ b/data/code/workflows/trigger-with-attachment.ts
@@ -117,29 +117,28 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{
+recipients := make([]knock.RecipientRequestUnionParam, len(recipientIds))
+for i, id := range recipientIds {
+  recipients[i] = shared.UnionString(id)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, "invoice-paid", knock.WorkflowTriggerParams{
+  Data: knock.F(map[string]interface{}{
     "attachments": []map[string]interface{}{
       {
-        "name": "Invoice.pdf",
-        "content": fileContents,
-        "content_type": "application/pdf"
-      }
+        "name":         "Invoice.pdf",
+        "content":      fileContents,
+        "content_type": "application/pdf",
+      },
     },
-  },
-  Recipients: make([]knock.RecipientRequestUnionParam, len(recipientIds)),
-}
-
-for i, r := range recipientIds {
-  params.Recipients[i] = r
-}
-
-result, _ := knockClient.Workflows.Trigger(ctx, "invoice-paid", params)
+  }),
+  Recipients: knock.F(recipients),
+})
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/trigger-with-branding-tenant.ts
+++ b/data/code/workflows/trigger-with-branding-tenant.ts
@@ -81,24 +81,21 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
-	"github.com/knocklabs/knock-go/param"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{
-    "reservation_id": reservation.ID
-  },
-  Tenant: "black-lodge",
-  Recipients: make([]knock.RecipientRequestUnionParam, len(reservationGuestIds)),
+recipients := make([]knock.RecipientRequestUnionParam, len(reservationGuestIds))
+for i, id := range reservationGuestIds {
+  recipients[i] = shared.UnionString(id)
 }
 
-for i, r := range reservationGuestIds {
-  params.Recipients[i] = r
-}
-
-result, _ := knockClient.Workflows.Trigger(ctx, "reservation-reminder-email", params)
+result, _ := knockClient.Workflows.Trigger(ctx, "reservation-reminder-email", knock.WorkflowTriggerParams{
+  Data:       knock.F(map[string]interface{}{"reservation_id": reservation.ID}),
+  Tenant:     knock.F[knock.InlineTenantRequestUnionParam](shared.UnionString("black-lodge")),
+  Recipients: knock.F(recipients),
+})
   `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/trigger-with-object-as-actor.ts
+++ b/data/code/workflows/trigger-with-object-as-actor.ts
@@ -66,23 +66,23 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-params := knock.WorkflowTriggerParams{
-  Actor: map[string]interface{}{
-    "collection": "projects",
-    "id": project.ID,
-  },
-  Recipients: make([]knock.RecipientRequestUnionParam, len(followerIds)),
+recipients := make([]knock.RecipientRequestUnionParam, len(followerIds))
+for i, id := range followerIds {
+  recipients[i] = shared.UnionString(id)
 }
 
-for i, f := range followerIds {
-  params.Recipients[i] = f
-}
-
-result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)
+result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTriggerParams{
+  Actor: knock.F[knock.RecipientRequestUnionParam](knock.InlineObjectRequestParam{
+    Collection: knock.F("projects"),
+    ID:         knock.F(project.ID),
+  }),
+  Recipients: knock.F(recipients),
+})
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/trigger-with-object-as-recipient.ts
+++ b/data/code/workflows/trigger-with-object-as-recipient.ts
@@ -77,12 +77,12 @@ ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Recipients: []knock.RecipientRequestUnionParam{
-    map[string]interface{}{
-      "collection": "projects",
-      "id": project.ID,
+  Recipients: knock.F([]knock.RecipientRequestUnionParam{
+    knock.InlineObjectRequestParam{
+      Collection: knock.F("projects"),
+      ID:         knock.F(project.ID),
     },
-  },
+  }),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger-with-object-identification.ts
+++ b/data/code/workflows/trigger-with-object-identification.ts
@@ -161,23 +161,27 @@ ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Recipients: []knock.RecipientRequestUnionParam{
-    map[string]interface{}{
-      "id": "project-1",
-      "collection": "projects",
-      "name": "My project",
-      "total_assets": 10,
-      "tags": []string{"cool", "fun", "project"},
+  Data: knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Recipients: knock.F([]knock.RecipientRequestUnionParam{
+    knock.InlineObjectRequestParam{
+      ID:         knock.F("project-1"),
+      Collection: knock.F("projects"),
+      Name:       knock.F("My project"),
+      ExtraFields: map[string]interface{}{
+        "total_assets": 10,
+        "tags":         []string{"cool", "fun", "project"},
+      },
     },
-    map[string]interface{}{
-      "id": "project-2",
-      "collection": "projects",
-      "name": "My second project",
-      "total_assets": 5,
-      "tags": []string{"very", "cool", "project"},
+    knock.InlineObjectRequestParam{
+      ID:         knock.F("project-2"),
+      Collection: knock.F("projects"),
+      Name:       knock.F("My second project"),
+      ExtraFields: map[string]interface{}{
+        "total_assets": 5,
+        "tags":         []string{"very", "cool", "project"},
+      },
     },
-  },
+  }),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger-with-tenant.ts
+++ b/data/code/workflows/trigger-with-tenant.ts
@@ -99,26 +99,26 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
-params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{
+recipients := make([]knock.RecipientRequestUnionParam, len(followerIds))
+for i, id := range followerIds {
+  recipients[i] = shared.UnionString(id)
+}
+
+result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", knock.WorkflowTriggerParams{
+  Data: knock.F(map[string]interface{}{
     "document_id":   document.ID,
     "document_name": document.Name,
     "comment_id":    comment.ID,
     "comment_text":  comment.Text,
-  },
-  Tenant: workspace.ID,
-  Recipients: make([]knock.RecipientRequestUnionParam, len(followerIds)),
-}
-
-for i, f := range followerIds {
-  params.Recipients[i] = f
-}
-
-result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)
+  }),
+  Tenant:     knock.F[knock.InlineTenantRequestUnionParam](shared.UnionString(workspace.ID)),
+  Recipients: knock.F(recipients),
+})
 `,
   java: `
 import app.knock.api.client.KnockClient;

--- a/data/code/workflows/trigger-with-user-channel-data.ts
+++ b/data/code/workflows/trigger-with-user-channel-data.ts
@@ -153,19 +153,21 @@ knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 // Get this value in your Knock dashboard
 apnsChannelId := "some-channel-id-from-knock"
 
-params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Recipients: []knock.RecipientRequestUnionParam{
-    map[string]interface{}{
-      "id": "1",
-      "email": "jhammond@ingen.net",
-      "channel_data": map[string]interface{}{
-        apnsChannelId: map[string]interface{}{
-          "tokens": []string{"apns-push-token"},
-        },
-      },
-    },
+channelData := knock.InlineChannelDataRequestParam{
+  apnsChannelId: knock.PushChannelDataTokensOnlyParam{
+    Tokens: knock.F([]string{"apns-push-token"}),
   },
+}
+
+params := knock.WorkflowTriggerParams{
+  Data: knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Recipients: knock.F([]knock.RecipientRequestUnionParam{
+    knock.InlineIdentifyUserRequestParam{
+      ID:          knock.F("1"),
+      Email:       knock.F("jhammond@ingen.net"),
+      ChannelData: knock.F(channelData),
+    },
+  }),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger-with-user-identification.ts
+++ b/data/code/workflows/trigger-with-user-identification.ts
@@ -137,19 +137,19 @@ ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Recipients: []knock.RecipientRequestUnionParam{
-    map[string]interface{}{
-      "id": "1",
-      "name": "John Hammond",
-      "email": "jhammond@ingen.net",
+  Data: knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Recipients: knock.F([]knock.RecipientRequestUnionParam{
+    knock.InlineIdentifyUserRequestParam{
+      ID:    knock.F("1"),
+      Name:  knock.F("John Hammond"),
+      Email: knock.F("jhammond@ingen.net"),
     },
-    map[string]interface{}{
-      "id": "2",
-      "name": "Ellie Sattler",
-      "email": "esattler@ingen.net",
+    knock.InlineIdentifyUserRequestParam{
+      ID:    knock.F("2"),
+      Name:  knock.F("Ellie Sattler"),
+      Email: knock.F("esattler@ingen.net"),
     },
-  },
+  }),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger-with-user-preferences.ts
+++ b/data/code/workflows/trigger-with-user-preferences.ts
@@ -168,27 +168,27 @@ ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Recipients: []knock.RecipientRequestUnionParam{
-    map[string]interface{}{
-      "id": "1",
-      "email": "jhammond@ingen.net",
-      "preferences": map[string]interface{}{
+  Data: knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Recipients: knock.F([]knock.RecipientRequestUnionParam{
+    knock.InlineIdentifyUserRequestParam{
+      ID:    knock.F("1"),
+      Email: knock.F("jhammond@ingen.net"),
+      Preferences: knock.Raw[knock.InlinePreferenceSetRequestParam](map[string]interface{}{
         "default": map[string]interface{}{
           "channel_types": map[string]bool{
             "email": true,
-            "sms": true,
+            "sms":   true,
           },
         },
         "{{ tenant.id }}": map[string]interface{}{
           "channel_types": map[string]bool{
             "email": false,
-            "sms": false,
+            "sms":   false,
           },
         },
-      },
+      }),
     },
-  },
+  }),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)

--- a/data/code/workflows/trigger.ts
+++ b/data/code/workflows/trigger.ts
@@ -104,16 +104,17 @@ import (
 
 	"github.com/knocklabs/knock-go"
 	"github.com/knocklabs/knock-go/option"
+	"github.com/knocklabs/knock-go/shared"
 )
 ctx := context.Background()
 knockClient := knock.NewClient(option.WithAPIKey("sk_12345"))
 
 params := knock.WorkflowTriggerParams{
-  Recipients: []knock.RecipientRequestUnionParam{"1", "2"},
-  Data: map[string]interface{}{"project_name": "My Project"},
-  Actor: "3",
-  CancellationKey: "cancel_123",
-  Tenant: "jurassic_world_employees",
+  Recipients:      knock.F([]knock.RecipientRequestUnionParam{shared.UnionString("1"), shared.UnionString("2")}),
+  Data:            knock.F(map[string]interface{}{"project_name": "My Project"}),
+  Actor:           knock.F[knock.RecipientRequestUnionParam](shared.UnionString("3")),
+  CancellationKey: knock.F("cancel_123"),
+  Tenant:          knock.F[knock.InlineTenantRequestUnionParam](shared.UnionString("jurassic_world_employees")),
 }
 
 result, _ := knockClient.Workflows.Trigger(ctx, "new-comment", params)


### PR DESCRIPTION
## Summary

This PR updates all Go code examples in the docs to be compatible with the v1.x Knock Go SDK (currently v1.33.0), resolving three categories of breaking issues that were not updated when the new 1.x SDK was released:

- **Removed inaccessible `internal/param` imports** — the `param` package is internal and cannot be imported by external consumers; replaced all `param.New()`, `param.String()`, `param.Int64()`, `param.Raw()`, and `param.Strings()` calls with their public equivalents from the top-level `knock` package (`knock.F()`, `knock.String()`, `knock.Raw[T]()`, etc.)
- **Wrapped bare struct field assignments** — all fields typed as `param.Field[T]` must be wrapped with `knock.F()`; fixed bare assignments for `Recipients`, `Data`, `Actor`, `Tenant`, `CancellationKey`, `Name`, `Settings`, etc.
- **Fixed non-existent type/function references** — replaced `knock.WorkflowTriggerParamsRecipientUnion`, `knock.RecipientRequestUnionParamString()`, `knock.WithAccessToken`, and the old object request structs (`SetObjectChannelDataRequest`, `SetObjectPreferencesRequest`) with the correct v1.x API

### Files changed (44)

**Workflows** (`cancel.ts`, `cancel-with-recipients.ts`, `playground.ts`, `trigger.ts`, `trigger-with-actor.ts`, `trigger-with-attachment.ts`, `trigger-with-branding-tenant.ts`, `trigger-with-object-as-actor.ts`, `trigger-with-object-as-recipient.ts`, `trigger-with-object-identification.ts`, `trigger-with-tenant.ts`, `trigger-with-user-channel-data.ts`, `trigger-with-user-identification.ts`, `trigger-with-user-preferences.ts`)

**Messages** (`list.ts`, `get-events.ts`, `get-activities.ts`)

**Objects** (`messages.ts`, `set-preferences.ts`, `set-channel-data-discord-bot.ts`, `set-channel-data-discord-webhook.ts`, `set-channel-data-ms-teams.ts`, `set-channel-data-slack.ts`)

**Tenants** (`set.ts`, `list.ts`)

**API** (`idempotency.ts`)

**Users** (`identify.ts`, `identify-channel-data.ts`, `merge.ts`, `messages.ts`, `delete.ts`, `set-channel-data.ts`, `set-channel-data-devices.ts`, `set-channel-data-push.ts`, `set-channel-data-aws-sns.ts`, `set-channel-data-one-signal.ts`, `set-preferences.ts`, `set-preferences-per-tenant.ts`, `set-preferences-with-conditions.ts`, `bulk-identify.ts`, `bulk-delete.ts`, `bulk-set-preferences.ts`)

**MDX** (`developer-tools/type-safety.mdx`, `developer-tools/migration-guides/go.mdx`)