### PR TITLE
docs(kno-13188): `commercial` and `override_preferences` workflow properties in template editor

### DIFF
--- a/content/template-editor/variables.mdx
+++ b/content/template-editor/variables.mdx
@@ -75,11 +75,13 @@ Provides access to the currently generated `Message` that the template is render
 
 Provides access to serialized properties about the currently executing workflow. The properties available are:
 
-| Variable     | Description                                   |
-| ------------ | --------------------------------------------- |
-| `id`         | The id of the version of the current workflow |
-| `key`        | The unique key of the workflow                |
-| `categories` | A list of categories set for the workflow     |
+| Variable               | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `id`                   | The id of the version of the current workflow                            |
+| `key`                  | The unique key of the workflow                                           |
+| `categories`           | A list of categories set for the workflow                                |
+| `commercial`           | Whether the workflow is marked as commercial messaging                   |
+| `override_preferences` | Whether to ignore recipient preferences for a given type of notification |
 
 ### Tenant
 

--- a/content/template-editor/variables.mdx
+++ b/content/template-editor/variables.mdx
@@ -75,13 +75,13 @@ Provides access to the currently generated `Message` that the template is render
 
 Provides access to serialized properties about the currently executing workflow. The properties available are:
 
-| Variable               | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| `id`                   | The id of the version of the current workflow                            |
-| `key`                  | The unique key of the workflow                                           |
-| `categories`           | A list of categories set for the workflow                                |
-| `commercial`           | Whether the workflow is marked as commercial messaging                   |
-| `override_preferences` | Whether to ignore recipient preferences for a given type of notification |
+| Variable               | Description                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------- |
+| `id`                   | The id of the version of the current workflow                                               |
+| `key`                  | The unique key of the workflow                                                              |
+| `categories`           | A list of categories set for the workflow                                                   |
+| `commercial`           | Whether the workflow is marked as commercial messaging                                      |
+| `override_preferences` | Whether the workflow is configured to ignore recipient preferences and send to all channels |
 
 ### Tenant
 


### PR DESCRIPTION
### Description

- Added new variables `commercial` and `override_preferences` to the workflow properties section

### Tasks

[KNO-13188](https://linear.app/knock/issue/KNO-13188/control-switchboard-expose-override-preferences-flag-in-workflow)

### Screenshots

<img width="820" height="322" alt="Screenshot 2026-05-27 at 14 35 15" src="https://github.com/user-attachments/assets/1d9f2621-f57d-4829-8d62-6c70e8e9056c" />
