### PR TITLE
Set up PostHog reverse proxy for docs site

### DIFF
--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -1,8 +1,12 @@
 import posthog from "posthog-js";
 
 export const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const POSTHOG_HOST =
-  process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com";
+
+// Use reverse proxy path to avoid ad-blocker tracking prevention
+// The /ingest path is rewritten to us.i.posthog.com in next.config.js
+const POSTHOG_API_HOST = "/ingest";
+// UI host is used for toolbar and session recording links
+const POSTHOG_UI_HOST = "https://us.posthog.com";
 
 let initialized = false;
 
@@ -12,7 +16,8 @@ export function init(): void {
   if (!POSTHOG_KEY) return;
 
   posthog.init(POSTHOG_KEY, {
-    api_host: POSTHOG_HOST,
+    api_host: POSTHOG_API_HOST,
+    ui_host: POSTHOG_UI_HOST,
     capture_pageview: false, // We handle page views manually on route changes
     capture_pageleave: true,
   });

--- a/next.config.js
+++ b/next.config.js
@@ -69,6 +69,25 @@ const nextConfig = {
     ];
   },
 
+  async rewrites() {
+    return [
+      // PostHog reverse proxy to avoid ad-blocker tracking prevention
+      // See: https://posthog.com/docs/advanced/proxy/nextjs
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      {
+        source: "/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+    ];
+  },
+
   async redirects() {
     return [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR sets up a PostHog reverse proxy for the docs site to prevent ad blockers from blocking PostHog tracking requests. The docs site was sending PostHog events directly to `https://us.i.posthog.com`, which is on default ad-blocker blocklists. Since the docs audience is primarily developers who commonly use ad blockers, this was causing significant underreporting of pageviews.

**Changes made:**

1. **Added Next.js rewrites in `next.config.js`** to proxy PostHog traffic through first-party paths:
   - `/ingest/static/:path*` → `https://us-assets.i.posthog.com/static/:path*` (for static assets)
   - `/ingest/:path*` → `https://us.i.posthog.com/:path*` (for API requests)
   - `/ingest/decide` → `https://us.i.posthog.com/decide` (for feature flag/decide endpoint)

2. **Updated `lib/posthog.ts`** to use the proxied paths:
   - `api_host: "/ingest"` (routes through the local proxy)
   - `ui_host: "https://us.posthog.com"` (for toolbar and session recording links)

This follows [PostHog's official Next.js reverse proxy documentation](https://posthog.com/docs/advanced/proxy/nextjs).

### Screenshots

Network requests showing PostHog traffic routing through the `/ingest` proxy path instead of external PostHog domains:

[Network tab showing PostHog requests going through the /ingest proxy](https://cursor.com/agents/bc-ea536ba7-ba27-40da-9260-90008891d0e0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fposthog_proxy_test_network_requests.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13949](https://linear.app/knock/issue/KNO-13949/set-up-posthog-reverse-proxy-for-docs-site)

<div><a href="https://cursor.com/agents/bc-ea536ba7-ba27-40da-9260-90008891d0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea536ba7-ba27-40da-9260-90008891d0e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

