### PR TITLE
feat: knock test emails only go to account members

### DIFF
--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -13,7 +13,8 @@ Knock comes with a built-in email channel to test your email notifications. This
   text={
     <>
       This provider is for testing purposes only. Sending is limited to email
-      addresses associated with the [members](/manage-your-account/managing-members) of your Knock account.
+      addresses associated with the
+      [members](/manage-your-account/managing-members) of your Knock account.
     </>
   }
 />

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -12,7 +12,7 @@ Knock comes with a built-in email channel to test your email notifications. This
   title="Note:"
   text={
     <>
-      This provider is for testing purposes only and is limited to send to email
+      This provider is for testing purposes only. Sending is limited to email
       addresses associated with the members of your Knock account.
     </>
   }

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -5,15 +5,15 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock comes with a built-in email channel to send email notifications to your users. This is a great way to get started with email notifications without needing to integrate with an external email provider.
+Knock comes with a built-in email channel to test your email notifications before sending them to your users. This is a great way to get started with email notifications without needing to integrate with an external email provider.
 
 <Callout
   type="warning"
   title="Note:"
   text={
     <>
-      This provider is for testing purposes only and is not intended for
-      production use. For production use, please configure a different provider.
+      This provider is for testing purposes only and is limited to send to email
+      addresses associated with the members of your Knock account only.
     </>
   }
 />
@@ -31,6 +31,10 @@ Knock comes with a built-in email channel to send email notifications to your us
 ## Getting started
 
 You'll find the Knock test channel under the **Channels and sources** page in your account settings. By default, all new Knock accounts will have the channel enabled and ready to use across all environments with no additional configuration required.
+
+### Allowed recipients
+
+The Knock test channel is limited to sending emails to email addresses associated with the **members of your Knock account only**. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error (`knock_recipient_not_allowed`).
 
 ## Channel configuration
 
@@ -130,6 +134,9 @@ Delivery tracking can result in the following status updates to your message:
 <AccordionGroup>
   <Accordion title="What is the limit on the number of emails I can send?">
     You can send up to 100 emails per month for free.
+  </Accordion>
+  <Accordion title="Who can I send emails to?">
+    You can only send emails to email addresses that are associated with the **members** of your Knock account. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error.
   </Accordion>
   <Accordion title="What happens when I exceed the limit?">
     If you exceed the monthly limit, your emails will be marked as `undelivered`

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -13,7 +13,7 @@ Knock comes with a built-in email channel to test your email notifications. This
   text={
     <>
       This provider is for testing purposes only. Sending is limited to email
-      addresses associated with the members of your Knock account.
+      addresses associated with the [members](/manage-your-account/managing-members) of your Knock account.
     </>
   }
 />
@@ -34,7 +34,7 @@ You'll find the Knock test channel under the **Channels and sources** page in yo
 
 ### Allowed recipients
 
-The Knock test channel is limited to sending emails to email addresses associated with the **members of your Knock account only**. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error (`knock_recipient_not_allowed`).
+The Knock test channel is limited to sending emails to email addresses associated with the **[members](/manage-your-account/managing-members) of your Knock account only**. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error (`knock_recipient_not_allowed`).
 
 ## Channel configuration
 
@@ -136,7 +136,7 @@ Delivery tracking can result in the following status updates to your message:
     You can send up to 100 emails per month for free.
   </Accordion>
   <Accordion title="Who can I send emails to?">
-    You can only send emails to email addresses that are associated with the **members** of your Knock account. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error.
+    You can only send emails to email addresses that are associated with the [**members**](/manage-your-account/managing-members) of your Knock account. Attempting to send emails to email addresses that are not associated with a member will result in a delivery error.
   </Accordion>
   <Accordion title="What happens when I exceed the limit?">
     If you exceed the monthly limit, your emails will be marked as `undelivered`

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -5,7 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock comes with a built-in email channel to test your email notifications before sending them to your users. This is a great way to get started with email notifications without needing to integrate with an external email provider.
+Knock comes with a built-in email channel to test your email notifications. This is a great way to get started with email notifications without needing to integrate with an external email provider.
 
 <Callout
   type="warning"
@@ -13,7 +13,7 @@ Knock comes with a built-in email channel to test your email notifications befor
   text={
     <>
       This provider is for testing purposes only and is limited to send to email
-      addresses associated with the members of your Knock account only.
+      addresses associated with the members of your Knock account.
     </>
   }
 />


### PR DESCRIPTION
### Description

Limit Knock test channel to send to members of the account only