### PR TITLE
docs(kno-13888): add multi-factor authentication docs page

### DIFF
--- a/content/manage-your-account/authentication-methods.mdx
+++ b/content/manage-your-account/authentication-methods.mdx
@@ -11,6 +11,8 @@ Understand and select your preferred authentication method in Knock.
 
 We support three methods of authenticating users to get access to the Knock dashboard: email based passwordless authentication, Google SSO, and SAML 2.0 SSO.
 
+You can add an extra layer of security on top of email and Google login with [multi-factor authentication (MFA)](/manage-your-account/multi-factor-authentication).
+
 ## Email (passwordless)
 
 With this authentication method users will receive an email to authenticate themselves in order to access the Knock dashboard. The email contains a "magic link" that expires after 5 minutes of being generated. Clicking the link will authenticate the user and grant access to the Knock dashboard.

--- a/content/manage-your-account/multi-factor-authentication.mdx
+++ b/content/manage-your-account/multi-factor-authentication.mdx
@@ -1,0 +1,92 @@
+---
+title: Multi-factor authentication
+description: Add an extra layer of security to your Knock account by enabling multi-factor authentication (MFA) for dashboard login.
+tags: ["mfa", "2fa", "two-factor", "authenticator", "backup codes", "security", "login"]
+section: Manage your account
+---
+
+Add a second factor to your Knock dashboard login using an authenticator app.
+
+## Overview
+
+Multi-factor authentication (MFA) adds a second verification step on top of your existing [login method](/manage-your-account/authentication-methods). After you sign in with email or Google, Knock prompts you for a one-time code from your authenticator app before granting access to the dashboard.
+
+MFA applies to email (passwordless) and Google logins. If your account uses [SAML SSO](/manage-your-account/saml-sso), your identity provider handles MFA for those users and Knock does not prompt for an additional factor.
+
+## Enroll in MFA
+
+Any member can enroll in MFA from their profile settings in the Knock dashboard.
+
+1. Open your profile settings and navigate to the **Security** section.
+2. Under **Two-factor authentication**, click **Set up**.
+3. Scan the QR code with an authenticator app (such as 1Password, Authy, or Google Authenticator).
+4. Enter the 6-digit code from your authenticator app to confirm enrollment.
+5. Save your backup codes in a secure location. Knock shows these codes once during enrollment.
+
+If your account owner or admin has enabled account-wide MFA enforcement, you are prompted to complete this enrollment flow the next time you log in before you can access the dashboard.
+
+## Backup codes
+
+When you enroll in MFA, Knock generates a set of backup codes you can use to sign in if you lose access to your authenticator app. Each backup code is single-use.
+
+You can regenerate backup codes from your profile **Security** settings at any time. Regenerating codes invalidates any previously issued backup codes.
+
+## Logging in with MFA
+
+When MFA is enabled on your account, Knock prompts you for a verification code after you complete the initial sign-in step (email magic link or Google).
+
+1. Open your authenticator app and enter the current 6-digit code on the MFA challenge screen.
+2. If you cannot access your authenticator app, click **Use a backup code** and enter one of your saved backup codes instead.
+
+After you verify your code, Knock completes your session and redirects you to the dashboard.
+
+## Enforce MFA for your account
+
+Account owners and admins can require all members to enroll in MFA before they can access the dashboard.
+
+1. Log in to your Knock dashboard.
+2. Navigate to the **Security** page under **Admin** in your account settings.
+3. Toggle **Require multi-factor authentication** to enable enforcement for all members.
+
+When enforcement is enabled, members who have not yet enrolled in MFA are prompted to set up an authenticator app at their next login or token refresh. They cannot access the dashboard until enrollment is complete.
+
+<Callout
+  type="info"
+  title="SAML SSO accounts."
+  text={
+    <>
+      The require MFA toggle is not available for accounts with{" "}
+      <a href="/manage-your-account/saml-sso">SAML SSO</a> enabled. Your
+      identity provider manages authentication, including MFA, for members who
+      sign in through SSO.
+    </>
+  }
+/>
+
+## Reset a member's MFA
+
+If a member loses access to their authenticator app and backup codes, an account owner or admin can reset their MFA from the account **Security** settings. Resetting a member's MFA removes their enrolled factor and backup codes. The member must enroll again at their next login.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="What authenticator apps are supported?">
+    Knock supports TOTP-based authenticator apps, including 1Password, Authy,
+    Google Authenticator, and other apps that scan QR codes or accept
+    otpauth:// URIs.
+  </Accordion>
+  <Accordion title="Can I disable MFA on my account?">
+    Yes. You can disable MFA from your profile **Security** settings. You must
+    enter a current code from your authenticator app to confirm. If your
+    account owner or admin has enabled account-wide MFA enforcement, you cannot
+    disable MFA until enforcement is turned off.
+  </Accordion>
+  <Accordion title="What happens if I lose my authenticator and backup codes?">
+    Contact an account owner or admin to reset your MFA. After the reset, you
+    enroll a new authenticator app at your next login.
+  </Accordion>
+  <Accordion title="Does MFA apply to API keys or service tokens?">
+    No. MFA applies to interactive dashboard login only. API keys, service
+    tokens, and other machine-to-machine credentials are not affected.
+  </Accordion>
+</AccordionGroup>

