### PR TITLE
Add PostHog events for Ask AI and docs search

### DIFF
--- a/components/AiChatButton.tsx
+++ b/components/AiChatButton.tsx
@@ -49,7 +49,7 @@ export function InkeepModalProvider({ children }: { children: ReactNode }) {
   } = useInkeepSettings();
 
   const openWithPrompt = useCallback((prompt: string) => {
-    posthog.track("ask_ai_mobile_modal_opened", {
+    posthog.track("ask-ai-mobile-modal-opened-client", {
       source: "search",
       has_prompt: true,
       prompt_length: prompt.length,
@@ -86,7 +86,7 @@ export function InkeepModalProvider({ children }: { children: ReactNode }) {
       <div className="md-visible">
         <button
           onClick={() => {
-            posthog.track("ask_ai_mobile_modal_opened", {
+            posthog.track("ask-ai-mobile-modal-opened-client", {
               source: "floating_button",
               has_prompt: false,
             });

--- a/components/AiChatButton.tsx
+++ b/components/AiChatButton.tsx
@@ -12,6 +12,8 @@ import {
   useState,
 } from "react";
 
+import * as posthog from "@/lib/posthog";
+
 import useInkeepSettings from "../hooks/useInKeepSettings";
 
 const ModalChat = dynamic(
@@ -47,6 +49,11 @@ export function InkeepModalProvider({ children }: { children: ReactNode }) {
   } = useInkeepSettings();
 
   const openWithPrompt = useCallback((prompt: string) => {
+    posthog.track("ask_ai_mobile_modal_opened", {
+      source: "search",
+      has_prompt: true,
+      prompt_length: prompt.length,
+    });
     setInitialQuery(prompt);
     setIsOpen(true);
   }, []);
@@ -78,7 +85,13 @@ export function InkeepModalProvider({ children }: { children: ReactNode }) {
       {children}
       <div className="md-visible">
         <button
-          onClick={() => setIsOpen(true)}
+          onClick={() => {
+            posthog.track("ask_ai_mobile_modal_opened", {
+              source: "floating_button",
+              has_prompt: false,
+            });
+            setIsOpen(true);
+          }}
           className="fixed right-4 bottom-4 z-40 flex h-11 w-11 items-center justify-center rounded-full border shadow-lg"
           style={{
             borderColor: "var(--tgph-gray-4)",

--- a/components/AskAiContext.tsx
+++ b/components/AskAiContext.tsx
@@ -236,25 +236,25 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const openSidebar = useCallback(() => {
-    posthog.track("ask_ai_sidebar_opened", {
+    posthog.track("ask-ai-sidebar-opened-client", {
       source: "button",
     });
     setIsOpen(true);
   }, []);
 
   const closeSidebar = useCallback(() => {
-    posthog.track("ask_ai_sidebar_closed");
+    posthog.track("ask-ai-sidebar-closed-client");
     setIsOpen(false);
   }, []);
 
   const toggleSidebar = useCallback(() => {
     setIsOpen((prev) => {
       if (!prev) {
-        posthog.track("ask_ai_sidebar_opened", {
+        posthog.track("ask-ai-sidebar-opened-client", {
           source: "button",
         });
       } else {
-        posthog.track("ask_ai_sidebar_closed");
+        posthog.track("ask-ai-sidebar-closed-client");
       }
       return !prev;
     });
@@ -262,7 +262,7 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
 
   const openSidebarWithPrompt = useCallback(
     (prompt: string) => {
-      posthog.track("ask_ai_sidebar_opened", {
+      posthog.track("ask-ai-sidebar-opened-client", {
         source: "search",
         has_prompt: true,
         prompt_length: prompt.length,
@@ -282,7 +282,7 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
     (sessionId: string) => {
       const session = chatSessions.find((s) => s.id === sessionId);
       if (session) {
-        posthog.track("ask_ai_session_switched", {
+        posthog.track("ask-ai-session-switched-client", {
           message_count: session.messages.length,
         });
 

--- a/components/AskAiContext.tsx
+++ b/components/AskAiContext.tsx
@@ -10,6 +10,8 @@ import {
   useState,
 } from "react";
 
+import * as posthog from "@/lib/posthog";
+
 const STORAGE_KEYS = {
   sidebarWidth: "askAiSidebarWidth",
   chatSessions: "askAiChatSessions",
@@ -233,11 +235,38 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
     return sessionId;
   }, []);
 
-  const openSidebar = useCallback(() => setIsOpen(true), []);
-  const closeSidebar = useCallback(() => setIsOpen(false), []);
-  const toggleSidebar = useCallback(() => setIsOpen((prev) => !prev), []);
+  const openSidebar = useCallback(() => {
+    posthog.track("ask_ai_sidebar_opened", {
+      source: "button",
+    });
+    setIsOpen(true);
+  }, []);
+
+  const closeSidebar = useCallback(() => {
+    posthog.track("ask_ai_sidebar_closed");
+    setIsOpen(false);
+  }, []);
+
+  const toggleSidebar = useCallback(() => {
+    setIsOpen((prev) => {
+      if (!prev) {
+        posthog.track("ask_ai_sidebar_opened", {
+          source: "button",
+        });
+      } else {
+        posthog.track("ask_ai_sidebar_closed");
+      }
+      return !prev;
+    });
+  }, []);
+
   const openSidebarWithPrompt = useCallback(
     (prompt: string) => {
+      posthog.track("ask_ai_sidebar_opened", {
+        source: "search",
+        has_prompt: true,
+        prompt_length: prompt.length,
+      });
       // Create new session before setting prompt to ensure each query starts fresh
       createNewSession();
       setInitialPrompt(prompt);
@@ -245,6 +274,7 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
     },
     [createNewSession],
   );
+
   const clearInitialPrompt = useCallback(() => setInitialPrompt(null), []);
 
   // Select an existing chat session
@@ -252,6 +282,10 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
     (sessionId: string) => {
       const session = chatSessions.find((s) => s.id === sessionId);
       if (session) {
+        posthog.track("ask_ai_session_switched", {
+          message_count: session.messages.length,
+        });
+
         // Abort any ongoing stream before switching sessions
         // This saves partial content to the current session
         beforeSessionChangeRef.current?.();

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -21,6 +21,8 @@ import React, {
 } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
+import * as posthog from "@/lib/posthog";
+
 import { Button } from "@telegraph/button";
 import { Icon } from "@telegraph/icon";
 import { Input } from "@telegraph/input";
@@ -136,6 +138,8 @@ const handleSearchNavigation = (
   router,
   itemUrl,
   onSearch: () => void,
+  resultType: "doc" | "endpoint",
+  query?: string,
 ) => {
   const pathname = router.asPath;
   const isMapiReference =
@@ -145,6 +149,13 @@ const handleSearchNavigation = (
     itemUrl.startsWith("api-reference") &&
     pathname.startsWith("/api-reference");
   const isSamePageReferenceResult = isMapiReference || isApiReference;
+
+  posthog.track("docs_search_result_selected", {
+    result_type: resultType,
+    path: itemUrl,
+    query: query || "",
+    query_length: query?.length || 0,
+  });
 
   // If the item is in the same reference, highlight the item, don't navigate
   if (isSamePageReferenceResult) {
@@ -167,9 +178,11 @@ const handleSearchNavigation = (
 const DocsSearchResult = ({
   item,
   onClick,
+  query,
 }: {
   item: ResultItem;
   onClick: () => void;
+  query: string;
 }) => {
   const router = useRouter();
   const href = `/${item.path}`;
@@ -204,7 +217,9 @@ const DocsSearchResult = ({
     return (
       <a
         href={href}
-        onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
+        onClick={(e) =>
+          handleSearchNavigation(e, router, item.path, onClick, "doc", query)
+        }
       >
         {content}
       </a>
@@ -214,7 +229,9 @@ const DocsSearchResult = ({
   return (
     <Link
       href={href}
-      onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
+      onClick={(e) =>
+        handleSearchNavigation(e, router, item.path, onClick, "doc", query)
+      }
     >
       {content}
     </Link>
@@ -224,9 +241,11 @@ const DocsSearchResult = ({
 const EndpointSearchResult = ({
   item,
   onClick,
+  query,
 }: {
   item: EndpointSearchItem;
   onClick: () => void;
+  query: string;
 }) => {
   const router = useRouter();
   const href = `/${item.path}`;
@@ -282,7 +301,16 @@ const EndpointSearchResult = ({
     return (
       <a
         href={href}
-        onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
+        onClick={(e) =>
+          handleSearchNavigation(
+            e,
+            router,
+            item.path,
+            onClick,
+            "endpoint",
+            query,
+          )
+        }
       >
         {content}
       </a>
@@ -292,7 +320,9 @@ const EndpointSearchResult = ({
   return (
     <Link
       href={href}
-      onClick={(e) => handleSearchNavigation(e, router, item.path, onClick)}
+      onClick={(e) =>
+        handleSearchNavigation(e, router, item.path, onClick, "endpoint", query)
+      }
     >
       {content}
     </Link>
@@ -330,6 +360,14 @@ const Autocomplete = () => {
       autocompleteInstance?: ReturnType<typeof createAutocomplete>,
     ) => {
       const prompt = createAskAiPrompt(query);
+
+      posthog.track("docs_search_result_selected", {
+        result_type: "ask_ai",
+        query,
+        query_length: query.length,
+        device_type: isMobile ? "mobile" : "desktop",
+      });
+
       if (isMobile) {
         openInkeepModal(prompt);
       } else {
@@ -346,12 +384,30 @@ const Autocomplete = () => {
     [],
   );
 
+  // Track search opened - use ref to track if we've already fired the event
+  const hasTrackedOpenRef = useRef(false);
+
   const autocomplete = useMemo(
     () =>
       createAutocomplete({
-        onStateChange({ state }) {
+        onStateChange({ state, prevState }) {
           setIsSearchOpen(state.isOpen);
           setAutocompleteState(state);
+
+          // Track when search panel opens (query becomes non-empty and panel opens)
+          if (state.isOpen && !prevState.isOpen && state.query) {
+            if (!hasTrackedOpenRef.current) {
+              hasTrackedOpenRef.current = true;
+              posthog.track("docs_search_opened", {
+                trigger: "query",
+              });
+            }
+          }
+
+          // Reset tracking when search closes
+          if (!state.isOpen && prevState.isOpen) {
+            hasTrackedOpenRef.current = false;
+          }
         },
         getSources() {
           return [
@@ -470,11 +526,21 @@ const Autocomplete = () => {
           navigate({ itemUrl, item, state }) {
             // Handle Ask AI navigation (check window.innerWidth inline since useMemo can't access isMobile state)
             if ((item as any).__isAskAiItem) {
+              const isMobileDevice = window.innerWidth <= MOBILE_BREAKPOINT;
+
+              posthog.track("docs_search_result_selected", {
+                result_type: "ask_ai",
+                query: state.query,
+                query_length: state.query.length,
+                device_type: isMobileDevice ? "mobile" : "desktop",
+                selection_method: "keyboard",
+              });
+
               closeAutocompleteRef.current?.();
               // Defer opening sidebar/modal to next tick to avoid UI conflicts during close
               setTimeout(() => {
                 const prompt = createAskAiPrompt(state.query);
-                if (window.innerWidth <= MOBILE_BREAKPOINT) {
+                if (isMobileDevice) {
                   openInkeepModal(prompt);
                 } else {
                   openSidebarWithPrompt(prompt);
@@ -482,6 +548,16 @@ const Autocomplete = () => {
               }, 0);
               return;
             }
+
+            // Track doc/endpoint selection via keyboard
+            const isEndpoint = (item as any).index === "endpoints";
+            posthog.track("docs_search_result_selected", {
+              result_type: isEndpoint ? "endpoint" : "doc",
+              path: itemUrl,
+              query: state.query,
+              query_length: state.query.length,
+              selection_method: "keyboard",
+            });
 
             // For API reference items, use window.location for full page reload
             // to ensure the ApiReferenceProvider context is properly initialized
@@ -519,6 +595,11 @@ const Autocomplete = () => {
     // adding small timeout so event doesn't get to the focused input resulting
     // in "/" being displayed on the input
     e.preventDefault();
+
+    posthog.track("docs_search_opened", {
+      trigger: "hotkey",
+    });
+
     setTimeout(() => {
       const ref = inputRef.current;
 
@@ -595,6 +676,16 @@ const Autocomplete = () => {
         | ResultItem
         | undefined;
       if (firstItem?.path) {
+        const isEndpoint = (firstItem as any).index === "endpoints";
+
+        posthog.track("docs_search_result_selected", {
+          result_type: isEndpoint ? "endpoint" : "doc",
+          path: firstItem.path,
+          query: autocompleteState?.query || "",
+          query_length: autocompleteState?.query?.length || 0,
+          selection_method: "keyboard_enter",
+        });
+
         // For API reference items, use window.location for full page reload
         if (isApiReferencePath(firstItem.path)) {
           window.location.href = `/${firstItem.path}`;
@@ -820,11 +911,13 @@ const Autocomplete = () => {
                                   <EndpointSearchResult
                                     item={item as EndpointSearchItem}
                                     onClick={() => autocomplete.setQuery("")}
+                                    query={autocompleteState?.query || ""}
                                   />
                                 ) : (
                                   <DocsSearchResult
                                     item={item as DocsSearchItem}
                                     onClick={() => autocomplete.setQuery("")}
+                                    query={autocompleteState?.query || ""}
                                   />
                                 )}
                               </MenuItem>

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -150,7 +150,7 @@ const handleSearchNavigation = (
     pathname.startsWith("/api-reference");
   const isSamePageReferenceResult = isMapiReference || isApiReference;
 
-  posthog.track("docs_search_result_selected", {
+  posthog.track("docs-search-result-selected-client", {
     result_type: resultType,
     path: itemUrl,
     query: query || "",
@@ -361,7 +361,7 @@ const Autocomplete = () => {
     ) => {
       const prompt = createAskAiPrompt(query);
 
-      posthog.track("docs_search_result_selected", {
+      posthog.track("docs-search-result-selected-client", {
         result_type: "ask_ai",
         query,
         query_length: query.length,
@@ -398,7 +398,7 @@ const Autocomplete = () => {
           if (state.isOpen && !prevState.isOpen && state.query) {
             if (!hasTrackedOpenRef.current) {
               hasTrackedOpenRef.current = true;
-              posthog.track("docs_search_opened", {
+              posthog.track("docs-search-opened-client", {
                 trigger: "query",
               });
             }
@@ -528,7 +528,7 @@ const Autocomplete = () => {
             if ((item as any).__isAskAiItem) {
               const isMobileDevice = window.innerWidth <= MOBILE_BREAKPOINT;
 
-              posthog.track("docs_search_result_selected", {
+              posthog.track("docs-search-result-selected-client", {
                 result_type: "ask_ai",
                 query: state.query,
                 query_length: state.query.length,
@@ -551,7 +551,7 @@ const Autocomplete = () => {
 
             // Track doc/endpoint selection via keyboard
             const isEndpoint = (item as any).index === "endpoints";
-            posthog.track("docs_search_result_selected", {
+            posthog.track("docs-search-result-selected-client", {
               result_type: isEndpoint ? "endpoint" : "doc",
               path: itemUrl,
               query: state.query,
@@ -596,7 +596,7 @@ const Autocomplete = () => {
     // in "/" being displayed on the input
     e.preventDefault();
 
-    posthog.track("docs_search_opened", {
+    posthog.track("docs-search-opened-client", {
       trigger: "hotkey",
     });
 
@@ -678,7 +678,7 @@ const Autocomplete = () => {
       if (firstItem?.path) {
         const isEndpoint = (firstItem as any).index === "endpoints";
 
-        posthog.track("docs_search_result_selected", {
+        posthog.track("docs-search-result-selected-client", {
           result_type: isEndpoint ? "endpoint" : "doc",
           path: firstItem.path,
           query: autocompleteState?.query || "",

--- a/components/ui/Autocomplete.tsx
+++ b/components/ui/Autocomplete.tsx
@@ -599,6 +599,7 @@ const Autocomplete = () => {
     posthog.track("docs-search-opened-client", {
       trigger: "hotkey",
     });
+    hasTrackedOpenRef.current = true;
 
     setTimeout(() => {
       const ref = inputRef.current;

--- a/hooks/useChatStream.ts
+++ b/hooks/useChatStream.ts
@@ -185,7 +185,7 @@ export function useChatStream(): UseChatStreamReturn {
       // A session is "new" if it was just created OR if it has no messages yet
       const isNewSession = wasNewSession || isFirstMessage;
 
-      posthog.track("ask_ai_message_sent", {
+      posthog.track("ask-ai-message-sent-client", {
         message_length: content.trim().length,
         is_first_message: isFirstMessage,
         is_new_session: isNewSession,
@@ -365,7 +365,7 @@ export function useChatStream(): UseChatStreamReturn {
   );
 
   const stopStream = useCallback(() => {
-    posthog.track("ask_ai_stream_stopped", {
+    posthog.track("ask-ai-stream-stopped-client", {
       content_length: contentBufferRef.current.length,
       displayed_length: displayedLengthRef.current,
     });

--- a/hooks/useChatStream.ts
+++ b/hooks/useChatStream.ts
@@ -1,4 +1,7 @@
 import { useCallback, useRef, useEffect, MutableRefObject } from "react";
+
+import * as posthog from "@/lib/posthog";
+
 import {
   useAskAi,
   type Message,
@@ -182,6 +185,13 @@ export function useChatStream(): UseChatStreamReturn {
       // A session is "new" if it was just created OR if it has no messages yet
       const isNewSession = wasNewSession || isFirstMessage;
 
+      posthog.track("ask_ai_message_sent", {
+        message_length: content.trim().length,
+        is_first_message: isFirstMessage,
+        is_new_session: isNewSession,
+        conversation_length: messages.length,
+      });
+
       // Add user message immediately
       const userMessage: Message = {
         id: `user-${Date.now()}`,
@@ -355,6 +365,11 @@ export function useChatStream(): UseChatStreamReturn {
   );
 
   const stopStream = useCallback(() => {
+    posthog.track("ask_ai_stream_stopped", {
+      content_length: contentBufferRef.current.length,
+      displayed_length: displayedLengthRef.current,
+    });
+
     // Mark that user manually stopped the stream
     userStoppedRef.current = true;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR instruments both the docs search and Ask AI experiences with PostHog events to help understand how customers interact with these features.

All events follow the `{noun}-{verb}-client` naming convention.

**Search events tracked:**
- `docs-search-opened-client` - When search is opened via hotkey (`/` or `Cmd+K`) or by typing a query
- `docs-search-result-selected-client` - When a user selects a search result, with properties:
  - `result_type`: `doc`, `endpoint`, or `ask_ai`
  - `path`: The path of the selected result (for docs/endpoints)
  - `query`: The search query
  - `query_length`: Length of the search query
  - `selection_method`: `keyboard`, `keyboard_enter`, or click (no value)
  - `device_type`: `mobile` or `desktop` (for Ask AI selections)

**Ask AI events tracked:**
- `ask-ai-sidebar-opened-client` - When the sidebar is opened, with `source` property (`button` or `search`)
- `ask-ai-sidebar-closed-client` - When the sidebar is closed
- `ask-ai-session-switched-client` - When switching between chat sessions, with `message_count`
- `ask-ai-message-sent-client` - When a message is sent, with properties:
  - `message_length`: Length of the message
  - `is_first_message`: Whether this is the first message in the session
  - `is_new_session`: Whether this is a new session
  - `conversation_length`: Number of messages in the conversation
- `ask-ai-stream-stopped-client` - When the user stops the AI stream
- `ask-ai-mobile-modal-opened-client` - When the mobile modal is opened (via search or floating button)

**Implementation details:**
- Uses the existing `posthog.track()` function from `lib/posthog.ts` which was already set up but unused
- Events are tracked at the appropriate interaction points in the components
- TypeScript type checking and linting both pass
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13817](https://linear.app/knock/issue/KNO-13817/posthog-events-for-ask-ai-and-docs-search)

<div><a href="https://cursor.com/agents/bc-d16134b7-17d2-4645-a0d6-973e6adac43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d16134b7-17d2-4645-a0d6-973e6adac43c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

