### PR TITLE
chore(kno-13657): add failure reason enums for `message.undelivered` event

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -103,12 +103,12 @@ Occurs when a message delivery attempt fails permanently. Delivery will not be r
       <Attribute
         name="failure_reason"
         type="string"
-        description="The reason for a message failure."
+        description="The reason for a message failure. One of `fatal_error` or `retries_exhausted`."
       />
       <Attribute
         name="failure_details"
         type="string"
-        description="Details about a message failure."
+        description="Details about a message failure. This field varies by provider and is nullable."
       />
     </Attributes>
   </Attribute>


### PR DESCRIPTION
### Description

Adds enums for `failure_reason` on the `message.undelivered` webhook event. Also clarifies that `failure_details` will vary by provider and is nullable.