### PR TITLE
docs: clone resource into environment

### DIFF
--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -31,7 +31,7 @@ Broadcasts are a way to power one-time, cross-channel messaging to your users th
 
 Unlike workflows and other resources in Knock, broadcasts do not have to be committed or promoted to an environment before they can be used. In fact, unlike workflows, broadcasts are **environment-specific** and can be created in any environment (including production).
 
-If you wish to mirror a flow where you create a broadcast in development, and then use it in production you can do so by _cloning_ the broadcast to the production environment.
+If you wish to mirror a flow where you create a broadcast in development, and then use it in production you can do so by [cloning the broadcast](/version-control/environments#clone-resources-across-environments) to the production environment.
 
 ## Targeting users for a broadcast
 

--- a/content/version-control/environments.mdx
+++ b/content/version-control/environments.mdx
@@ -150,7 +150,7 @@ You can clone the following resources across environments:
 - Partials
 - Translations
 - Reusable requests
-- Source events
+- Source event mappings
 
 Archived resources cannot be cloned.
 
@@ -168,9 +168,9 @@ When you clone a workflow, Knock also copies its channel step templates and work
 Which environments you can clone into depends on your account's **production write access** setting on the **Permissions** page in your account settings:
 
 1. **Production write access enabled.** You can clone into any environment in your project.
-2. **Production write access disabled.** You can only clone into sandbox environments (typically your development environment).
+2. **Production write access disabled.** You can only clone into your Development environment.
 
-This follows the same rules as creating and editing content in an environment. If production write access is disabled, non-sandbox environments such as production and staging are read-only and cannot be selected as a clone destination.
+This follows the same rules as creating and editing content in an environment. If production write access is disabled, environments other than Development are read-only and cannot be selected as a clone destination.
 
 Branch environments cannot be used as clone targets.
 
@@ -219,9 +219,9 @@ There are two tools you can use to control access to your data in the Knock dash
   <Accordion title="I accidentally created a resource in my production environment, but I want to move it to development so that I can use the promotion model. Is this possible?">
     Yes. Use [cloning resources across
     environments](/version-control/environments#clone-resources-across-environments)
-    to copy the resource into your development environment. You can keep the
-    default `-copy` key if you want a separate copy to experiment with, or set
-    the key to match the production resource if you plan to promote it back and
-    overwrite the production version later.
+    to copy the resource into your development environment. By default a `-copy`
+    suffix will be added to the key of the cloned resource. Set the key to match
+    the production resource that you're cloning if you want promotions from the
+    lower environment to overwrite the production version later on.
   </Accordion>
 </AccordionGroup>

--- a/content/version-control/environments.mdx
+++ b/content/version-control/environments.mdx
@@ -11,6 +11,9 @@ tags:
     "staging",
     "production write access",
     "production member role",
+    "clone",
+    "cloning",
+    "duplicate",
   ]
 section: Concepts
 ---
@@ -126,6 +129,57 @@ These rules enable two ways of working with content and shipping it to your end 
   }
 />
 
+## Clone resources across environments
+
+You can clone supported resources from one environment to another in the Knock dashboard. Cloning creates a new copy of the resource in the destination environment. The clone gets a new key by default (with a `-copy` suffix) and is independent from the original.
+
+Open a resource's action menu and select **Clone** (or **Duplicate** for email layouts) to start a clone. When your account has more than one writable destination environment, you can choose which environment to clone into.
+
+Cloning is a dashboard-only feature. It is not available through the [Knock CLI](/cli/overview) or [Management API](/developer-tools/management-api) at this time.
+
+### Supported resources
+
+You can clone the following resources across environments:
+
+- Workflows
+- Broadcasts
+- Guides
+- Message types
+- Email layouts
+- Audiences
+- Partials
+- Translations
+- Reusable requests
+- Source events
+
+Archived resources cannot be cloned.
+
+### Clone vs promote
+
+Clone and promote solve different problems:
+
+1. **Clone.** Creates a new resource in another environment. Use this when you want a copy to exist in both environments, or when you need to copy content to an environment lower in the promotion chain (for example, from production to development).
+2. **Promote.** Moves committed changes for an existing resource up through your environment chain, keeping the same key. Use this when you are following the development-to-production workflow and want the same resource to exist across environments.
+
+When you clone a workflow, Knock also copies its channel step templates and workflow schema into the destination environment.
+
+### Environment targeting
+
+Which environments you can clone into depends on your account's **production write access** setting on the **Permissions** page in your account settings:
+
+1. **Production write access enabled.** You can clone into any environment in your project.
+2. **Production write access disabled.** You can only clone into sandbox environments (typically your development environment).
+
+This follows the same rules as creating and editing content in an environment. If production write access is disabled, non-sandbox environments such as production and staging are read-only and cannot be selected as a clone destination.
+
+Branch environments cannot be used as clone targets.
+
+### Common use cases
+
+1. **Copy a broadcast from development to production.** Create and test a broadcast in development, then clone it to production when you are ready to send it to real users.
+2. **Copy production content back to development.** If you created a workflow directly in production and want to edit it using the promotion model, clone it into your development environment. You can give the clone the same key as the production resource if you plan to promote it back and overwrite the production version later.
+3. **Duplicate a workflow for experimentation.** Clone a workflow within the same environment (or into another environment) to try changes without affecting the original.
+
 ## Create additional environments
 
 <Callout
@@ -163,9 +217,11 @@ There are two tools you can use to control access to your data in the Knock dash
     create and delete environments through the Knock dashboard at this time.
   </Accordion>
   <Accordion title="I accidentally created a resource in my production environment, but I want to move it to development so that I can use the promotion model. Is this possible?">
-    Yes, but you'll need to move it manually. You can create a new resource in
-    your development environment that uses the same `key` that you used in
-    production. When you promote it to production later on, it will overwrite
-    the existing version that was previously created directly in production.
+    Yes. Use [cloning resources across
+    environments](/version-control/environments#clone-resources-across-environments)
+    to copy the resource into your development environment. You can keep the
+    default `-copy` key if you want a separate copy to experiment with, or set
+    the key to match the production resource if you plan to promote it back and
+    overwrite the production version later.
   </Accordion>
 </AccordionGroup>


### PR DESCRIPTION
### Description

Docs about cloning resources across environments, this clarifies some stuff about how to use this feature, like the **production write access** that need to be enabled in order to write to all envs
