### PR TITLE
chore(kno-13491): clarify cross-platform payload overrides for Expo

### DIFF
--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -129,7 +129,7 @@ Overrides are merged into the notification payload sent to Expo. See the <a href
 
 When using the `expo-notifications` SDK, the device's platform determines where custom payload data lands in the notification object. Your Knock payload overrides should account for both iOS and Android to ensure that the data is accessible under the same `notification.request.content.data` key on both platforms.
 
-- **iOS (APNs):** Nest custom data under the `body` key. The `expo-notifications` SDK <a href="https://docs.expo.dev/push-notifications/receiving-notifications/#ios-notification-object-example-from-addnotificationreceivedlistener" target="_blank">maps</a> `request.trigger.payload.body` properties to `request.content.data` in the notification object received by the Expo iOS event listeners.
+- **iOS (APNs):** Nest custom data under the `body` key. The `expo-notifications` SDK maps `request.trigger.payload.body` properties to `request.content.data` in <a href="https://docs.expo.dev/push-notifications/receiving-notifications/#ios-notification-object-example-from-addnotificationreceivedlistener" target="_blank">the notification object</a> received by the Expo iOS event listeners.
 - **Android (FCM):** Nest custom data under the `data` key. Note that FCM <a href="https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages" target="_blank">requires</a> `data` to be a flat dictionary with string values.
 
 You can include both keys in the same override; each platform will use its own key and ignore the other.

--- a/content/integrations/push/expo.mdx
+++ b/content/integrations/push/expo.mdx
@@ -125,6 +125,28 @@ Push overrides support Liquid for injecting `data` properties and referencing at
 
 Overrides are merged into the notification payload sent to Expo. See the <a href="https://docs.expo.dev/push-notifications/sending-notifications/#message-request-format" target="_blank">Expo documentation for more details</a>.
 
+### Accessing custom data client-side with `expo-notifications`
+
+When using the `expo-notifications` SDK, the device's platform determines where custom payload data lands in the notification object. Your Knock payload overrides should account for both iOS and Android to ensure that the data is accessible under the same `notification.request.content.data` key on both platforms.
+
+- **iOS (APNs):** Nest custom data under the `body` key. The `expo-notifications` SDK <a href="https://docs.expo.dev/push-notifications/receiving-notifications/#ios-notification-object-example-from-addnotificationreceivedlistener" target="_blank">maps</a> `request.trigger.payload.body` properties to `request.content.data` in the notification object received by the Expo iOS event listeners.
+- **Android (FCM):** Nest custom data under the `data` key. Note that FCM <a href="https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages" target="_blank">requires</a> `data` to be a flat dictionary with string values.
+
+You can include both keys in the same override; each platform will use its own key and ignore the other.
+
+```json title="A payload override to send a custom URL property to both iOS and Android"
+{
+  "body": {
+    "url": "{{ data.url }}"
+  },
+  "data": {
+    "url": "{{ data.url }}"
+  }
+}
+```
+
+With the above override, `request.content.data.url` will be accessible on both platforms.
+
 ## Channel data requirements
 
 In order to use a configured Expo channel you must store a list of one or more device tokens for the user or the object that you wish to deliver a notification to. You can retrieve a device token by following the tutorial in the <a href="https://docs.expo.dev/push-notifications/push-notifications-setup/" target="_blank">Expo developer documentation</a>.


### PR DESCRIPTION
### Description

This PR adds guidance on how to handle payload overrides when working with an Expo channel so that custom data will appear under `notification.request.content.data` regardless of which platform the recipient device uses.
