### PR TITLE
docs(kno-13979): wait for event step

### DIFF
--- a/content/designing-workflows/overview.mdx
+++ b/content/designing-workflows/overview.mdx
@@ -74,6 +74,7 @@ We currently support the following functions:
 - [Branch](/send-notifications/designing-workflows/branch-function) (evaluate conditions to determine which path a workflow should take)
 - [Experiment](/send-notifications/designing-workflows/experiment-function) (randomly assign recipients to percentage-based cohorts for A/B testing and experimentation)
 - [Delay](/send-notifications/designing-workflows/delay-function) (wait an amount of time before proceeding to the next workflow step)
+- [Wait for event](/send-notifications/designing-workflows/wait-for-event-function) (pause a workflow until a matching event is received or the wait time expires)
 - [Fetch](/send-notifications/designing-workflows/fetch-function) (execute an HTTP request to fetch additional data for a workflow)
 - [AI agent](/send-notifications/designing-workflows/ai-agent-function) (run a prompt on an AI model and merge the response into workflow state)
 - [Throttle](/send-notifications/designing-workflows/throttle-function) (limits the number of executions of the workflow for the recipient over a window of time)

--- a/content/designing-workflows/wait-for-event-function.mdx
+++ b/content/designing-workflows/wait-for-event-function.mdx
@@ -1,0 +1,261 @@
+---
+title: Wait for event function
+description: Learn more about the wait for event workflow function within Knock's notification engine.
+tags:
+  [
+    "steps",
+    "wait",
+    "events",
+    "sources",
+    "messages",
+    "audiences",
+    "recipients",
+    "functions",
+  ]
+section: Designing workflows
+---
+
+A wait for event function pauses a workflow until a matching event is received, or until a configured wait time expires. Use it when the next step in your workflow should depend on something that happens after the run starts — such as a payment completing in an external system, a message being delivered, another workflow finishing for the same recipient, an audience membership change, or a recipient property update.
+
+## How it works
+
+When a workflow run reaches a wait for event step, Knock pauses execution and registers a durable wait for the configured event. The workflow stays paused until one of the following happens:
+
+1. **A matching event is received.** Knock evaluates the event against your match conditions (when configured). If the event passes, Knock applies your **On match** action and resumes the workflow (or halts it, depending on your configuration).
+2. **The wait time expires.** If no matching event arrives before the wait time ends, Knock applies your **After wait time** action.
+
+While the workflow is paused, no downstream steps execute. This makes the wait for event function useful for coordinating notifications with product activity without building polling or state management in your application.
+
+## Event types
+
+Select an **event type** in the step settings, then configure the fields for that type.
+
+### Integration source
+
+Wait for an event from a connected [integration source](/integrations/sources/overview), such as Segment, Stripe, or a custom webhook source.
+
+Configure:
+
+- **Event.** The source event to wait for. Knock identifies the event by its event key and integration source key, which remain stable when you promote workflows between environments.
+
+Your Knock environment must have at least one configured source that has received the event you want to wait for.
+
+When a source event includes a `user_id`, Knock scopes matching to the workflow recipient for that run. Events without a recipient association can still match waits that are registered without recipient scoping.
+
+### Message
+
+Wait for a [message lifecycle event](/send-notifications/message-statuses) produced by a specific [workflow](/concepts/workflows), [broadcast](/concepts/broadcasts), or [guide](/concepts/guides) for the same recipient.
+
+Configure:
+
+- **Source type.** The kind of message source to observe: workflow, broadcast, or guide.
+- **Source.** The specific workflow, broadcast, or guide whose messages should match this wait.
+- **Message event.** The lifecycle event to wait for, such as delivered, bounced, seen, read, or link clicked.
+
+Available message events include: created, queued, sent, not sent, delivered, delivery attempted, undelivered, bounced, read, unread, seen, unseen, archived, unarchived, interacted, and link clicked.
+
+Message event waits are scoped to the workflow recipient and the selected message source. Match conditions are **required** for message events.
+
+### Workflow
+
+Wait for a workflow lifecycle event from another workflow run for the same recipient.
+
+Configure:
+
+- **Workflow.** The workflow whose lifecycle events this wait should observe.
+- **Workflow event.** Either **Started** or **Completed**.
+
+Workflow event waits are scoped to the workflow recipient and the selected workflow. Match conditions are **required** for workflow events.
+
+### Audience
+
+Wait for a [dynamic audience](/concepts/audiences) membership change for the workflow recipient.
+
+Configure:
+
+- **Audience.** The dynamic audience to watch. Static audiences are not supported for wait for event steps.
+- **Membership event.** Either **Enter** or **Exit**.
+
+### Recipient
+
+Wait for the current workflow recipient to be updated in Knock. Today, recipient waits listen for the **updated** event for that recipient (not updates for other recipients).
+
+Recipient waits have no additional configuration fields beyond the event type. Use match conditions when you only want to resume on specific property, preference, or channel data changes.
+
+## Configuring a wait for event step
+
+Beyond selecting the event type and its event-specific fields, you configure the following settings for every wait for event step.
+
+### Match conditions
+
+Match conditions filter candidate events before the workflow resumes. Knock evaluates each candidate event against these conditions. If an event does not pass, the workflow keeps waiting until a matching event arrives or the wait time expires.
+
+| Event type         | Match conditions |
+| ------------------ | ---------------- |
+| Integration source | Optional         |
+| Message            | Required         |
+| Workflow           | Required         |
+| Audience           | Optional         |
+| Recipient          | Optional         |
+
+You can build match conditions using the same [conditions builder](/concepts/conditions) used elsewhere in Knock. The following variable namespaces are available:
+
+| Namespace           | Description                                                                     |
+| ------------------- | ------------------------------------------------------------------------------- |
+| `event.*`           | The awaited event payload. Use this namespace for fields on the incoming event. |
+| `recipient.*`       | The workflow recipient.                                                         |
+| `data.*`            | The original workflow trigger payload.                                          |
+| `vars.*`            | Environment variables.                                                          |
+| `tenant.*`          | The tenant associated with the workflow run.                                    |
+| Audience membership | Check whether the recipient belongs to an audience.                             |
+| `refs.*`            | Message status from preceding channel steps in the workflow run.                |
+
+The shape of `event.*` depends on the event type:
+
+| Event type         | Example `event.*` fields                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Integration source | Fields from the source event payload (for example, properties from a Segment track event)                                      |
+| Message            | `message_id`, `event_type`, `channel_id`, `recipient`, `inserted_at`, `source.type`, `source.key`, and event-specific `data.*` |
+| Workflow           | `workflow_key`, `workflow_run_id`, `recipient`, `status`, `inserted_at`                                                        |
+| Audience           | `audience_id`, `recipient`, `transition`, `happened_at`                                                                        |
+| Recipient          | `recipient`, `event_type`, `timestamp`, `properties`, `preferences`, `knock_traits`, `channel_data`                            |
+
+### On match
+
+Controls what happens when a matching event is received before the wait time expires:
+
+- **Continue workflow.** Resume execution and proceed to the next step. This is the default.
+- **Halt workflow.** Cancel the workflow run. Use this when the awaited event means later steps should not execute — for example, canceling a reminder workflow when a user completes the action you were going to remind them about.
+
+### Wait time
+
+How long Knock waits for a matching event before timing out. The dashboard default is 15 minutes. You can configure the duration in seconds, minutes, hours, days, or weeks.
+
+A wait for event step can wait for a maximum of 30 days.
+
+### After wait time
+
+Controls what happens when the wait time expires before a matching event arrives:
+
+- **Halt workflow.** Cancel the workflow run. This is the default.
+- **Continue workflow.** Resume execution and proceed to the next step.
+
+### Step conditions
+
+Like other workflow steps, a wait for event step supports [step conditions](/designing-workflows/step-conditions) that determine whether the step executes at all when the workflow run reaches it. Step conditions are evaluated when the step runs, not when an awaited event arrives.
+
+## Downstream step output
+
+When a wait for event step resumes on a **Continue workflow** path, it writes output under `refs.<step_ref>` that downstream steps can reference:
+
+| Property           | Type    | Description                                                                     |
+| ------------------ | ------- | ------------------------------------------------------------------------------- |
+| `matched`          | boolean | `true` when a matching event claimed the wait; `false` when the wait timed out. |
+| `signal_variables` | object  | The payload from the matched event. An empty object on timeout.                 |
+
+Use `refs.<step_ref>.matched` in a downstream [branch function](/designing-workflows/branch-function) to run different logic depending on whether the event arrived in time. Use `refs.<step_ref>.signal_variables` to access fields from the matched event payload in conditions or templates.
+
+```json title="Example downstream condition"
+// Branch on whether the event matched before timeout
+refs.wait_for_payment.matched == true
+
+// Branch on a field from the matched event payload
+refs.wait_for_payment.signal_variables.status == "paid"
+```
+
+## Common patterns
+
+### Wait for an external action before sending a follow-up
+
+Trigger a workflow when a user starts a flow, add a wait for event step that listens for a completion event from an integration source (such as Segment), then send a follow-up notification only if the user does not complete the action within your wait window.
+
+Pair this with **On match: Halt workflow** and **After wait time: Continue workflow** so the workflow proceeds to your reminder step only when the completion event does not arrive in time.
+
+### Escalate when a message is not engaged
+
+Send an in-app notification, then wait for a message **seen** or **read** event from that workflow. If the wait times out, continue to an email channel step. Use match conditions on `event.*` as needed to narrow which message events resume the workflow.
+
+### Wait for a nested workflow to finish
+
+Trigger a child workflow with a [trigger workflow function](/designing-workflows/trigger-workflow-function), then wait for that workflow's **Completed** event for the same recipient before continuing in the parent workflow.
+
+### React to audience membership changes
+
+Wait for a recipient to enter or exit a dynamic audience before sending a campaign or changing notification volume. Use audience event waits when membership is driven by properties rather than an explicit API action.
+
+### Branch on event payload
+
+After the wait resolves, use a branch step with conditions on `refs.<step_ref>.signal_variables` to send different notifications based on data in the matched event.
+
+## Wait for event vs. delay
+
+Both wait for event and [delay](/designing-workflows/delay-function) functions pause a workflow, but they differ in what resumes execution:
+
+|                                       | Wait for event                                     | Delay                                        |
+| ------------------------------------- | -------------------------------------------------- | -------------------------------------------- |
+| Resumes when                          | A matching event arrives, or the wait time expires | The configured interval or timestamp elapses |
+| Depends on external or Knock activity | Yes                                                | No                                           |
+| Match conditions                      | Yes                                                | No                                           |
+
+Use a delay when you need to wait a fixed amount of time. Use wait for event when the workflow should react to a specific event.
+
+## Using workflow cancellation with wait for event steps
+
+Workflow runs paused at a wait for event step can be canceled using the [workflow cancellation API](/send-notifications/canceling-workflows), the same as runs paused at a delay, batch, or fetch step. Provide a `cancellation_key` when you trigger the workflow, then call the cancel endpoint with the same key.
+
+Canceling a paused workflow deletes the scheduled resume job and marks the durable wait as canceled. No downstream steps execute after cancellation.
+
+## Debugging wait for event steps
+
+You can inspect wait for event execution in the [workflow debugger](/send-notifications/debugging-workflows). For each workflow run, the debugger shows:
+
+- Whether the workflow is still waiting for an event, or which event was received
+- When the wait expires or expired
+- Match condition evaluations for candidate events, including the result of each evaluation
+
+When match conditions reject an incoming event, Knock logs a `wait_conditions_evaluated` event on the workflow run so you can see why the event did not resume the workflow.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="What happens if multiple events arrive while the workflow is waiting?">
+    Knock claims the wait for the first event that passes your match conditions.
+    Subsequent events for the same wait are ignored because the wait has already
+    been claimed.
+  </Accordion>
+  <Accordion title="What happens if an event arrives after the wait time expires?">
+    Knock ignores events whose timestamp falls outside the wait window. If the
+    wait has already timed out and the workflow resumed or halted, late-arriving
+    events do not affect the run.
+  </Accordion>
+  <Accordion title="Do I need a source configured to use wait for event?">
+    Only when waiting for an integration source event. Message, workflow,
+    audience, and recipient event waits use events generated inside Knock and do
+    not require a connected source.
+  </Accordion>
+  <Accordion title="Why are match conditions required for message and workflow events?">
+    When the event type is message or workflow, Knock requires at least one
+    match condition. Integration source, audience, and recipient waits can omit
+    match conditions.
+  </Accordion>
+  <Accordion title="Can I use wait for event in an API-triggered workflow?">
+    Yes. The workflow trigger type does not affect the wait for event step. The
+    step listens for the configured event type independently of how the workflow
+    was triggered.
+  </Accordion>
+  <Accordion title="Can a workflow wait for its own message events?">
+    Yes. Select message as the event type, set the source type to workflow, and
+    choose the current workflow as the source. The wait matches message events
+    for the same recipient from that workflow.
+  </Accordion>
+  <Accordion title="What happens to paused workflow runs when I update the underlying workflow?">
+    Workflow recipient runs reference the workflow version that was current when
+    the run was triggered. Changes to the workflow do not affect runs that are
+    already in flight. Use the [workflow cancellation
+    API](/send-notifications/canceling-workflows) to stop a paused run after you
+    update the workflow.
+  </Accordion>
+  <Accordion title="How long can a workflow wait for an event?">
+    A wait for event step can wait for a maximum of 30 days.
+  </Accordion>
+</AccordionGroup>

