### PR TITLE
chore(kno-13295): add mAPI SDKs to docs

### DIFF
--- a/content/__api-reference/content.mdx
+++ b/content/__api-reference/content.mdx
@@ -19,14 +19,96 @@ https://api.knock.app/v1
 
 Knock offers native SDKs in several popular programming languages:
 
-- [Node.js](https://github.com/knocklabs/knock-node)
-- [Python](https://github.com/knocklabs/knock-python)
-- [Ruby](https://github.com/knocklabs/knock-ruby)
-- [Go](https://github.com/knocklabs/knock-go)
-- [PHP](https://github.com/knocklabs/knock-php)
-- [Java](https://github.com/knocklabs/knock-java)
-- [C# (dotnet)](https://github.com/knocklabs/knock-dotnet)
-- [Elixir](https://github.com/knocklabs/knock-elixir)
+<ul>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-node"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Node.js
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-python"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Python
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-ruby"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Ruby
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-go"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Go
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-php"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        PHP
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-java"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Java
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-dotnet"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        C# (dotnet)
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-elixir"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Elixir
+      </a>
+    }
+  </Text>
+</ul>
 
 </ContentColumn>
 </Section>

--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -52,6 +52,18 @@ https://control.knock.app/v1
 </ExampleColumn>
 </Section>
 
+<Section title="Client libraries" slug="client-libraries" path="/overview/client-libraries">
+<ContentColumn>
+
+Knock offers native SDKs for the management API in several popular programming languages:
+
+- <a href="https://github.com/knocklabs/knock-mgmt-node" target="_blank" rel="noopener noreferrer">Node.js</a>
+- <a href="https://github.com/knocklabs/knock-mgmt-python" target="_blank" rel="noopener noreferrer">Python</a>
+- <a href="https://github.com/knocklabs/knock-mgmt-go" target="_blank" rel="noopener noreferrer">Go</a>
+
+</ContentColumn>
+</Section>
+
 <Section title="Authentication" slug="authentication" path="/overview/authentication">
 <ContentColumn>
 

--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -57,9 +57,41 @@ https://control.knock.app/v1
 
 Knock offers native SDKs for the management API in several popular programming languages:
 
-- <a href="https://github.com/knocklabs/knock-mgmt-node" target="_blank" rel="noopener noreferrer">Node.js</a>
-- <a href="https://github.com/knocklabs/knock-mgmt-python" target="_blank" rel="noopener noreferrer">Python</a>
-- <a href="https://github.com/knocklabs/knock-mgmt-go" target="_blank" rel="noopener noreferrer">Go</a>
+<ul>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-node"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Node.js
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-python"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Python
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-go"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Go
+      </a>
+    }
+  </Text>
+</ul>
 
 </ContentColumn>
 </Section>

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -18,7 +18,11 @@ You can use the Knock management API to:
 
 ## Interacting with the management API
 
-Currently, we do not ship SDKs that wrap the management API but we do ship a [CLI](/developer-tools/knock-cli) for easily interacting with the resources in your Knock account.
+Knock provides SDKs for the management API in Node.js, Python, and Go. You can also use the [CLI](/developer-tools/knock-cli) for easily interacting with the resources in your Knock account.
+
+- <a href="https://github.com/knocklabs/knock-mgmt-node" target="_blank" rel="noopener noreferrer">Node.js management API SDK</a>
+- <a href="https://github.com/knocklabs/knock-mgmt-python" target="_blank" rel="noopener noreferrer">Python management API SDK</a>
+- <a href="https://github.com/knocklabs/knock-mgmt-go" target="_blank" rel="noopener noreferrer">Go management API SDK</a>
 
 ## Use cases
 

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -20,9 +20,41 @@ You can use the Knock management API to:
 
 Knock provides SDKs for the management API in Node.js, Python, and Go. You can also use the [CLI](/developer-tools/knock-cli) for easily interacting with the resources in your Knock account.
 
-- <a href="https://github.com/knocklabs/knock-mgmt-node" target="_blank" rel="noopener noreferrer">Node.js management API SDK</a>
-- <a href="https://github.com/knocklabs/knock-mgmt-python" target="_blank" rel="noopener noreferrer">Python management API SDK</a>
-- <a href="https://github.com/knocklabs/knock-mgmt-go" target="_blank" rel="noopener noreferrer">Go management API SDK</a>
+<ul>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-node"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Node.js management API SDK
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-python"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Python management API SDK
+      </a>
+    }
+  </Text>
+  <Text as="li" size="2" ml="4" data-tgph-list-item>
+    {
+      <a
+        href="https://github.com/knocklabs/knock-mgmt-go"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Go management API SDK
+      </a>
+    }
+  </Text>
+</ul>
 
 ## Use cases
 

--- a/content/developer-tools/sdks.mdx
+++ b/content/developer-tools/sdks.mdx
@@ -130,3 +130,31 @@ Knock's client-side libraries (also known as client-side SDKs) reduce the amount
     isExternal={true}
   />
 </SdkCardGroup>
+
+## Management API SDKs
+
+Knock also provides SDKs for the [Management API](/developer-tools/management-api), which you can use to programmatically manage your Knock dashboard resources.
+
+<SdkCardGroup>
+  <SdkCard
+    title="Node.js management API SDK"
+    linkUrl="https://github.com/knocklabs/knock-mgmt-node"
+    icon="node"
+    languages={["Node.js", "TypeScript"]}
+    isExternal={true}
+  />
+  <SdkCard
+    title="Python management API SDK"
+    linkUrl="https://github.com/knocklabs/knock-mgmt-python"
+    icon="python"
+    languages={["Python"]}
+    isExternal={true}
+  />
+  <SdkCard
+    title="Go management API SDK"
+    linkUrl="https://github.com/knocklabs/knock-mgmt-go"
+    icon="go"
+    languages={["Golang"]}
+    isExternal={true}
+  />
+</SdkCardGroup>

--- a/data/sidebars/mapiOverviewSidebar.ts
+++ b/data/sidebars/mapiOverviewSidebar.ts
@@ -32,6 +32,10 @@ export const MAPI_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [
         slug: `/`,
       },
       {
+        title: "Client libraries",
+        slug: `/client-libraries`,
+      },
+      {
         title: "Authentication",
         slug: `/authentication`,
       },


### PR DESCRIPTION
### Description

This PR adds the mAPI SDKs to the mAPI reference as well as the developer tools pages for mAPI and SDKs. It also updates the SDK links in the main API reference so that they will open in a new tab instead of redirecting the current page to GitHub.

- https://docs-kywejz932-knocklabs.vercel.app/developer-tools/management-api#interacting-with-the-management-api
- https://docs-kywejz932-knocklabs.vercel.app/developer-tools/sdks#management-api-sdks
- https://docs-kywejz932-knocklabs.vercel.app/mapi-reference/overview/client-libraries
- https://docs-kywejz932-knocklabs.vercel.app/api-reference/overview/client-libraries
