### PR TITLE
docs: update email layout docs with branding-aware buttons, dark mode, and plan availability

### DIFF
--- a/content/integrations/email/client-previews.mdx
+++ b/content/integrations/email/client-previews.mdx
@@ -5,24 +5,13 @@ section: Integrations > Email
 layout: integrations
 ---
 
-<Callout
-  type="enterprise"
-  title="Enterprise plan feature."
-  style={{ alignItems: "center" }}
-  text={
-    <>
-      Email client previews are currently only available on our{" "}
-      <a href="https://knock.app/pricing" target="_blank" rel="noopener">
-        Enterprise plan
-      </a>
-      .
-    </>
-  }
-/>
-
 ## Overview
 
 Email client previews allow you to test how your email notifications will render across different email clients. This feature is embedded directly in the Knock template editor, using Litmus technology to generate accurate previews without requiring you to leave the editor or send test emails.
+
+## Availability
+
+Email client previews are available on all paid plans (Starter and above). On the free plan, the client previews button appears in the template editor but is disabled. Hovering over the disabled button displays a tooltip prompting you to upgrade to Starter.
 
 ## Features
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -105,10 +105,16 @@ Inject account- and environment-level variables into your layout with the `vars.
 
 Branding properties set in account settings are available under `vars.branding.*`:
 
-- `vars.branding.logo_url`
-- `vars.branding.icon_url`
-- `vars.branding.primary_color`
-- `vars.branding.primary_color_contrast`
+| Variable                                    | Description                                                                        |
+| ------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `vars.branding.logo_url`                    | Your brand logo URL.                                                               |
+| `vars.branding.icon_url`                    | Your brand icon URL.                                                               |
+| `vars.branding.dark_logo_url`               | Logo for dark mode (falls back to `logo_url`).                                     |
+| `vars.branding.dark_icon_url`               | Icon for dark mode (falls back to `icon_url`).                                     |
+| `vars.branding.primary_color`               | Primary brand color for buttons and accents. Defaults to `#000000`.                |
+| `vars.branding.primary_color_contrast`      | Text color used on primary-colored backgrounds. Defaults to `#FFFFFF`.             |
+| `vars.branding.dark_primary_color`          | Primary color for dark mode (falls back to `primary_color`).                       |
+| `vars.branding.dark_primary_color_contrast` | Contrast color for dark mode (falls back to `primary_color_contrast`).             |
 
 With [per-tenant branding](/multi-tenancy/per-tenant-branding), Knock resolves these properties against the `tenant_id` on the workflow run, falling back to account-level branding if the tenant has none set.
 
@@ -222,6 +228,98 @@ The `<!--[if !mso]>` conditional prevents Outlook, which doesn't support `prefer
     </>
   }
 />
