### PR TITLE
docs(KNO-13841): document per-link opt-out for link tracking

### DIFF
--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -150,6 +150,24 @@ Knock is able to identify many types of URLs for tracking:
   }
 />
 
+#### Opting links out of tracking
+
+When link tracking is enabled, Knock wraps every eligible URL in a notification as a trackable link, so a click on any of these links counts toward your engagement metrics. For some notifications, such as campaign emails, you may only care about clicks on your primary calls to action and you don't want footer or utility links—a privacy policy or help center link, for example—to count toward your click-through metrics.
+
+To opt a single link out of tracking, add the `data-knock-no-track` attribute to its HTML anchor tag:
+
+```html
+<a href="https://example.com/privacy" data-knock-no-track>Privacy policy</a>
+```
+
+When Knock renders the notification, it will:
+
+- Leave the link's original `href` untouched, so the recipient is sent directly to the destination URL.
+- Remove the `data-knock-no-track` attribute from the rendered output.
+- Skip capturing a `message.link_clicked` event when the recipient clicks the link.
+
+Because this relies on an HTML attribute, opting out is available in channels that render HTML, such as email.
+
 There are two types of trackable links Knock may generate: standard and short. Standard links encode the target URL (and other event metadata) into a variable-length token added to the link path. Short links instead use a lookup key added to the link that maps to a record of the target URL. The short link lookup key will always be 10-characters in length, with short links always 31-characters long in total.
 
 Given their brevity and consistent length, Knock will use short links for channels that often have character constraints. Specifically these are:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Documents the new per-link click-tracking opt-out shipped in [knocklabs/switchboard#6712](https://github.com/knocklabs/switchboard/pull/6712).

By default, Knock wraps every eligible URL in a notification as a trackable link, so utility and footer links count toward engagement metrics alongside primary CTAs. This change adds an "Opting links out of tracking" subsection to the link and open tracking docs explaining:

- The caveat that all eligible links are tracked by default, which can skew click-through metrics for campaign emails.
- How to exclude an individual link by adding the `data-knock-no-track` attribute to its HTML anchor tag.
- The resulting behavior — the original `href` is preserved, the attribute is stripped from the rendered output, and no `message.link_clicked` event is captured.
- That this applies to channels that render HTML, such as email.

### Tasks

KNO-13841 — Allow per-link opt-out for email click tracking

### Screenshots

Rendered "Opting links out of tracking" section on the local docs site:

[Opting links out of tracking section](https://cursor.com/agents/bc-5d247031-5c38-4897-9aa6-3a188c7e271f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopting_links_out_of_tracking.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d247031-5c38-4897-9aa6-3a188c7e271f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d247031-5c38-4897-9aa6-3a188c7e271f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

