### PR TITLE
fix(kno-13650): fix broken link in callout, add clarity to intro on Knock email page

### DIFF
--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -14,7 +14,7 @@ Knock comes with a built-in email channel to test your email notifications. This
     <>
       This provider is for testing purposes only. Sending is limited to email
       addresses associated with the{" "}
-      <a href="https://dashboard.knock.app/~/settings/team">members</a> of your
+      <a href="https://dashboard.knock.app/~/settings/team" target="_blank">members</a> of your
       Knock account.
     </>
   }

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -1,11 +1,11 @@
 ---
 title: Send email with Knock's built-in test channel
-description: Get started with Knock's built-in email channel to start sending email notifications.
+description: Start testing with Knock's built-in email channel.
 section: Integrations > Email
 layout: integrations
 ---
 
-Knock comes with a built-in email channel to test your email notifications. This is a great way to get started with email notifications without needing to integrate with an external email provider.
+Knock comes with a built-in email channel to test your email notifications. This is a great way to get started with testing email notifications quickly before integrating your [email provider of choice](/integrations/email/overview#supported-providers).
 
 <Callout
   type="warning"
@@ -13,8 +13,9 @@ Knock comes with a built-in email channel to test your email notifications. This
   text={
     <>
       This provider is for testing purposes only. Sending is limited to email
-      addresses associated with the
-      [members](/manage-your-account/managing-members) of your Knock account.
+      addresses associated with the{" "}
+      <a href="https://dashboard.knock.app/~/settings/team">members</a> of your
+      Knock account.
     </>
   }
 />

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -14,8 +14,10 @@ Knock comes with a built-in email channel to test your email notifications. This
     <>
       This provider is for testing purposes only. Sending is limited to email
       addresses associated with the{" "}
-      <a href="https://dashboard.knock.app/~/settings/team" target="_blank">members</a> of your
-      Knock account.
+      <a href="https://dashboard.knock.app/~/settings/team" target="_blank">
+        members
+      </a>{" "}
+      of your Knock account.
     </>
   }
 />

--- a/content/integrations/email/knock-test.mdx
+++ b/content/integrations/email/knock-test.mdx
@@ -5,7 +5,7 @@ section: Integrations > Email
 layout: integrations
 ---
 
-Knock comes with a built-in email channel to test your email notifications. This is a great way to get started with testing email notifications quickly before integrating your [email provider of choice](/integrations/email/overview#supported-providers).
+Knock comes with a built-in email channel to test your email notifications. This is a great way to explore Knock and start testing email notifications before integrating your [email provider of choice](/integrations/email/overview#supported-providers).
 
 <Callout
   type="warning"


### PR DESCRIPTION
## KNO-13650: Fix broken link and add clarity to Knock email page

### Summary

Update members link
- Fix markdown link in Callout `text` prop — markdown syntax doesn't render inside JSX; replaced with a JSX `<a>` element.
- Also updated the link to dynamically link to the dashboard team page.

Clarify intent
- Update intro paragraph to clarify the channel is for initial evaluation until you connect your ESP.
- Adjusted subtitle of the page to help clarify intent. 