### PR TITLE
docs(KNO-13457): document the directory sync account-lockout edge

### DIFF
--- a/content/manage-your-account/directory-sync.mdx
+++ b/content/manage-your-account/directory-sync.mdx
@@ -59,6 +59,25 @@ In the case where you want to force a group to a particular role within your IDP
 
 If a user does not belong to any group, Knock will assign the **support** role to the user. If a user belongs to more than one of these groups, then Knock will assign the **highest privileged role available** to that user. See [roles and permissions](/manage-your-account/roles-and-permissions) for more details.
 
+## Preventing account lockout
+
+Because Knock uses your identity provider as the source of truth, role changes coming from your IdP are applied even when they would remove or demote your last account owner. As a result, it's possible to end up with an account that has no owner — for example, if the only user mapped to the `owner` role is removed from your directory (or from the `knock-role-owner` group).
+
+<Callout
+  type="warning"
+  title="Keep at least one owner in your directory."
+  text={
+    <>
+      To avoid losing owner access, make sure at least one person is always
+      mapped to the <code>owner</code> role — via the{" "}
+      <code>knock-role-owner</code> group or your custom group-to-role mapping —
+      and is not removed from your identity provider. If owner access is lost,
+      re-add a user to the owner-granting group from your IdP to restore it, or
+      contact the <a href="mailto:support@knock.app">Knock support team</a>.
+    </>
+  }
+/>
+
 ## Frequently asked questions
 
 <AccordionGroup>


### PR DESCRIPTION
## Summary

Adds a **Preventing account lockout** section to the directory sync page (KNO-13457).

Because Knock treats the IdP as the source of truth, directory sync applies role changes even when they remove or demote an account's last owner — so an account can end up with no owner. This documents how to **prevent** it (keep at least one user mapped to the `owner` role via the `knock-role-owner` group) and how to **recover** (re-add a user to the owner-granting group from the IdP, or contact support).

Context: the backend deliberately does *not* block dsync from doing this — blocking would break the IdP source-of-truth contract. This is the customer-facing callout for that edge.
