### PR TITLE
fix(kno-13429): fix query param typo and add css import note to guide…

### DIFF
--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -32,12 +32,13 @@ The guides toolbar is a floating panel that enables you to inspect and debug gui
 
 <Callout
   type="warning"
-  title="SDK version requirement."
+  title="Technical requirements."
   text={
     <>
-      Guides toolbar requires <code>@knocklabs/react</code> v0.11.13 or higher.
+      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.11.13 or higher and must include an import of <code>@knocklabs/react/dist/index.css</code>.
     </>
-  }
+
+}
 />
 
 ### Activating the toolbar
@@ -46,7 +47,7 @@ The guides toolbar is a floating panel that enables you to inspect and debug gui
 2. Provide or confirm the URL for your environment and click **Open preview**. The URL should point to a page where the guide's target element exists and the [guide provider is initialized](/in-app-ui/guides/render-guides).
 3. After clicking **Open preview**, the toolbar appears as a floating panel that you can expand or collapse.
 
-You can also reopen the toolbar at any time by appending `?knock_guides_toolbar=true` to any URL in your application.
+You can also reopen the toolbar at any time by appending `?knock_guide_toolbar=true` to any URL in your application.
 
 ### Toolbar views
 

--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -35,7 +35,7 @@ The guides toolbar is a floating panel that enables you to inspect and debug gui
   title="Technical requirements."
   text={
     <>
-      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.11.13 or higher and must include an import of <code>@knocklabs/react/dist/index.css</code>.
+      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.11.13 or higher and import <code>@knocklabs/react/dist/index.css</code>.
     </>
 
 }


### PR DESCRIPTION
### Summary
- Add a note that `@knocklabs/react/dist/index.css` must be imported for the toolbar.
- Fix incorrect query parameter `knock_guides_toolbar=true` → `knock_guide_toolbar=true`.

### Changes
- `content/in-app-ui/guides/debugging-guides.mdx` — add CSS import note; fix query param typo