### PR TITLE
Document new warehouse message export columns

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -74,8 +74,11 @@ Below is a description of the columns included in the table and the data type of
             channel_key character varying(65535) ENCODE lzo,
             channel_type character varying(65535) ENCODE lzo,
             channel_provider character varying(65535) ENCODE lzo,
+            external_provider_id character varying(65535) ENCODE lzo,
             workflow_id character varying(65535) ENCODE lzo,
             workflow_key character varying(65535) ENCODE lzo,
+            workflow_run_id character varying(65535) ENCODE lzo,
+            workflow_recipient_run_id character varying(65535) ENCODE lzo,
             combined_trigger_data character varying(32768) ENCODE lzo,
             step_ref character varying(65535) ENCODE lzo,
             recipient_id character varying(65535) ENCODE lzo,
@@ -133,6 +136,11 @@ Below is a description of the columns included in the table and the data type of
           "string",
           "The provider for the channel the message was sent on",
         ],
+        [
+          "external_provider_id",
+          "string",
+          "The provider identifier returned for the message",
+        ],
         ["channel_type", "string", "The type of channel the message was sent on"],
         [
           "workflow_id",
@@ -143,6 +151,16 @@ Below is a description of the columns included in the table and the data type of
           "workflow_key",
           "string",
           "The unique key of the workflow the message belongs to",
+        ],
+        [
+          "workflow_run_id",
+          "string",
+          "The workflow run ID for the trigger request that generated the message",
+        ],
+        [
+          "workflow_recipient_run_id",
+          "string",
+          "The workflow recipient run ID for the recipient-specific workflow run that generated the message",
         ],
         [
           "combined_trigger_data",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Adds the new message export columns to the data warehouse sync documentation:

- `external_provider_id`
- `workflow_run_id`
- `workflow_recipient_run_id`

The SQL table definition example and rendered messages table structure now match the updated schema.

### Todos

None.

### Tasks

N/A.

### Screenshots

Not applicable for this documentation-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019edaf6-4e81-7727-9aca-b6b38a5b0f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019edaf6-4e81-7727-9aca-b6b38a5b0f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

