### PR TITLE
Upgrade ws to 8.21.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6491,9 +6491,9 @@ wrappy@1:
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 ws@^8.2.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Upgrade the transitive `ws@^8.2.3` lockfile entry from `8.18.3` to `8.21.0` to pick up the patched release for the security issue.

### Todos

- [ ] Review and merge

### Tasks

Tracked in Linear.

### Screenshots

Not relevant for this lockfile-only dependency update.

### Verification

- `yarn install --frozen-lockfile --ignore-engines`
- `yarn why ws --ignore-engines` reports `ws@8.21.0` hoisted from `next-remote-refresh#ws`
- `node -p "require('ws/package.json').version"` prints `8.21.0`
- `yarn lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13785](https://linear.app/knock/issue/KNO-13785/minor-upgrade-for-ws)

<div><a href="https://cursor.com/agents/bc-d14a6eea-1c81-49bb-a05b-0730284c618f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d14a6eea-1c81-49bb-a05b-0730284c618f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