+
+### Branding-aware buttons
+
+The Knock default email layout wires button styles to your branding colors so buttons match your brand out of the box. This applies to both the legacy `.button` class and the visual editor's `.block-button` components.
+
+#### Legacy `.button` class
+
+If your templates use the legacy `.button` class, the default layout styles it with your branding colors:
+
+- **Light mode.** Background and border use `primary_color`; text uses `primary_color_contrast`.
+- **Dark mode.** Background and border use `dark_primary_color`; text uses `dark_primary_color_contrast`.
+
+#### Visual editor buttons (`.block-button`)
+
+Buttons inserted from the visual editor use the `.block-button` class with solid or outline variants:
+
+- **Solid buttons (`.block-button--solid`).**
+  - Light mode: background uses `primary_color`, text uses `primary_color_contrast`.
+  - Dark mode: background uses `dark_primary_color`, text uses `dark_primary_color_contrast`.
+
+- **Outline buttons (`.block-button--outline`).**
+  - Light mode: transparent background with `primary_color` text and border.
+  - Dark mode: transparent background with `dark_primary_color` text and border.
+
+In light mode, the layout styles do not use `!important`, so per-button colors set in the visual editor's style attributes take precedence. This means you can customize individual button colors without modifying the layout.
+
+#### Why dark mode uses `!important` overrides
+
+In dark mode, the layout applies `!important` to button styles. This is necessary because the visual editor renders button colors as static inline styles that do not change between light and dark mode. Without layout-level overrides, buttons would display their light-mode colors on a dark background, making text unreadable.
+
+The tradeoff: in light mode, per-button color customizations from the visual editor are respected. In dark mode, the layout forces branding colors on all buttons to ensure readability. If you need per-button dark mode colors, you can customize the layout's dark mode CSS.
+
+<Callout
+  emoji="🌠"
+  title="Note:"
+  text={
+    <>
+      If your default layout was created before April 21, 2026, it does not
+      include branding-aware button styles. Either create a new layout (which
+      starts from Knock's latest default) or add the button styles from the
+      snippet below to your existing layout.
+    </>
+  }
+/>
+
+Here's the CSS the default layout uses for branding-aware buttons:
+
+```css title="Branding-aware button styles"
+/* Legacy button class */
+.button {
+  background-color: {{ vars.branding.primary_color | default: "#000000" }};
+  border-color: {{ vars.branding.primary_color | default: "#000000" }};
+  color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
+}
+
+/* Visual editor solid buttons */
+.block-button.block-button--solid {
+  background-color: {{ vars.branding.primary_color | default: "#000000" }};
+  border-color: {{ vars.branding.primary_color | default: "#000000" }};
+  color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
+}
+
+/* Visual editor outline buttons */
+.block-button.block-button--outline {
+  background-color: transparent;
+  border-color: {{ vars.branding.primary_color | default: "#000000" }};
+  color: {{ vars.branding.primary_color | default: "#000000" }};
+}
+
+@media (prefers-color-scheme: dark) {
+  /* Legacy button - dark mode */
+  .button {
+    background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
+  }
+
+  /* Visual editor solid buttons - dark mode */
+  .block-button.block-button--solid {
+    background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
+  }
+
+  /* Visual editor outline buttons - dark mode */
+  .block-button.block-button--outline {
+    background-color: transparent !important;
+    border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+  }
+}
+```
 
 ### Injecting workflow run scope into a layout at runtime
 

--- a/content/integrations/email/layouts.mdx
+++ b/content/integrations/email/layouts.mdx
@@ -105,16 +105,16 @@ Inject account- and environment-level variables into your layout with the `vars.
 
 Branding properties set in account settings are available under `vars.branding.*`:
 
-| Variable                                    | Description                                                                        |
-| ------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `vars.branding.logo_url`                    | Your brand logo URL.                                                               |
-| `vars.branding.icon_url`                    | Your brand icon URL.                                                               |
-| `vars.branding.dark_logo_url`               | Logo for dark mode (falls back to `logo_url`).                                     |
-| `vars.branding.dark_icon_url`               | Icon for dark mode (falls back to `icon_url`).                                     |
-| `vars.branding.primary_color`               | Primary brand color for buttons and accents. Defaults to `#000000`.                |
-| `vars.branding.primary_color_contrast`      | Text color used on primary-colored backgrounds. Defaults to `#FFFFFF`.             |
-| `vars.branding.dark_primary_color`          | Primary color for dark mode (falls back to `primary_color`).                       |
-| `vars.branding.dark_primary_color_contrast` | Contrast color for dark mode (falls back to `primary_color_contrast`).             |
+| Variable                                    | Description                                                            |
+| ------------------------------------------- | ---------------------------------------------------------------------- |
+| `vars.branding.logo_url`                    | Your brand logo URL.                                                   |
+| `vars.branding.icon_url`                    | Your brand icon URL.                                                   |
+| `vars.branding.dark_logo_url`               | Logo for dark mode (falls back to `logo_url`).                         |
+| `vars.branding.dark_icon_url`               | Icon for dark mode (falls back to `icon_url`).                         |
+| `vars.branding.primary_color`               | Primary brand color for buttons and accents. Defaults to `#000000`.    |
+| `vars.branding.primary_color_contrast`      | Text color used on primary-colored backgrounds. Defaults to `#FFFFFF`. |
+| `vars.branding.dark_primary_color`          | Primary color for dark mode (falls back to `primary_color`).           |
+| `vars.branding.dark_primary_color_contrast` | Contrast color for dark mode (falls back to `primary_color_contrast`). |
 
 With [per-tenant branding](/multi-tenancy/per-tenant-branding), Knock resolves these properties against the `tenant_id` on the workflow run, falling back to account-level branding if the tenant has none set.
 
@@ -245,6 +245,7 @@ If your templates use the legacy `.button` class, the default layout styles it w
 Buttons inserted from the visual editor use the `.block-button` class with solid or outline variants:
 
 - **Solid buttons (`.block-button--solid`).**
+
   - Light mode: background uses `primary_color`, text uses `primary_color_contrast`.
   - Dark mode: background uses `dark_primary_color`, text uses `dark_primary_color_contrast`.
 

--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -46,18 +46,9 @@ The Knock default MJML layout supports dark mode out of the box via the `prefers
       <meta name="supported-color-schemes" content="light dark" />
     </mj-raw>
     <mj-style>
-      :root {
-        color-scheme: light dark;
-        supported-color-schemes: light dark;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        .email-wrapper,
-        .email-body {
-          background-color: #262626 !important;
-          color: #ffffff !important;
-        }
-      }
+      :root { color-scheme: light dark; supported-color-schemes: light dark; }
+      @media (prefers-color-scheme: dark) { .email-wrapper, .email-body {
+      background-color: #262626 !important; color: #ffffff !important; } }
     </mj-style>
   </mj-head>
   <mj-body>
@@ -111,46 +102,36 @@ Here's the CSS to add branding-aware buttons to a custom MJML layout:
 
 ```mjml title="Branding-aware button styles for MJML"
 <mj-style>
-  /* Legacy button class */
-  .button {
-    background-color: {{ vars.branding.primary_color | default: "#000000" }};
-    border-color: {{ vars.branding.primary_color | default: "#000000" }};
-    color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
-  }
-
-  /* Visual editor solid buttons */
-  .block-button.block-button--solid {
-    background-color: {{ vars.branding.primary_color | default: "#000000" }};
-    border-color: {{ vars.branding.primary_color | default: "#000000" }};
-    color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
-  }
-
-  /* Visual editor outline buttons */
-  .block-button.block-button--outline {
-    background-color: transparent;
-    border-color: {{ vars.branding.primary_color | default: "#000000" }};
-    color: {{ vars.branding.primary_color | default: "#000000" }};
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .button {
-      background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-      color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
-    }
-
-    .block-button.block-button--solid {
-      background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-      color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
-    }
-
-    .block-button.block-button--outline {
-      background-color: transparent !important;
-      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-      color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
-    }
-  }
+  /* Legacy button class */ .button { background-color: {{
+  vars.branding.primary_color | default: "#000000" }}; border-color: {{
+  vars.branding.primary_color | default: "#000000" }}; color: {{
+  vars.branding.primary_color_contrast | default: "#FFFFFF" }}; } /* Visual
+  editor solid buttons */ .block-button.block-button--solid { background-color:
+  {{ vars.branding.primary_color | default: "#000000" }}; border-color: {{
+  vars.branding.primary_color | default: "#000000" }}; color: {{
+  vars.branding.primary_color_contrast | default: "#FFFFFF" }}; } /* Visual
+  editor outline buttons */ .block-button.block-button--outline {
+  background-color: transparent; border-color: {{ vars.branding.primary_color |
+  default: "#000000" }}; color: {{ vars.branding.primary_color | default:
+  "#000000" }}; } @media (prefers-color-scheme: dark) { .button {
+  background-color: {{ vars.branding.dark_primary_color | default:
+  vars.branding.primary_color | default: "#000000" }} !important; border-color:
+  {{ vars.branding.dark_primary_color | default: vars.branding.primary_color |
+  default: "#000000" }} !important; color: {{
+  vars.branding.dark_primary_color_contrast | default:
+  vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important; }
+  .block-button.block-button--solid { background-color: {{
+  vars.branding.dark_primary_color | default: vars.branding.primary_color |
+  default: "#000000" }} !important; border-color: {{
+  vars.branding.dark_primary_color | default: vars.branding.primary_color |
+  default: "#000000" }} !important; color: {{
+  vars.branding.dark_primary_color_contrast | default:
+  vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important; }
+  .block-button.block-button--outline { background-color: transparent
+  !important; border-color: {{ vars.branding.dark_primary_color | default:
+  vars.branding.primary_color | default: "#000000" }} !important; color: {{
+  vars.branding.dark_primary_color | default: vars.branding.primary_color |
+  default: "#000000" }} !important; } }
 </mj-style>
 ```
 

--- a/content/integrations/email/mjml.mdx
+++ b/content/integrations/email/mjml.mdx
@@ -34,6 +34,126 @@ To include plain HTML within an MJML layout, wrap it in `<mjml-raw>` tags. MJML 
 
 [Learn more about email layouts](/integrations/email/layouts).
 
+### Dark mode support in MJML layouts
+
+The Knock default MJML layout supports dark mode out of the box via the `prefers-color-scheme` CSS media query. To add dark mode support to a custom MJML layout, include the color scheme meta tags and CSS overrides in your `<mj-head>`:
+
+```mjml title="MJML layout with dark mode support"
+<mjml>
+  <mj-head>
+    <mj-raw>
+      <meta name="color-scheme" content="light dark" />
+      <meta name="supported-color-schemes" content="light dark" />
+    </mj-raw>
+    <mj-style>
+      :root {
+        color-scheme: light dark;
+        supported-color-schemes: light dark;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .email-wrapper,
+        .email-body {
+          background-color: #262626 !important;
+          color: #ffffff !important;
+        }
+      }
+    </mj-style>
+  </mj-head>
+  <mj-body>
+    <!-- layout content -->
+  </mj-body>
+</mjml>
+```
+
+<Callout
+  emoji="🌠"
+  title="Note:"
+  text={
+    <>
+      Not every email client supports <code>prefers-color-scheme</code>. Clients
+      that don't will fall back to your light mode styles, so treat light mode
+      as the default experience.
+    </>
+  }
+/>
+
+### Branding-aware buttons in MJML layouts
+
+The Knock default MJML layout wires button styles to your [branding colors](/integrations/email/layouts#using-variables-and-brand-attributes-in-a-custom-layout) so buttons match your brand out of the box. This applies to both the legacy `.button` class and the visual editor's `.block-button` components.
+
+#### Button behavior in light and dark mode
+
+- **Solid buttons (`.block-button--solid`).** Background uses `primary_color`, text uses `primary_color_contrast`. In dark mode, these switch to `dark_primary_color` and `dark_primary_color_contrast`.
+
+- **Outline buttons (`.block-button--outline`).** Transparent background with `primary_color` text and border. In dark mode, these switch to `dark_primary_color`.
+
+In light mode, per-button colors set in the visual editor take precedence. In dark mode, the layout applies `!important` to override inline styles and ensure readability on dark backgrounds.
+
+#### Why dark mode uses `!important` overrides
+
+The visual editor renders button colors as static inline styles that do not change between light and dark mode. Without layout-level overrides, buttons would display their light-mode colors on a dark background, making text unreadable. The layout uses `!important` in dark mode to force branding colors on all buttons.
+
+<Callout
+  emoji="🌠"
+  title="Note:"
+  text={
+    <>
+      If your MJML layout was created before April 21, 2026, it does not include
+      branding-aware button styles or dark mode support. Either create a new
+      layout (which starts from Knock's latest default) or add the styles to
+      your existing layout.
+    </>
+  }
+/>
+
+Here's the CSS to add branding-aware buttons to a custom MJML layout:
+
+```mjml title="Branding-aware button styles for MJML"
+<mj-style>
+  /* Legacy button class */
+  .button {
+    background-color: {{ vars.branding.primary_color | default: "#000000" }};
+    border-color: {{ vars.branding.primary_color | default: "#000000" }};
+    color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
+  }
+
+  /* Visual editor solid buttons */
+  .block-button.block-button--solid {
+    background-color: {{ vars.branding.primary_color | default: "#000000" }};
+    border-color: {{ vars.branding.primary_color | default: "#000000" }};
+    color: {{ vars.branding.primary_color_contrast | default: "#FFFFFF" }};
+  }
+
+  /* Visual editor outline buttons */
+  .block-button.block-button--outline {
+    background-color: transparent;
+    border-color: {{ vars.branding.primary_color | default: "#000000" }};
+    color: {{ vars.branding.primary_color | default: "#000000" }};
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .button {
+      background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+      color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
+    }
+
+    .block-button.block-button--solid {
+      background-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+      color: {{ vars.branding.dark_primary_color_contrast | default: vars.branding.primary_color_contrast | default: "#FFFFFF" }} !important;
+    }
+
+    .block-button.block-button--outline {
+      background-color: transparent !important;
+      border-color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+      color: {{ vars.branding.dark_primary_color | default: vars.branding.primary_color | default: "#000000" }} !important;
+    }
+  }
+</mj-style>
+```
+
 ## MJML templates
 
 Email templates can use MJML in two ways:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR updates the email layout documentation to reflect recent product changes:

**Email layouts page** (`/integrations/email/layouts`)
- Expanded the branding variables table to include all 8 variables with descriptions, including the new dark mode variants (`dark_primary_color`, `dark_primary_color_contrast`)
- Added a new "Branding-aware buttons" section documenting:
  - Legacy `.button` class wiring to branding colors
  - Visual editor `.block-button` solid/outline behavior in light and dark mode
  - Explanation of why dark mode requires `!important` overrides (the visual editor renders button colors as static inline styles that don't change between light/dark)
  - CSS code snippet for branding-aware button styles

**MJML support page** (`/integrations/email/mjml`)
- Added "Dark mode support in MJML layouts" section with MJML-specific code snippet
- Added "Branding-aware buttons in MJML layouts" section documenting the same behavior as HTML layouts, with MJML styling code

**Client previews page** (`/integrations/email/client-previews`)
- Removed the "Enterprise plan feature" callout
- Added an "Availability" section explaining that client previews are now available on all paid plans (Starter and above)
- Documented the disabled button behavior with tooltip on the free plan

### Screenshots

**Email layouts - Branding variables table:**
[Branding variables table showing all 8 variables](https://cursor.com/agents/bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femail_layouts_branding_variables.webp)

**Email layouts - Branding-aware buttons section:**
[Branding-aware buttons documentation section](https://cursor.com/agents/bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Femail_layouts_branding_buttons.webp)

**MJML - Dark mode and branding-aware buttons:**
[MJML dark mode and branding-aware buttons sections](https://cursor.com/agents/bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmjml_dark_mode_buttons.webp)

**Client previews - Updated availability:**
[Client previews page showing availability on all paid plans](https://cursor.com/agents/bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclient_previews_availability.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13880](https://linear.app/knock/issue/KNO-13880/update-email-layout-and-client-preview-docs-branding-aware-buttons)

<div><a href="https://cursor.com/agents/bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-038360ef-dd7b-4fc7-9cc8-3de0a5a646e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

