### PR TITLE
fix(KNO-13274): Update broken #available-actions anchor links in source pages

### DIFF
--- a/content/integrations/sources/clerk.mdx
+++ b/content/integrations/sources/clerk.mdx
@@ -111,7 +111,7 @@ You can modify the default action mappings or add new ones for any event type Kn
 
 If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
 
-If you need to map Clerk events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map Clerk events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/posthog.mdx
+++ b/content/integrations/sources/posthog.mdx
@@ -105,7 +105,7 @@ You can modify the default action mappings or add new ones for any event type Kn
 
 If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
 
-If you need to map PostHog events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map PostHog events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/rudderstack.mdx
+++ b/content/integrations/sources/rudderstack.mdx
@@ -149,7 +149,7 @@ See the [RudderStack event spec documentation](https://www.rudderstack.com/docs/
 
 You can modify the default action mappings or add new ones for any event type Knock receives from RudderStack. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
-If you need to map RudderStack events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map RudderStack events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/segment.mdx
+++ b/content/integrations/sources/segment.mdx
@@ -120,7 +120,7 @@ See the <a href="https://segment.com/docs/connections/spec/" target="_blank">Seg
 
 You can modify the default action mappings or add new ones for any event type Knock receives from Segment. For details on how field mapping works with dot-notation paths, see the [custom source](/integrations/sources/custom) page.
 
-If you need to map Segment events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map Segment events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/stripe.mdx
+++ b/content/integrations/sources/stripe.mdx
@@ -172,7 +172,7 @@ You can modify the default action mappings or add new ones for any event type Kn
 
 If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
 
-If you need to map Stripe events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map Stripe events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/supabase.mdx
+++ b/content/integrations/sources/supabase.mdx
@@ -131,7 +131,7 @@ You can modify the default action mappings or add new ones for any event type Kn
 
 If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
 
-If you need to map Supabase events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map Supabase events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 

--- a/content/integrations/sources/workos.mdx
+++ b/content/integrations/sources/workos.mdx
@@ -116,7 +116,7 @@ You can modify the default action mappings or add new ones for any event type Kn
 
 If a single event type maps to multiple actions, Knock executes those actions in a fixed order. See [execution order for multiple mappings](/integrations/sources/overview#execution-order-for-multiple-mappings).
 
-If you need to map WorkOS events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#available-actions) in the sources overview.
+If you need to map WorkOS events to actions beyond triggering workflows, see the full list of [available actions](/integrations/sources/overview#triggering-actions-from-source-events) in the sources overview.
 
 ## Event idempotency
 


### PR DESCRIPTION
### Description

Fix broken anchor links in the "Customization" section of 7 source integration pages. The links referenced `/integrations/sources/overview#available-actions`, which doesn't exist. Updated to point to the correct anchor `/integrations/sources/overview#triggering-actions-from-source-events`

### Tasks

[KNO-13274](https://linear.app/knock/issue/KNO-13274/docs-update-links-to-sources-overview-page-referencing-available)
