### PR TITLE
chore: removes go and python mgmt sdks

### DIFF
--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -69,28 +69,6 @@ Knock offers native SDKs for the management API in several popular programming l
       </a>
     }
   </Text>
-  <Text as="li" size="2" ml="4" data-tgph-list-item>
-    {
-      <a
-        href="https://github.com/knocklabs/knock-mgmt-python"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Python
-      </a>
-    }
-  </Text>
-  <Text as="li" size="2" ml="4" data-tgph-list-item>
-    {
-      <a
-        href="https://github.com/knocklabs/knock-mgmt-go"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Go
-      </a>
-    }
-  </Text>
 </ul>
 
 </ContentColumn>

--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -55,7 +55,7 @@ https://control.knock.app/v1
 <Section title="Client libraries" slug="client-libraries" path="/overview/client-libraries">
 <ContentColumn>
 
-Knock offers native SDKs for the management API in several popular programming languages:
+Knock offers a Node.js SDK for the management API:
 
 <ul>
   <Text as="li" size="2" ml="4" data-tgph-list-item>

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -32,28 +32,6 @@ Knock provides SDKs for the management API in Node.js, Python, and Go. You can a
       </a>
     }
   </Text>
-  <Text as="li" size="2" ml="4" data-tgph-list-item>
-    {
-      <a
-        href="https://github.com/knocklabs/knock-mgmt-python"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Python management API SDK
-      </a>
-    }
-  </Text>
-  <Text as="li" size="2" ml="4" data-tgph-list-item>
-    {
-      <a
-        href="https://github.com/knocklabs/knock-mgmt-go"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Go management API SDK
-      </a>
-    }
-  </Text>
 </ul>
 
 ## Use cases

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -18,7 +18,7 @@ You can use the Knock management API to:
 
 ## Interacting with the management API
 
-Knock provides SDKs for the management API in Node.js, Python, and Go. You can also use the [CLI](/developer-tools/knock-cli) for easily interacting with the resources in your Knock account.
+Knock provides a Node.js SDK for the management API. You can also use the [CLI](/developer-tools/knock-cli) for easily interacting with the resources in your Knock account.
 
 <ul>
   <Text as="li" size="2" ml="4" data-tgph-list-item>

--- a/content/developer-tools/sdks.mdx
+++ b/content/developer-tools/sdks.mdx
@@ -143,18 +143,4 @@ Knock also provides SDKs for the [Management API](/developer-tools/management-ap
     languages={["Node.js", "TypeScript"]}
     isExternal={true}
   />
-  <SdkCard
-    title="Python management API SDK"
-    linkUrl="https://github.com/knocklabs/knock-mgmt-python"
-    icon="python"
-    languages={["Python"]}
-    isExternal={true}
-  />
-  <SdkCard
-    title="Go management API SDK"
-    linkUrl="https://github.com/knocklabs/knock-mgmt-go"
-    icon="go"
-    languages={["Golang"]}
-    isExternal={true}
-  />
 </SdkCardGroup>

--- a/content/developer-tools/sdks.mdx
+++ b/content/developer-tools/sdks.mdx
@@ -133,7 +133,7 @@ Knock's client-side libraries (also known as client-side SDKs) reduce the amount
 
 ## Management API SDKs
 
-Knock also provides SDKs for the [Management API](/developer-tools/management-api), which you can use to programmatically manage your Knock dashboard resources.
+Knock also provides a Node.js SDK for the [Management API](/developer-tools/management-api), which you can use to programmatically manage your Knock dashboard resources.
 
 <SdkCardGroup>
   <SdkCard


### PR DESCRIPTION
### Description

Our build pipeline hasn't been executing these for a while. Let's remove from docs since our support isn't 100%.
