### PR TITLE
fix(kno-13851): remove stale no-components callout from RN feed page

### DIFF
--- a/content/in-app-ui/react-native/feed.mdx
+++ b/content/in-app-ui/react-native/feed.mdx
@@ -7,18 +7,6 @@ section: Building in-app UI
 
 This page provides common recipes to help you build in-app feed experiences within your React Native applications. The SDK handles all aspects of managing the data surrounding notifications on your behalf, including managing unread badge counts.
 
-<Callout
-  emoji="🌠"
-  title="Note"
-  text={
-    <>
-      in the current version of the React Native SDK there are no pre-built UI
-      components. That means you must bring your own notification components to
-      render an in-app feed.
-    </>
-  }
-/>
-
 **Quick links**:
 
 - [`@knocklabs/react-native` library reference](/in-app-ui/react-native/sdk/reference)


### PR DESCRIPTION
## KNO-13851: [Docs] Remove stale callout from React Native feed page

### Summary
- Removes an outdated callout in `feed.mdx` that states the RN SDK has no pre-built UI components

### Changes
- `content/in-app-ui/react-native/feed.mdx` — remove stale callout (lines 10–20)