### PR TITLE
fix(KNO-13936): Reorganize link tracking opt-out docs

### DIFF
--- a/content/send-notifications/tracking.mdx
+++ b/content/send-notifications/tracking.mdx
@@ -150,7 +150,14 @@ Knock is able to identify many types of URLs for tracking:
   }
 />
 
-#### Opting links out of tracking
+There are two types of trackable links Knock may generate: standard and short. Standard links encode the target URL (and other event metadata) into a variable-length token added to the link path. Short links instead use a lookup key added to the link that maps to a record of the target URL. The short link lookup key will always be 10-characters in length, with short links always 31-characters long in total.
+
+Given their brevity and consistent length, Knock will use short links for channels that often have character constraints. Specifically these are:
+
+- All SMS channels
+- WhatsApp chat channel
+
+#### Opting single links out of tracking
 
 When link tracking is enabled, Knock wraps every eligible URL in a notification as a trackable link, so a click on any of these links counts toward your engagement metrics. For some notifications, such as campaign emails, you may only care about clicks on your primary calls to action and you don't want footer or utility links—a privacy policy or help center link, for example—to count toward your click-through metrics.
 
@@ -167,13 +174,6 @@ When Knock renders the notification, it will:
 - Skip capturing a `message.link_clicked` event when the recipient clicks the link.
 
 Because this relies on an HTML attribute, opting out is available in channels that render HTML, such as email.
-
-There are two types of trackable links Knock may generate: standard and short. Standard links encode the target URL (and other event metadata) into a variable-length token added to the link path. Short links instead use a lookup key added to the link that maps to a record of the target URL. The short link lookup key will always be 10-characters in length, with short links always 31-characters long in total.
-
-Given their brevity and consistent length, Knock will use short links for channels that often have character constraints. Specifically these are:
-
-- All SMS channels
-- WhatsApp chat channel
 
 ### Link-click tracking domains
 


### PR DESCRIPTION
### Description

Moves the link-tracking opt-out section so the link-click tracking flow reads more clearly.

### Tasks

[KNO-13936](https://linear.app/knock/issue/KNO-13936/docs-edit-flow-of-link-tracking-docs)
