### PR TITLE
fix(KNO-13299): Use prettier-ignore to preserve inline <a> tag in Shopify Step component

### DIFF
--- a/content/integrations/sources/shopify.mdx
+++ b/content/integrations/sources/shopify.mdx
@@ -56,13 +56,9 @@ These steps are the same regardless of which Shopify path you use.
 Use this path if you're a store owner and want to forward events directly from a single Shopify store without building an app.
 
 <Steps>
+  {/* prettier-ignore */}
   <Step title="Create the webhook in Shopify">
-    In the [Shopify admin panel](https://www.shopify.com/admin), navigate to
-    **Settings > Notifications** and scroll to the **Webhooks** section. Click
-    "Create webhook," paste the Knock webhook URL into the **URL** field, select
-    the event topic you want to send (for example, `orders/create`), set the
-    format to **JSON**, and save. Repeat this step for each topic you want to
-    send to Knock.
+    In the <a href="https://www.shopify.com/admin" target="_blank" rel="noopener noreferrer">Shopify admin panel</a>, navigate to **Settings > Notifications** and scroll to the **Webhooks** section. Click "Create webhook," paste the Knock webhook URL into the **URL** field, select the event topic you want to send (for example, `orders/create`), set the format to **JSON**, and save. Repeat this step for each topic you want to send to Knock.
   </Step>
   <Step title="Copy the signing secret into Knock">
     After creating your first webhook, Shopify displays a **Signing secret** at


### PR DESCRIPTION
### Description
Follow up from https://github.com/knocklabs/docs/pull/1439#discussion_r3277447092

The `<a>` tag for the Shopify admin panel link inside the "Create the webhook in Shopify" step was causing a spacing bug. Prettier reformats inline `<a>` tags to multi-line JSX, which MDX then interprets as separate paragraphs, breaking the rendered output.

Added `{/* prettier-ignore */}` before the `<Step>` to preserve the inline `<a>` tag so the link renders correctly and opens in a new tab.

### Tasks

[KNO-13299](https://linear.app/knock/issue/KNO-13299/docs-look-into-shopify-step-link)

