### PR TITLE
fix(KNO-13276): Clarify workflow status selector location and terminology

### DIFF
--- a/content/concepts/workflows.mdx
+++ b/content/concepts/workflows.mdx
@@ -66,7 +66,7 @@ Read more about [environments](/version-control/environments) and [versioning](/
 
 ### Workflow status
 
-Each workflow has an `Active`/`Inactive` status that is displayed in your dashboard's **Workflows** section. The status defaults to `Active` and can be set by clicking on the workflow and using the "Status" selector.
+Each workflow has an `Active`/`Inactive` status that is displayed in your dashboard's **Workflows** section. The status defaults to `Active` and can be set by clicking on the workflow and using the **Status** selector in the **Details** section of the **Overview** tab.
 
 This is your kill switch for a given workflow should you need it; any attempt to trigger an `Inactive` workflow will result in a `workflow_inactive` [error](/api-reference/overview/errors) and no workflow runs will be enqueued.
 
@@ -163,7 +163,7 @@ You can learn more about automating workflow management in the [Knock CLI refere
     
     Workflow runs that are currently in a paused state (due to a [delay](/designing-workflows/delay-function) or [batch](/designing-workflows/batch-function) step) when you set your workflow to `Inactive` are not immediately affected; however, if the paused step completes and the workflow run progresses to the next step while the workflow remains `Inactive`, it will be terminated.
 
-    If you toggle a workflow to `Inactive` and back to `Active` while a given in-progress workflow run remains paused, that workflow run will resume at the end of the delay and continue to completion.
+    If you set a workflow to `Inactive` and back to `Active` while a given in-progress workflow run remains paused, that workflow run will resume at the end of the delay and continue to completion.
 
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

Updates the workflow status section to better explain where to find the Status selector (in the Details section of the Overview tab), and replaces a misleading reference to "toggle" with "set" to match the actual UI.

### Tasks

[KNO-13276](https://linear.app/knock/issue/KNO-13276/docs-update-toggle-reference-for-workflow-status)

