### PR TITLE
feat(kno-13827): add new timestamp operators to conditions docs

### DIFF
--- a/content/concepts/conditions.mdx
+++ b/content/concepts/conditions.mdx
@@ -301,6 +301,24 @@ You can use any of the following operators in condition comparisons:
     | `created_at is is_timestamp_between ["2025-01-01", "2025-12-31"]` where `created_at` is `2024-12-31` | false |
 
   </Accordion>
+  <Accordion title="`is_timestamp_before_now`">
+    True if the variable is a timestamp before the current server time. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `deleted_at is_timestamp_before_now` where `deleted_at` is a past timestamp | true |
+    | `deleted_at is_timestamp_before_now` where `deleted_at` is a future timestamp | false |
+
+  </Accordion>
+  <Accordion title="`is_timestamp_on_or_after_now`">
+    True if the variable is a timestamp on or after the current server time. No argument needed.
+
+    | Example condition | Evaluation |
+    | --- | --- |
+    | `expires_at is_timestamp_on_or_after_now` where `expires_at` is a future timestamp | true |
+    | `expires_at is_timestamp_on_or_after_now` where `expires_at` is a past timestamp | false |
+
+  </Accordion>
 </AccordionGroup>
 
 ### Conditions scope


### PR DESCRIPTION
## KNO-13827: [Docs] Add is_timestamp_before_now and is_timestamp_on_or_after_now operators to conditions reference

### Summary
- Adds two new timestamp operators to the conditions reference page that shipped in KNO-13393/KNO-13394 
- `is_timestamp_before_now` and `is_timestamp_on_or_after_now` take no argument and compare against the current server time at evaluation.

### Changes
- `content/concepts/conditions.mdx` — add accordion entries for both "now" operators in the timestamp operators section