### PR TITLE
Upgrade structured clone dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,9 +2221,9 @@
     eslint-visitor-keys "^3.3.0"
 
 "@ungap/structured-clone@^1.0.0", "@ungap/structured-clone@^1.2.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
-  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.1.tgz#0e8f34854df7966b09304a18e808b23997bb9fc1"
+  integrity sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
 
 "@vercel/og@^0.5.20":
   version "0.5.20"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Upgrade the transitive `@ungap/structured-clone` lockfile resolution from 1.3.0 to 1.3.1 for the structured clone patch release.

### Todos

None.

### Tasks

Handled in the assigned security issue.

### Screenshots

Not relevant for this lockfile-only security upgrade.

### Verification

- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn why @ungap/structured-clone`
- `yarn list --pattern @ungap/structured-clone`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13789](https://linear.app/knock/issue/KNO-13789/small-upgrade-for-ungapstructured-clone)

<div><a href="https://cursor.com/agents/bc-be7a4b62-57aa-4e74-8a5b-40d939b1ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be7a4b62-57aa-4e74-8a5b-40d939b1ef38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

