### PR TITLE
chore: document message_events data sync

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -339,13 +339,13 @@ Below is a description of the columns included in the table and the data type of
 
 ### Message events table
 
-Our data warehouse connector syncs data from our `message_events` table. Each row represents a delivery or engagement event emitted for a message. You can read more about [message events](/send-notifications/message-statuses#message-events).
+The `message_events` export contains the event-level records behind message delivery and engagement. Each row captures one delivery or engagement event for a message, along with the workflow, channel, and recipient context around it. You can read more about [message events](/send-notifications/message-statuses#message-events).
 
-Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
+Use the column reference below to understand the fields included in this export. To see how these data types map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 
 <AccordionGroup>
-<Accordion title="Table definition example">
-    Please note that the table name will vary based on the name of the schema provided when filling out the form.
+<Accordion title="Table definition example (Redshift)">
+    The table name will vary based on the schema name provided during setup.
     ```sql
         CREATE TABLE <name of schema>.message_events (
           id character varying(65535) NOT NULL,

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -337,6 +337,142 @@ Below is a description of the columns included in the table and the data type of
   </Accordion>
 </AccordionGroup>
 
+### Message events table
+
+Our data warehouse connector syncs data from our `message_events` table. Each row represents a delivery or engagement event emitted for a message. You can read more about [message events](/send-notifications/message-statuses#message-events).
+
+Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
+
+<AccordionGroup>
+<Accordion title="Table definition example">
+    Please note that the table name will vary based on the name of the schema provided when filling out the form.
+    ```sql
+        CREATE TABLE <name of schema>.message_events (
+          id character varying(65535) NOT NULL,
+            environment_id character varying(65535),
+            message_id character varying(65535),
+            channel_id character varying(65535),
+            channel_type character varying(65535),
+            channel_provider character varying(65535),
+            type character varying(65535),
+            data super,
+            inserted_at timestamp with time zone,
+            recipient_type character varying(65535),
+            object_collection_name character varying(65535),
+            recipient_id character varying(65535),
+            exec_mode character varying(65535),
+            tenant_id character varying(65535),
+            workflow_key character varying(65535),
+            workflow_id character varying(65535),
+            step_ref character varying(65535),
+            guide_key character varying(65535),
+            guide_id character varying(65535),
+            PRIMARY KEY (id)
+        );
+    ```
+  </Accordion>
+  <Accordion title="Message events table structure">
+    <Table
+      headers={["Name", "Type", "Description"]}
+      rows={[
+        ["id", "string", "Unique event ID. Can be used to deduplicate events."],
+        [
+          "environment_id",
+          "string",
+          "The UUID of the environment for the message event",
+        ],
+        [
+          "message_id",
+          "string",
+          "The unique identifier for the message associated with this event",
+        ],
+        [
+          "channel_id",
+          "string",
+          "The UUID of the channel the message was sent on",
+        ],
+        [
+          "channel_type",
+          "string",
+          "The type of channel the message was sent on",
+        ],
+        [
+          "channel_provider",
+          "string",
+          "The provider for the channel the message was sent on",
+        ],
+        ["type", "string", "The message event type"],
+        ["data", "json", "The payload data for the message event"],
+        [
+          "inserted_at",
+          "timestamp",
+          "The timestamp of when the message event was created",
+        ],
+        [
+          "recipient_type",
+          "string",
+          <div key="message_events_recipient_type_body">
+            The{" "}
+            <a
+              href="/concepts/recipients"
+              target="_blank"
+              rel="noreferrer"
+              style={{
+                color: "var(--tgph-accent-11)",
+                textDecoration: "underline",
+              }}
+            >
+              type of recipient for the message event
+            </a>, such as <code>users</code>, <code>tenants</code>, or{" "}
+            <code>objects</code>
+          </div>,
+        ],
+        [
+          "object_collection_name",
+          "string",
+          <div key="message_events_object_collection_name_body">
+            The object collection name when <code>recipient_type</code> is{" "}
+            <code>objects</code>. Blank for user and tenant recipients.
+          </div>,
+        ],
+        [
+          "recipient_id",
+          "string",
+          "The ID of the recipient for the message event",
+        ],
+        ["exec_mode", "string", "The execution mode of the workflow"],
+        ["tenant_id", "string", "The tenant associated with this message event"],
+        [
+          "workflow_key",
+          "string",
+          "The unique key of the workflow the message event belongs to",
+        ],
+        [
+          "workflow_id",
+          "string",
+          "The UUID of the version of the workflow the message event belongs to",
+        ],
+        [
+          "step_ref",
+          "string",
+          "The reference of the workflow step the message event belongs to",
+        ],
+        [
+          "guide_key",
+          "string",
+          "The key of the guide, if the message event was emitted for a guide",
+        ],
+        [
+          "guide_id",
+          "string",
+          "The UUID of the version of the guide, if the message event was emitted for a guide",
+        ],
+      ]}
+    />
+
+  </Accordion>
+</AccordionGroup>
+
 ### Recipient change stream table
 
 <Callout


### PR DESCRIPTION
### Description

Updating docs to reflect our new message_events sync.

### Tasks

https://linear.app/knock/issue/PLA-3084/add-message-events-model-to-prequel

### Screenshots
<img width="1774" height="676" alt="CleanShot 2026-07-01 at 15 42 17@2x" src="https://github.com/user-attachments/assets/2176e58f-1b9f-4c34-b5f7-f5b0e343d2c2" />

<img width="1696" height="1792" alt="CleanShot 2026-07-01 at 15 42 23@2x" src="https://github.com/user-attachments/assets/c797813c-e1e0-43a3-a379-cdb3e348ca2b" />
