### PR TITLE
chore(kno-13539) remove experiment function beta callout

### DIFF
--- a/content/designing-workflows/experiment-function.mdx
+++ b/content/designing-workflows/experiment-function.mdx
@@ -17,20 +17,6 @@ tags:
 section: Designing workflows
 ---
 
-<Callout
-  type="beta"
-  text={
-    <>
-      Experiment function is currently in beta. If you'd like early access, or
-      this is blocking your adoption of Knock, please{" "}
-      <a href="mailto:support@knock.app?subject=Experiment function">
-        get in touch
-      </a>
-      .
-    </>
-  }
-/>
-
 The experiment function enables you to split recipients into randomized cohorts within your workflows, routing each recipient down a specific branch based on a percentage-based distribution. This is useful for A/B testing notification content, gradually rolling out new notification strategies, or running experiments across your recipient base.
 
 <Image


### PR DESCRIPTION
### Description

This PR removes the beta callout on the experiment function page.