--- a/content/manage-your-account/multi-factor-authentication.mdx
+++ b/content/manage-your-account/multi-factor-authentication.mdx
@@ -14,8 +14,6 @@ tags:
 section: Manage your account
 ---
 
-Add a second factor to your Knock dashboard login using an authenticator app.
-
 ## Overview
 
 Multi-factor authentication (MFA) adds a second verification step on top of your existing [login method](/manage-your-account/authentication-methods). After you sign in with email or Google, Knock prompts you for a one-time code from your authenticator app before granting access to the dashboard.
@@ -24,9 +22,9 @@ MFA applies to email (passwordless) and Google logins. If your account uses [SAM
 
 ## Enroll in MFA
 
-Any member can enroll in MFA from their profile settings in the Knock dashboard.
+Any member can enroll in MFA from their profile settings in the Knock dashboard. Account owners and admins who want to require MFA for all members use a separate account-level setting (see [Enforce MFA for your account](#enforce-mfa-for-your-account) below).
 
-1. Open your profile settings and navigate to the **Security** section.
+1. Click **Overview** in the sidebar, then open your <a href="https://dashboard.knock.app/~/settings/profile" target="_blank" rel="noopener">**profile settings**</a> and navigate to the **Security** section.
 2. Under **Two-factor authentication**, click **Set up**.
 3. Scan the QR code with an authenticator app (such as 1Password, Authy, or Google Authenticator).
 4. Enter the 6-digit code from your authenticator app to confirm enrollment.
@@ -42,19 +40,19 @@ You can regenerate backup codes from your profile **Security** settings at any t
 
 ## Logging in with MFA
 
-When MFA is enabled on your account, Knock prompts you for a verification code after you complete the initial sign-in step (email magic link or Google).
+When MFA is enabled on your account, Knock prompts you for a verification code after you complete the initial sign-in step (email magic link or Google SSO).
 
 1. Open your authenticator app and enter the current 6-digit code on the MFA challenge screen.
 2. If you cannot access your authenticator app, click **Use a backup code** and enter one of your saved backup codes instead.
 
-After you verify your code, Knock completes your session and redirects you to the dashboard.
+After you verify your code, Knock authenticates your session and redirects you to the dashboard.
 
 ## Enforce MFA for your account
 
-Account owners and admins can require all members to enroll in MFA before they can access the dashboard.
+Account owners and admins can require all members to enroll in MFA before they can access the dashboard. This is separate from enrolling MFA for your own login on the **Profile** page.
 
 1. Log in to your Knock dashboard.
-2. Navigate to the **Security** page under **Admin** in your account settings.
+2. Navigate to the **Security** page under **Admin** in your account settings (`dashboard.knock.app/<slug>/settings/security`, where `<slug>` is your account identifier).
 3. Toggle **Require multi-factor authentication** to enable enforcement for all members.
 
 When enforcement is enabled, members who have not yet enrolled in MFA are prompted to set up an authenticator app at their next login or token refresh. They cannot access the dashboard until enrollment is complete.
@@ -64,10 +62,9 @@ When enforcement is enabled, members who have not yet enrolled in MFA are prompt
   title="SAML SSO accounts."
   text={
     <>
-      The require MFA toggle is not available for accounts with{" "}
-      <a href="/manage-your-account/saml-sso">SAML SSO</a> enabled. Your
-      identity provider manages authentication, including MFA, for members who
-      sign in through SSO.
+      The require MFA toggle is not available for accounts with SAML SSO
+      enabled. Your identity provider manages authentication, including MFA, for
+      members who sign in through SSO.
     </>
   }
 />
@@ -81,8 +78,8 @@ If a member loses access to their authenticator app and backup codes, an account
 <AccordionGroup>
   <Accordion title="What authenticator apps are supported?">
     Knock supports TOTP-based authenticator apps, including 1Password, Authy,
-    Google Authenticator, and other apps that scan QR codes or accept otpauth://
-    URIs.
+    Google Authenticator, and other apps that scan QR codes or accept
+    `otpauth://` URIs.
   </Accordion>
   <Accordion title="Can I disable MFA on my account?">
     Yes. You can disable MFA from your profile **Security** settings. You must

--- a/content/manage-your-account/multi-factor-authentication.mdx
+++ b/content/manage-your-account/multi-factor-authentication.mdx
@@ -1,7 +1,16 @@
 ---
 title: Multi-factor authentication
 description: Add an extra layer of security to your Knock account by enabling multi-factor authentication (MFA) for dashboard login.
-tags: ["mfa", "2fa", "two-factor", "authenticator", "backup codes", "security", "login"]
+tags:
+  [
+    "mfa",
+    "2fa",
+    "two-factor",
+    "authenticator",
+    "backup codes",
+    "security",
+    "login",
+  ]
 section: Manage your account
 ---
 
@@ -72,14 +81,14 @@ If a member loses access to their authenticator app and backup codes, an account
 <AccordionGroup>
   <Accordion title="What authenticator apps are supported?">
     Knock supports TOTP-based authenticator apps, including 1Password, Authy,
-    Google Authenticator, and other apps that scan QR codes or accept
-    otpauth:// URIs.
+    Google Authenticator, and other apps that scan QR codes or accept otpauth://
+    URIs.
   </Accordion>
   <Accordion title="Can I disable MFA on my account?">
     Yes. You can disable MFA from your profile **Security** settings. You must
-    enter a current code from your authenticator app to confirm. If your
-    account owner or admin has enabled account-wide MFA enforcement, you cannot
-    disable MFA until enforcement is turned off.
+    enter a current code from your authenticator app to confirm. If your account
+    owner or admin has enabled account-wide MFA enforcement, you cannot disable
+    MFA until enforcement is turned off.
   </Accordion>
   <Accordion title="What happens if I lose my authenticator and backup codes?">
     Contact an account owner or admin to reset your MFA. After the reset, you

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -221,6 +221,10 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
     desc: "Learn more about the tools available in managing your Knock account.",
     pages: [
       { slug: "/authentication-methods", title: "Authentication methods" },
+      {
+        slug: "/multi-factor-authentication",
+        title: "Multi-factor authentication",
+      },
       { slug: "/saml-sso", title: "SAML SSO" },
       { slug: "/directory-sync", title: "Directory sync (SCIM)" },
       { slug: "/managing-members", title: "Managing members" },


### PR DESCRIPTION
### Description

Adds a new **Multi-factor authentication** page under Manage your account covering:

- Per-user MFA enrollment via an authenticator app
- Backup codes for recovery at login
- Account-level MFA enforcement for owners and admins
- Member MFA reset for lost-device recovery
- FAQ and SSO interaction notes

Also adds the page to the platform sidebar and cross-links from the authentication methods page.

### Todos

- [ ] Confirm exact UI labels and settings locations before publishing
- [ ] Confirm whether account-wide enforcement is plan-gated
- [ ] Add screenshots to `/public/images/manage-your-account/` when available

### Tasks

[KNO-13888](https://linear.app/knock/issue/KNO-13888)

### Screenshots

N/A — text-only docs page for now.


Made with [Cursor](https://cursor.com)