### PR TITLE
chore(KNO-14013): clarify teams prereqs and publication process

### DIFF
--- a/content/in-app-ui/react/teams-kit.mdx
+++ b/content/in-app-ui/react/teams-kit.mdx
@@ -8,7 +8,7 @@ Our `@knocklabs/react` library comes with pre-built components for allowing your
 
 ## Getting started
 
-To get started you'll need a [Knock account](https://dashboard.knock.app), a [Microsoft Teams channel connected to a Microsoft Teams bot](/integrations/chat/microsoft-teams/overview), a [Graph API-enabled application](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra), and a workflow with a Microsoft Teams channel step.
+To get started you'll need a [Knock account](https://dashboard.knock.app), a [Microsoft Teams channel connected to a Microsoft Teams bot](/integrations/chat/microsoft-teams/overview), a [Graph API-enabled application](/integrations/chat/microsoft-teams/overview#configure-graph-api-in-microsoft-entra), and a workflow with a Microsoft Teams channel step.
 
 Follow step-by-step instructions for your use case:
 

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -17,27 +17,110 @@ Today, Knock supports sending notifications to Microsoft Teams using two differe
 
 How you configure your Microsoft Teams channel in Knock depends on the method you choose.
 
-## How to connect to Teams with Knock
+## Prerequisites
 
-### Prerequisites
+If you're using an incoming webhook URL, there are no prerequisites. If you're using a Microsoft Teams bot, you'll need to follow the steps below to enable your users to connect your Teams app to their Microsoft Teams workspaces. Knock does not manage deploying and configuring your bot.
 