--- a/content/send-notifications/canceling-workflows.mdx
+++ b/content/send-notifications/canceling-workflows.mdx
@@ -7,10 +7,11 @@ section: Send notifications
 
 Canceling a workflow allows you to stop a workflow run mid-execution. This action will stop the workflow from sending new messages to recipients. This can be useful in situations like reminder workflows, where a notification needs to be canceled once a user has performed an intended action.
 
-Only workflows with a step that can pause the run can be canceled, since otherwise Knock will _immediately_ send a notification to your recipients. The three steps that can pause a workflow run are:
+Only workflows with a step that can pause the run can be canceled, since otherwise Knock will _immediately_ send a notification to your recipients. The steps that can pause a workflow run are:
 
 - [Batch functions](/send-notifications/designing-workflows/batch-function) will pause workflows while the batch window is open.
 - [Delay functions](/send-notifications/designing-workflows/delay-function) will pause workflows for the configured delay window.
+- [Wait for event functions](/send-notifications/designing-workflows/wait-for-event-function) will pause workflows until a matching event is received or the wait time expires.
 - [Fetch functions](/send-notifications/designing-workflows/fetch-function) may pause workflows during a [retry backoff](/send-notifications/designing-workflows/fetch-function#error-handling).
 
 ## Canceling a triggered workflow

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -66,6 +66,10 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
         title: "Function steps",
         pages: [
           { slug: "/delay-function", title: "Delay function" },
+          {
+            slug: "/wait-for-event-function",
+            title: "Wait for event function",
+          },
           { slug: "/batch-function", title: "Batch function" },
           { slug: "/branch-function", title: "Branch function" },
           { slug: "/experiment-function", title: "Experiment function" },


### PR DESCRIPTION
### Description

Documents the **wait for event** workflow function, a new step type that pauses a workflow until a matching integration source event arrives or the configured wait time expires.

- Adds `wait-for-event-function.mdx` covering how the step works, configuration (event selection, match conditions, on match / after wait time actions, wait time limits), downstream refs output, common patterns, comparison with delay, cancellation, debugging, and FAQs
- Adds the wait for event function to the workflow functions overview and platform sidebar under function steps
- Updates `canceling-workflows.mdx`

### Tasks

[KNO-13979](https://linear.app/knock/issue/KNO-13979/docs-wait-for-event-step)

### Screenshots

<img width="288" height="203" alt="Screenshot 2026-06-29 at 14 48 41" src="https://github.com/user-attachments/assets/2ee14219-414f-44a4-9fa0-d4e7cc8937e4" />
<img width="837" height="671" alt="Screenshot 2026-06-29 at 14 48 58" src="https://github.com/user-attachments/assets/71b35585-e899-44c5-91c9-d9aeca9768f3" />
<img width="822" height="767" alt="Screenshot 2026-06-29 at 14 49 21" src="https://github.com/user-attachments/assets/061c0cb6-7182-428e-9b23-d9c000caee5c" />
