### PR TITLE
chore(KNO-13495): Add broadcast email best practices

### DIFF
--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -24,7 +24,7 @@ Broadcasts are a way to power one-time, cross-channel messaging to your users th
 <Callout
   type="info"
   title="Consider using a separate email channel for marketing broadcasts."
-  text="If you plan to use broadcasts for high-volume or frequent marketing sends, we recommend configuring a dedicated email channel that is separate from your transactional email channel, and using a separate sending domain or subdomain where possible. Marketing and transactional email can have different engagement and complaint patterns, and separating them helps protect the deliverability and sender reputation of your transactional email."
+  text="If you plan to send frequent or high-volume marketing broadcasts, we recommend configuring a dedicated email channel that is separate from your transactional email channel, with a unique sending domain or subdomain where possible. Marketing and transactional email can have different engagement and complaint patterns, and separating them helps protect the deliverability and sender reputation of your transactional email."
 />
 
 ## Broadcasts and the environment model

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -131,6 +131,10 @@ Broadcasts respect all [user preferences](/concepts/preferences) that are config
 
 Knock also supports [commercial unsubscribe](/preferences/commercial-unsubscribe) preferences that will automatically add a 1-click unsubscribe header and link to your email messages, to respect CAN-SPAM compliance.
 
+## Best practices
+
+If you plan to send broadcasts regularly or at high volume, we recommend configuring a dedicated email channel for marketing sends that is separate from your transactional email channel, and ideally using a separate sending domain or subdomain. Marketing and transactional email have different engagement and complaint patterns, and isolating them protects the deliverability and sender reputation of your transactional email if a broadcast generates higher-than-expected unsubscribes or spam complaints.
+
 ## Frequently asked questions
 
 <AccordionGroup>

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -50,6 +50,12 @@ In the broadcast builder, you can add:
 
 When adding a channel step, you can select from any of the channel types you've configured in Knock to send a message to a user on that channel. Once you've added a channel step, you can design and manage the template for the step by selecting the channel step and clicking the "Edit template" button.
 
+<Callout
+  type="info"
+  title="Consider a dedicated email channel for broadcasts."
+  text="If you plan to send broadcasts at high volume or on a set cadence, we recommend configuring a dedicated email channel for marketing sends, separate from your transactional email channel and using a separate sending domain or subdomain. Marketing and transactional email can have different engagement and complaint patterns, and isolating them helps protect the deliverability and sender reputation of your transactional email if a broadcast generates higher-than-expected unsubscribes or spam complaints."
+/>
+
 ### Working with the template editor
 
 The broadcast template editor is the same template editor you've come to know and love from [workflows](/concepts/workflows). You can read more about working in the template editor [here](/template-editor/overview).
@@ -130,10 +136,6 @@ Additionally, developer tools and extensions are available for broadcasts as the
 Broadcasts respect all [user preferences](/concepts/preferences) that are configured in Knock. That means for any categories added to a broadcast, preferences linked to those categories will be respected. Additionally, any channel type preferences set for a user will be respected during the execution of a broadcast.
 
 Knock also supports [commercial unsubscribe](/preferences/commercial-unsubscribe) preferences that will automatically add a 1-click unsubscribe header and link to your email messages, to respect CAN-SPAM compliance.
-
-## Best practices
-
-If you plan to send broadcasts regularly or at high volume, we recommend configuring a dedicated email channel for marketing sends that is separate from your transactional email channel, and ideally using a separate sending domain or subdomain. Marketing and transactional email have different engagement and complaint patterns, and isolating them protects the deliverability and sender reputation of your transactional email if a broadcast generates higher-than-expected unsubscribes or spam complaints.
 
 ## Frequently asked questions
 

--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -21,6 +21,12 @@ section: Concepts
 
 Broadcasts are a way to power one-time, cross-channel messaging to your users through Knock. They are built on Knock's [workflow engine](/concepts/workflows), giving you the power to create intelligent messaging across all of the [channels you've configured in Knock](/concepts/channels).
 
+<Callout
+  type="info"
+  title="Consider using a separate email channel for marketing broadcasts."
+  text="If you plan to use broadcasts for high-volume or frequent marketing sends, we recommend configuring a dedicated email channel that is separate from your transactional email channel, and using a separate sending domain or subdomain where possible. Marketing and transactional email can have different engagement and complaint patterns, and separating them helps protect the deliverability and sender reputation of your transactional email."
+/>
+
 ## Broadcasts and the environment model
 
 Unlike workflows and other resources in Knock, broadcasts do not have to be committed or promoted to an environment before they can be used. In fact, unlike workflows, broadcasts are **environment-specific** and can be created in any environment (including production).
@@ -49,12 +55,6 @@ In the broadcast builder, you can add:
 - [Channel steps](/designing-workflows/channel-step): to send a message to a user on a specific channel.
 
 When adding a channel step, you can select from any of the channel types you've configured in Knock to send a message to a user on that channel. Once you've added a channel step, you can design and manage the template for the step by selecting the channel step and clicking the "Edit template" button.
-
-<Callout
-  type="info"
-  title="Consider a dedicated email channel for broadcasts."
-  text="If you plan to send broadcasts at high volume or on a set cadence, we recommend configuring a dedicated email channel for marketing sends, separate from your transactional email channel and using a separate sending domain or subdomain. Marketing and transactional email can have different engagement and complaint patterns, and isolating them helps protect the deliverability and sender reputation of your transactional email if a broadcast generates higher-than-expected unsubscribes or spam complaints."
-/>
 
 ### Working with the template editor
 


### PR DESCRIPTION
### Description

Adds a callout to the broadcast page recommending that customers consider adding a separate, dedicated marketing email channel for recurring/high-volume broadcasts to help protect transactional email deliverability and sender reputation. 

https://docs-git-rt-kno-13495-broadcast-best-practices-knocklabs.vercel.app/concepts/broadcasts#best-practices

### Tasks

[KNO-13495](https://linear.app/knock/issue/KNO-13495/docs-add-best-practice-recommendation-for-segmenting-marketing-and)