-If you're using an incoming webhook URL, there are no prerequisites.
+Additionally, if you intend to use our [TeamsKit](/in-app-ui/react/teams-kit) SDK or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure your bot as a Graph API-enabled application in the Microsoft Entra admin center](#configure-graph-api-in-microsoft-entra).
 
-If you're using a Microsoft Teams bot, make sure your bot has been registered and deployed with Azure. Knock does not manage deploying and configuring your bot. To set up Knock to send notifications as your bot, you'll need your bot's ID and password. These are sometimes called the App ID and App Password, and were provided to you when you registered your bot with Azure or the <a href="https://dev.teams.microsoft.com/" target="_blank">Microsoft Teams Developer Portal</a>.
+### Register a new bot
 
-Additionally, if you intend to use [TeamsKit](/in-app-ui/react/teams-kit) or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure a Graph API-enabled application in the Microsoft Entra admin center](#configuring-a-graph-api-enabled-application-in-microsoft-entra).
+<Callout
+  type="warning"
+  title="Multi-tenant bot deprecation."
+  text={
+    <>
+      As of July 31, 2025, Microsoft no longer allows the creation of
+      multi-tenant bots in Azure. If you're registering a new bot, you'll need
+      to register it as single-tenant and{" "}
+      <a href="#publish-your-app-to-the-microsoft-teams-store">
+        publish it to the Microsoft Teams app store
+      </a>{" "}
+      within a cross-tenant app so that it can be installed across customer
+      workspaces.
+    </>
+  }
+/>
 
-#### Registering a new bot
+If you haven't already, you'll need to <a href="https://learn.microsoft.com/en-us/azure/bot-service/bot-service-quickstart-create-bot?view=azure-bot-service-4.0&tabs=csharp%2Cvs" target="_blank" rel="noreferrer noopener">create a bot</a> with the Bot Framework SDK and <a href="https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=userassigned" target="_blank" rel="noreferrer noopener">register it</a> in Azure. Once your bot is created, you'll need to <a href="https://learn.microsoft.com/en-us/azure/bot-service/provision-and-publish-a-bot?view=azure-bot-service-4.0&tabs=userassigned%2Ccsharp" target="_blank" rel="noreferrer noopener">deploy it</a> to Azure so that it can be used by your customers.
 
-As of July 31, 2025, Microsoft no longer allows the creation of multi-tenant bots in Azure. If you're registering a new bot, you'll need to register it as single-tenant and publish it to the Microsoft Teams app store as a cross-tenant app so it can be installed across customer workspaces.
+### Configure Graph API in Microsoft Entra
 
-The app store submission process is managed entirely by Microsoft and typically takes 4–6 weeks to complete. We recommend reviewing Microsoft's <a href="https://learn.microsoft.com/en-us/partner-center/marketplace-offers/add-in-submission-guide" target="_blank" rel="noreferrer noopener">app submission guide</a> ahead of time to understand what's required, as there are several steps involved.
+To use TeamsKit, you'll also need to configure the API permissions and OAuth redirect URL associated with a Graph API-enabled application in the Microsoft Entra admin center. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's app registration.
+
+<Steps>
+  <Step title="Find your bot's application in the Microsoft Entra admin center">
+    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Entra ID** > **App registrations**, and locate your bot's application.
+  </Step>
+  <Step title="Configure OAuth">
+    On your app's registration page, click **Authentication**. Under **Platform configurations**, click **Add a platform** and select **Web**.
+
+    Copy and paste the following URL into the **Redirect URI** text field:
+
+    <CopyableText
+      label="https://api.knock.app/providers/ms-teams/authenticate"
+      content="https://api.knock.app/providers/ms-teams/authenticate"
+    />
+
+    This will allow Knock to handle the OAuth redirect on behalf of your bot, and manage connecting a Microsoft Entra tenant to a Knock tenant.
+
+    Under **Supported account types**, select **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
+
+    Click **Configure** to save your changes.
+
+  </Step>
+  <Step title="Add API permissions">
+    In the top-level sidebar, navigate to **API permissions** and click **Add a permission**. Select **Microsoft Graph** > **Application permissions**.
+
+    Under **Select permissions**, add the following permissions:
+
+    - `Team.ReadBasic.All`: This permission allows your bot to read a list of all teams within a Microsoft Entra tenant.
+    - `Channel.ReadBasic.All`: This permission allows your bot to read a list of all channels within a team.
+    - `AppCatalog.Read.All`: This permission allows your bot to locate itself in the Microsoft Teams app catalog.
+    - `TeamsAppInstallation.ReadWriteSelfForTeam.All`: This permission allows your bot to install itself into a team.
+    - `TeamsAppInstallation.ReadWriteSelfForUser.All`: This permission allows your bot to install itself into a user's personal scope.
+
+    Click **Add permissions** to save your changes.
+
+  </Step>
+</Steps>
+
+### Publish your app to the Microsoft Teams Store
+
+<Callout
+  type="info"
+  title="Teams Store submission timeline."
+  text={
+    <>
+      The Microsoft Teams Store submission process is managed entirely by
+      Microsoft and typically takes 4–6 weeks to complete. We recommend
+      reviewing Microsoft's{" "}
+      <a
+        href="https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/appsource/publish"
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        app submission guide
+      </a>{" "}
+      ahead of time to understand what's required, as there are several steps
+      involved.
+    </>
+  }
+/>
+
+Before you can start sending production notifications to your customers, you'll need to <a href="https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/deploy-and-publish/apps-publish-overview" target="_blank" rel="noreferrer noopener">publish an app package</a> to the Microsoft Teams Store.
+
+The Teams app package includes a `manifest.json` <a href="https://learn.microsoft.com/en-us/microsoft-365/extensibility/schema/root?view=m365-app-1.29&tabs=syntax" target="_blank" rel="noreferrer noopener">file</a> that contains the configuration for your bot. The required `scopes` will depend on the specific use case that you're targeting; see the documentation on [sending messages to public channels](/integrations/chat/microsoft-teams/sending-a-message-to-channels#adding-required-scopes-to-your-apps-manifest) and [sending direct messages](/integrations/chat/microsoft-teams/sending-a-direct-message#adding-required-scopes-to-your-apps-manifest) for more details.
 
 While your submission is under review, you can test your integration end-to-end by sideloading your app into a tenant directly. Download your Teams app as a `.zip` package from the <a href="https://dev.teams.microsoft.com/" target="_blank" rel="noreferrer noopener">Teams Developer Portal</a>, then upload it to the Teams Admin Center of the tenant you want to test in under **Teams apps** > **Manage app** > **Upload**. This makes your app available in that tenant's catalog without needing to wait for store approval.
 
+## How to connect to Teams with Knock
+
+To set up Knock to send notifications as your bot, you'll need your bot's ID and password. These are sometimes called the App ID and App Password, and were provided to you when you registered your bot with Azure or the <a href="https://dev.teams.microsoft.com/" target="_blank">Microsoft Teams Developer Portal</a>.
+
 ### Add Teams to Knock as a channel
 
-First you'll need to add Teams as a channel in Knock. Navigate to **Channels and sources** in your Knock dashboard account settings and click “Create channel” to add Microsoft Teams.
+First you'll need to add Teams as a channel in Knock. Navigate to <a href="https://dashboard.knock.app/~/settings/integrations/channels" target="_blank"><strong>Channels and sources</strong></a> in your Knock dashboard account settings and click “Create channel” to add Microsoft Teams.
 
 If you're using an incoming webhook URL, no additional environment configuration is required.
 
@@ -110,47 +193,6 @@ Now you're ready to notify Teams. [Trigger the workflow](/send-notifications/tri
 />
 
 Your Teams channel should have received a notification. If you need to debug your integration, you can view the logs page in the Knock dashboard.
-
-## Configuring a Graph API-enabled application in Microsoft Entra
-
-To use TeamsKit, you'll need to configure the API permissions and OAuth redirect URL associated with a Graph API-enabled application in the Microsoft Entra admin center. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's app registration.
-
-<Steps titleSize="h3">
-  <Step title="Find your application in the Microsoft Entra admin center">
-    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Entra ID** > **App registrations**, and locate your application.
-  </Step>
-  <Step title="Configure OAuth">
-    On your app's registration page, click **Authentication**. Under **Platform configurations**, click **Add a platform** and select **Web**.
-
-    Copy and paste the following URL into the **Redirect URI** text field:
-
-    <CopyableText
-      label="https://api.knock.app/providers/ms-teams/authenticate"
-      content="https://api.knock.app/providers/ms-teams/authenticate"
-    />
-
-    This will allow Knock to handle the OAuth redirect on behalf of your application, and manage connecting a Microsoft Entra tenant to a Knock tenant.
-
-    Under **Supported account types**, select **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
-
-    Click **Configure** to save your changes.
-
-  </Step>
-  <Step title="Add API permissions">
-    In the top-level sidebar, navigate to **API permissions** and click **Add a permission**. Select **Microsoft Graph** > **Application permissions**.
-
-    Under **Select permissions**, add the following permissions:
-
-    - `Team.ReadBasic.All`: This permission allows your bot to read a list of all teams within a Microsoft Entra tenant.
-    - `Channel.ReadBasic.All`: This permission allows your bot to read a list of all channels within a team.
-    - `AppCatalog.Read.All`: This permission allows your bot to locate itself in the Microsoft Teams app catalog.
-    - `TeamsAppInstallation.ReadWriteSelfForTeam.All`: This permission allows your bot to install itself into a team.
-    - `TeamsAppInstallation.ReadWriteSelfForUser.All`: This permission allows your bot to install itself into a user's personal scope.
-
-    Click **Add permissions** to save your changes.
-
-  </Step>
-</Steps>
 
 ## How to set channel data for a Microsoft Teams integration in Knock
 

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -21,7 +21,7 @@ How you configure your Microsoft Teams channel in Knock depends on the method yo
 
 If you're using an incoming webhook URL, there are no prerequisites. If you're using a Microsoft Teams bot, you'll need to follow the steps below to enable your users to connect your Teams app to their Microsoft Teams workspaces. Knock does not manage deploying and configuring your bot.
 
-Additionally, if you intend to use our [TeamsKit](/in-app-ui/react/teams-kit) SDK or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure your bot as a Graph API-enabled application in the Microsoft Entra admin center](#configure-graph-api-in-microsoft-entra).
+Additionally, if you intend to use our [TeamsKit](/in-app-ui/react/teams-kit) SDK or Knock's [Microsoft Teams-related React hooks](/in-app-ui/react/teams-kit#using-teamskit-headless), you'll need to [configure a Graph API-enabled application in the Microsoft Entra admin center](#configure-graph-api-in-microsoft-entra).
 
 ### Register a new bot
 
@@ -46,11 +46,11 @@ If you haven't already, you'll need to <a href="https://learn.microsoft.com/en-u
 
 ### Configure Graph API in Microsoft Entra
 
-To use TeamsKit, you'll also need to configure the API permissions and OAuth redirect URL associated with a Graph API-enabled application in the Microsoft Entra admin center. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's app registration.
+To use TeamsKit, you'll also need to configure the API permissions and OAuth redirect URL associated with a Graph API-enabled application in the Microsoft Entra admin center. You can use the bot application that has already been registered with Azure, or you can use a separate application.
 
 <Steps>
-  <Step title="Find your bot's application in the Microsoft Entra admin center">
-    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Entra ID** > **App registrations**, and locate your bot's application.
+  <Step title="Find your application in the Microsoft Entra admin center">
+    Log in to the <a href="https://entra.microsoft.com/" target="_blank">Microsoft Entra admin center</a>. In the sidebar, navigate to **Entra ID** > **App registrations**, and locate your application.
   </Step>
   <Step title="Configure OAuth">
     On your app's registration page, click **Authentication**. Under **Platform configurations**, click **Add a platform** and select **Web**.
@@ -62,7 +62,7 @@ To use TeamsKit, you'll also need to configure the API permissions and OAuth red
       content="https://api.knock.app/providers/ms-teams/authenticate"
     />
 
-    This will allow Knock to handle the OAuth redirect on behalf of your bot, and manage connecting a Microsoft Entra tenant to a Knock tenant.
+    This will allow Knock to handle the OAuth redirect on behalf of your app, and manage connecting a Microsoft Entra tenant to a Knock tenant.
 
     Under **Supported account types**, select **Accounts in any organizational directory (Any Microsoft Entra ID tenant - Multitenant)**.
 
@@ -74,11 +74,11 @@ To use TeamsKit, you'll also need to configure the API permissions and OAuth red
 
     Under **Select permissions**, add the following permissions:
 
-    - `Team.ReadBasic.All`: This permission allows your bot to read a list of all teams within a Microsoft Entra tenant.
-    - `Channel.ReadBasic.All`: This permission allows your bot to read a list of all channels within a team.
-    - `AppCatalog.Read.All`: This permission allows your bot to locate itself in the Microsoft Teams app catalog.
-    - `TeamsAppInstallation.ReadWriteSelfForTeam.All`: This permission allows your bot to install itself into a team.
-    - `TeamsAppInstallation.ReadWriteSelfForUser.All`: This permission allows your bot to install itself into a user's personal scope.
+    - `Team.ReadBasic.All`: This permission allows your application to read a list of all teams within a Microsoft Entra tenant.
+    - `Channel.ReadBasic.All`: This permission allows your application to read a list of all channels within a team.
+    - `AppCatalog.Read.All`: This permission allows your application to locate itself in the Microsoft Teams app catalog.
+    - `TeamsAppInstallation.ReadWriteSelfForTeam.All`: This permission allows your application to install itself into a team.
+    - `TeamsAppInstallation.ReadWriteSelfForUser.All`: This permission allows your application to install itself into a user's personal scope.
 
     Click **Add permissions** to save your changes.
 
@@ -133,8 +133,7 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
   <Step title="Select your bot’s type">
     Before selecting a bot type in Knock, you'll first want to confirm how your bot is registered in Azure. You can locate both the Bot Type and App (Entra) Tenant ID in the <a href="https://portal.azure.com/" target="_blank">Azure Portal</a> by
     navigating to your Azure Bot resource and selecting “Settings” > “Configuration” in the sidebar to view your
-    bot’s configuration details. The “Bot Type” dropdown menu will indicate whether your bot is multi-tenant or
-    single-tenant. The “App Tenant ID” text field will display the ID of your Entra tenant.
+    bot’s configuration details. The “Bot Type” dropdown menu will indicate whether your bot is single-tenant or multi-tenant (legacy). The “App Tenant ID” text field will display the ID of your Entra tenant.
 
     <figure>
       <Image
@@ -150,7 +149,7 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
     </figure>
 
     <AccordionGroup>
-      <Accordion title="Single-tenant bot" >
+      <Accordion title="Single-tenant bot" defaultOpen={true} >
         If your bot is registered with Azure as a single-tenant bot, select “Single-tenant”.
         Then, in the “Entra tenant ID” text field, enter the ID of the Microsoft
         Entra tenant in which your bot is registered.
@@ -168,9 +167,9 @@ If you're using a Microsoft Teams bot, follow these steps to configure your bot 
     changes.
   </Step>
   <Step title="Enter your Graph API-enabled client credentials">
-    If you intend to use TeamsKit, you'll need to enter the client ID and secret associated with a [Graph API-enabled application](#configuring-a-graph-api-enabled-application-in-microsoft-entra) registered with Microsoft Entra. If your bot has been registered with Azure as a multi-tenant bot, you can use your bot's credentials.
+    If you intend to use TeamsKit, you'll need to enter the client ID and secret associated with a [Graph API-enabled application](#configure-graph-api-in-microsoft-entra) registered with Microsoft Entra.
 
-    In the “Graph API client ID” and “Graph API client secret” fields, enter the client ID and secret associated with your application.
+    In the “Graph API client ID” and “Graph API client secret” fields, enter the client ID and secret associated with your application. If you registered your bot application in Entra for this purpose, the values for these fields will be the same as the bot ID and password in the previous step.
 
     Click the “Update settings” button to save your changes.
 
@@ -185,7 +184,7 @@ You can learn more about how to write basic and advanced templates for Teams in 
 
 ### Trigger the workflow
 
-Now you're ready to notify Teams. [Trigger the workflow](/send-notifications/triggering-workflows) that you added your Teams channel to. You'll need to include the user or object that has your Teams channel data as a `recipient` on the workflow trigger call.
+Now you're ready to notify Teams. [Trigger the workflow](/send-notifications/triggering-workflows) that you added your Teams channel to. You'll need to include a user or object that has [Teams channel data](#how-to-set-channel-data-for-a-microsoft-teams-integration-in-knock) set as the `recipient` on the workflow trigger call; if no `channel_data` is set on the recipient, the Teams step will be skipped.
 
 <MultiLangCodeBlock
   snippet="workflows.trigger-with-object-as-recipient"
@@ -216,9 +215,15 @@ Here's an example of setting channel data on an `Object` in Knock.
       In the example above, the <code>KNOCK_TEAMS_CHANNEL_ID</code> variable is
       the id of the Knock channel you've created to represent your Microsoft
       Teams integration within the Knock dashboard. You can find it by going to{" "}
-      <span className="font-bold">Integrations</span> {">"}{" "}
-      <span className="font-bold">Channels</span> in the Knock dashboard and
-      then copying the ID of your Microsoft Teams channel.
+      <a
+        href="https://dashboard.knock.app/~/integrations/channels"
+        target="_blank"
+      >
+        <span className="font-bold">Integrations</span> {">"}{" "}
+        <span className="font-bold">Channels</span>
+      </a>{" "}
+      in the Knock dashboard and then copying the ID of your Microsoft Teams
+      channel.
     </>
   }
 />

--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -120,7 +120,7 @@ To set up Knock to send notifications as your bot, you'll need your bot's ID and
 
 ### Add Teams to Knock as a channel
 
-First you'll need to add Teams as a channel in Knock. Navigate to <a href="https://dashboard.knock.app/~/settings/integrations/channels" target="_blank"><strong>Channels and sources</strong></a> in your Knock dashboard account settings and click “Create channel” to add Microsoft Teams.
+First you'll need to add Teams as a channel in Knock. Navigate to <a href="https://dashboard.knock.app/~/settings/integrations/channels" target="_blank"><strong>Integrations</strong> > <strong>Channels</strong></a> in your Knock dashboard account settings and click “Create channel” to add Microsoft Teams.
 
 If you're using an incoming webhook URL, no additional environment configuration is required.
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -239,7 +239,7 @@ export class TeamsBot extends TeamsActivityHandler {
 
 Here, `KNOCK_MS_TEAMS_CHANNEL_ID` is the channel ID of your Microsoft Teams integration within Knock. `getKnockUserIdFromEmailAddress` is a function that you'll need to implement to look up a Knock `User` ID in your application's database for a given email address. How you get this ID depends upon your specific application.
 
-Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your Graph API-enabled app in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configuring-a-graph-api-enabled-application-in-microsoft-entra).
+Please keep in mind that if you intend to use the Microsoft Graph API in this fashion, you'll need to add the `User.Read.All` API permission when [configuring your Graph API-enabled app in Microsoft Entra](/integrations/chat/microsoft-teams/overview#configure-graph-api-in-microsoft-entra).
 
 ## Triggering a workflow
 


### PR DESCRIPTION
### Description

This PR attempts to clarify the process for getting your MS Teams bot published as a Teams app to the Microsoft Teams Store. It adds a new section on publication to the Teams store, and also moves all of the Microsoft-side setup under the **Prerequisites** header so that **How to connect Teams with Knock** only includes the steps for dashboard configuration.

It also puts some of the existing information about multi-tenant bot deprecation and expected (lengthy) submission timelines into callouts to draw attention to those details.

Finally, it includes updated guidance regarding the multi-tenant Azure bot deprecation Microsoft-side; Microsoft support has confirmed that the Azure and Entra registrations are separate from one another, and that single-tenant Azure bots may be registered as cross-tenant applications in Entra for use with the Graph API (which TeamsKit leverages for the OAuth process and listing channels in the UI upon successful authentication). 

https://docs-lvn6kh7xy-knocklabs.vercel.app/integrations/chat/microsoft-teams/overview