### PR TITLE
fix(KNO-13317): Remove js-cookie 

### DIFF
--- a/lib/attribution.ts
+++ b/lib/attribution.ts
@@ -1,5 +1,3 @@
-import Cookies from "js-cookie";
-
 const FIRST_TOUCH_COOKIE = "knock_ft";
 const LAST_TOUCH_COOKIE = "knock_lt";
 const SESSION_COOKIE = "knock_session";
@@ -7,6 +5,38 @@ const ATTRIBUTION_EXPIRY_DAYS = 90;
 const SESSION_EXPIRY_MINUTES = 30;
 const COOKIE_DOMAIN_PROD = ".knock.app";
 const COOKIE_DOMAIN_DEV = ".knock-dev.app";
+
+interface CookieOptions {
+  expires?: number | Date;
+  domain?: string;
+  sameSite?: string;
+  secure?: boolean;
+}
+
+function getCookie(name: string): string | undefined {
+  const match = document.cookie.match(
+    new RegExp(
+      `(?:^|; )${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}=([^;]*)`,
+    ),
+  );
+  return match ? decodeURIComponent(match[1]) : undefined;
+}
+
+function setCookie(name: string, value: string, options: CookieOptions): void {
+  let cookie = `${name}=${encodeURIComponent(value)}`;
+  if (options.expires != null) {
+    const date =
+      options.expires instanceof Date
+        ? options.expires
+        : new Date(Date.now() + options.expires * 864e5);
+    cookie += `; expires=${date.toUTCString()}`;
+  }
+  if (options.domain) cookie += `; domain=${options.domain}`;
+  if (options.sameSite) cookie += `; SameSite=${options.sameSite}`;
+  if (options.secure) cookie += `; Secure`;
+  cookie += "; path=/";
+  document.cookie = cookie;
+}
 
 const UTM_PARAMS = [
   "utm_source",
@@ -90,7 +120,7 @@ function createAttributionData(): AttributionData | null {
 export function initAttribution(): void {
   if (typeof window === "undefined") return;
 
-  const cookieOptions: Cookies.CookieAttributes = {
+  const cookieOptions: CookieOptions = {
     expires: ATTRIBUTION_EXPIRY_DAYS,
     sameSite: "lax",
     secure: window.location.protocol === "https:",
@@ -99,18 +129,16 @@ export function initAttribution(): void {
   if (domain) cookieOptions.domain = domain;
 
   const attributionData = createAttributionData();
-  const isNewSession = !Cookies.get(SESSION_COOKIE);
+  const isNewSession = !getCookie(SESSION_COOKIE);
 
   // Refresh session cookie
-  const sessionOptions: Cookies.CookieAttributes = { ...cookieOptions };
   const sessionExpiry = new Date();
   sessionExpiry.setMinutes(sessionExpiry.getMinutes() + SESSION_EXPIRY_MINUTES);
-  sessionOptions.expires = sessionExpiry;
-  Cookies.set(SESSION_COOKIE, "1", sessionOptions);
+  setCookie(SESSION_COOKIE, "1", { ...cookieOptions, expires: sessionExpiry });
 
   // Set first touch only if it doesn't exist and we have attribution data
-  if (!Cookies.get(FIRST_TOUCH_COOKIE) && attributionData) {
-    Cookies.set(
+  if (!getCookie(FIRST_TOUCH_COOKIE) && attributionData) {
+    setCookie(
       FIRST_TOUCH_COOKIE,
       JSON.stringify(attributionData),
       cookieOptions,
@@ -119,7 +147,7 @@ export function initAttribution(): void {
 
   // Update last touch on new sessions if we have attribution data
   if (isNewSession && attributionData) {
-    Cookies.set(
+    setCookie(
       LAST_TOUCH_COOKIE,
       JSON.stringify(attributionData),
       cookieOptions,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "eventemitter": "^0.3.3",
     "framer-motion": "^12.7.4",
     "isomorphic-unfetch": "3.1.0",
-    "js-cookie": "^3.0.7",
     "js-yaml": "4.1.1",
     "jsonpointer": "^5.0.1",
     "locale-codes": "^1.3.1",
@@ -83,7 +82,6 @@
   },
   "devDependencies": {
     "@types/gtag.js": "^0.0.5",
-    "@types/js-cookie": "^3.0.6",
     "@types/node": "^14.14.32",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eventemitter": "^0.3.3",
     "framer-motion": "^12.7.4",
     "isomorphic-unfetch": "3.1.0",
-    "js-cookie": "^3.0.5",
+    "js-cookie": "^3.0.7",
     "js-yaml": "4.1.1",
     "jsonpointer": "^5.0.1",
     "locale-codes": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,11 +2095,6 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/js-cookie@^3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-3.0.6.tgz#a04ca19e877687bd449f5ad37d33b104b71fdf95"
-  integrity sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==
-
 "@types/katex@^0.16.0":
   version "0.16.8"
   resolved "https://registry.yarnpkg.com/@types/katex/-/katex-0.16.8.tgz#80bf3e0814d09a846412a0b0f140946b79c36c3e"
@@ -3928,11 +3923,6 @@ jiti@^1.21.7:
   version "1.21.7"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
-
-js-cookie@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
-  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3929,10 +3929,10 @@ jiti@^1.21.7:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
-js-cookie@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.5.tgz#0b7e2fd0c01552c58ba86e0841f94dc2557dcdbc"
-  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+js-cookie@^3.0.7:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
+  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
### Description
https://linear.app/knock/issue/KNO-13317/control-marketing-site-docs-small-upgrade-for-js-cookie

@kylemcd pointed out our usage is pretty trivial.

I rewrote the code to remove the dependency entirely instead of maintaining it


### Test steps:

Open `http://localhost:3002?utm_source=test&utm_medium=manual`

Verify that cookies are set correctly

<img width="2546" height="559" alt="Screenshot 2026-05-26 at 12 24 11 PM" src="https://github.com/user-attachments/assets/72cba669-9fcb-4fbb-9b95-2ae4759dfeb9" />


Refresh page without utm headers, verify cookies persist

<img width="2546" height="559" alt="Screenshot 2026-05-26 at 12 24 17 PM" src="https://github.com/user-attachments/assets/84cb3935-68de-4e82-8737-7c038a9d2e8b" />

<img width="2546" height="908" alt="Screenshot 2026-05-26 at 12 25 24 PM" src="https://github.com/user-attachments/assets/479b9b56-1bf5-4ac2-9fc8-5a5207694017" />



