### PR TITLE
feat(KNO-13285): Preference Center externalization API docs

### DIFF
--- a/content/in-app-ui/react/preferences.mdx
+++ b/content/in-app-ui/react/preferences.mdx
@@ -5,7 +5,26 @@ description: How to build a complete notification preference center, powered by 
 section: Building in-app UI
 ---
 
-This page covers how to build a `PreferenceCenter` React component with Knock's preference APIs. This component should be flexible enough to handle most of your needs and can easily be customized or extended for more specific use cases. If you want to reference a TypeScript example, you can find one in the <a href="https://github.com/knocklabs/notion-feed-example/blob/main/components/PreferenceCenter.tsx" target="_blank" rel="noopener">Notion feed example</a>.
+This page covers how to build a `PreferenceCenter` React component with Knock's JavaScript SDK and preference APIs. This approach gives you full control over the preference model in your codebase, including support for [per-tenant preferences](/multi-tenancy/per-tenant-preferences).
+
+<Callout
+  type="info"
+  title="Use token based preferences APIs first."
+  text={
+    <>
+      For most custom preference center UIs, we recommend{" "}
+      <a href="/preferences/build-your-preference-center">
+        building your preference center
+      </a>{" "}
+      with Knock's token based preferences APIs instead. That approach reuses
+      dashboard configuration and doesn't require a user token in the browser.
+      Use this React tutorial when you need tenant-scoped preferences or want to
+      manage preferences entirely through the SDK.
+    </>
+  }
+/>
+
+If you want to reference a TypeScript example, you can find one in the <a href="https://github.com/knocklabs/notion-feed-example/blob/main/components/PreferenceCenter.tsx" target="_blank" rel="noopener">Notion feed example</a>.
 
 <SdkCard
   title="Video walkthrough"

--- a/content/preferences/build-your-preference-center.mdx
+++ b/content/preferences/build-your-preference-center.mdx
@@ -1,0 +1,152 @@
+---
+title: "Build your preference center"
+description: "Learn how to build a custom preference center in your application using Knock's token based preferences APIs."
+tags: ["preferences", "preference center", "token", "api"]
+section: Preferences
+---
+
+A preference center is a place where users can manage their notification preferences. Use this approach when you want to configure preference rows, labels, and branding in the Knock dashboard, but need visual control beyond what the [hosted preference center](/preferences/hosted-preference-center) provides in your own application.
+
+<Callout
+  type="info"
+  title="Use the hosted preference center."
+  text={
+    <>
+      The fastest way to give your users a preference center is Knock's hosted
+      preference center, a no-code page you configure from the dashboard. Use
+      the steps below when you want to build and host your own UI within your
+      application.
+    </>
+  }
+/>
+
+Knock's token based preferences APIs authenticate requests with a single-purpose signed token rather than a user token. Because the token is scoped to preference center operations only, you can call these endpoints directly from the browser. See the [Preference center API reference](/api-reference/preference_center) for endpoint details and SDK examples.
+
+<Callout
+  type="info"
+  title="No tenant preferences."
+  text={
+    <>
+      Knock's token based preferences APIs support user recipients only. They
+      don't support managing{" "}
+      <a href="/multi-tenancy/per-tenant-preferences">per-tenant preferences</a>.
+      To build a preference center for tenant-scoped preferences, use the preferences
+      API with a secret or public API key instead, as shown in the <a href="/in-app-ui/react/preferences">
+        React preferences tutorial
+      </a>.
+    </>
+  }
+/>
+
+<Callout
+  type="info"
+  title="Config is optional."
+  text={
+    <>
+      The preference center config is not required to use the token based get
+      and update preference APIs. You can drive your UI from your own
+      application logic and call the list and update endpoints directly. Fetch
+      the config when you want to reuse the rows, labels, and branding you
+      configured in the dashboard.
+    </>
+  }
+/>
+
+<Callout
+  type="info"
+  title="Same token as hosted links."
+  text={
+    <>
+      The preference center token returned by this API is the same token
+      embedded in <code>vars.manage_preferences_url</code> links sent in
+      notifications.
+    </>
+  }
+/>
+
+<Steps titleSize="h3">
+  <Step title="Generate a preference center token">
+    From your server, call the <a href="/api-reference/users/generate_preference_center_signed_url">signed URL endpoint</a> with your secret API key to generate a preference center token for a user. Keep this call server-side, then pass the <code>token</code> to your client.
+
+```bash title="Generate a preference center token"
+curl -X POST "https://api.knock.app/v1/users/user_123/preference_center/signed_url" \
+  -H "Authorization: Bearer $KNOCK_API_KEY"
+```
+
+```json title="Response"
+{
+  "url": "https://p.knock.app/p/eyJhbGciOiJIUzI1NiJ9...",
+  "token": "eyJhbGciOiJIUzI1NiJ9..."
+}
+```
+
+    Your application only needs the <code>token</code>. The <code>url</code> field is for linking users to the hosted preference center.
+
+  </Step>
+  <Step title="Fetch the preference center config (optional)">
+    If you configured a preference center in the dashboard, you can use the token to fetch that environment-level configuration for the token holder via the <a href="/api-reference/preference_center/get_config">get preference center config</a> endpoint. This returns the title, body, preference rows, and branding you configured for that environment. See the Configure your preference center section on the hosted preference center page for details on what each field represents.
+
+```javascript title="Fetch preference center config"
+const response = await fetch(
+  "https://api.knock.app/v1/preference_center/config",
+  {
+    headers: {
+      "x-knock-preference-center-token": token,
+    },
+  },
+);
+
+const config = await response.json();
+```
+
+  </Step>
+  <Step title="Get the user's preference sets">
+    Fetch the token holder's preference sets via the <a href="/api-reference/preference_center/list_preference_sets">list preference center preference sets</a> endpoint to render their current settings in your UI.
+
+```javascript title="List preference sets"
+const response = await fetch(
+  "https://api.knock.app/v1/preference_center/preferences",
+  {
+    headers: {
+      "x-knock-preference-center-token": token,
+    },
+  },
+);
+
+const preferenceSets = await response.json();
+```
+
+    The response is an array of <a href="/api-reference/recipients/preferences/schemas/preference_set">`PreferenceSet`</a> objects. The preference center supports the <code>default</code> set only—the same set the hosted preference center writes to when a user saves their preferences.
+
+  </Step>
+  <Step title="Update the user's preferences">
+    When a user saves their changes, update their <code>default</code> preference set via the <a href="/api-reference/preference_center/set_preference_set">update preference center preference set</a> endpoint. Send only the keys you want to update. Knock's token based preferences APIs merge the provided preferences into the existing set, unlike the standard <a href="/api-reference/users/set_preferences">set preferences</a> endpoint, which overwrites by default.
+
+```javascript title="Update a preference set"
+const response = await fetch(
+  "https://api.knock.app/v1/preference_center/preferences/default",
+  {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "x-knock-preference-center-token": token,
+    },
+    body: JSON.stringify({
+      categories: {
+        collaboration: {
+          channel_types: {
+            email: false,
+          },
+        },
+      },
+    }),
+  },
+);
+
+const updatedPreferenceSet = await response.json();
+```
+
+  </Step>
+</Steps>
+
+This gives you visual control over the preference center experience. When you fetch the config, your dashboard configuration remains the source of truth for labels, rows, and branding.

--- a/content/preferences/hosted-preference-center.mdx
+++ b/content/preferences/hosted-preference-center.mdx
@@ -8,7 +8,7 @@ section: Preferences
 
 Knock's hosted preference center is a page where your users manage their `default` notification preferences. You configure it from the dashboard; Knock hosts and renders the page, so you can launch a preference center without building or hosting any UI yourself.
 
-This is the fastest way to let your users update their preferences when they receive a notification. If you need more control over the experience, you can [build your own preference center UI](/preferences/overview#build-your-preference-center) on top of Knock's preferences API.
+This is the fastest way to let your users update their preferences when they receive a notification. If you need more control over the experience, you can [build your own preference center UI](/preferences/build-your-preference-center) using Knock's token based preferences APIs.
 
 <Callout
   type="info"
@@ -118,6 +118,8 @@ To link a user directly to their preference center from a notification, include 
 ```
 
 Knock renders the user-specific link in the notification. Use `vars.manage_preferences_url` when you want to give users full control over their preferences via the hosted preference center. For single-click opt-out of commercial messages via the commercial unsubscribe feature, use `vars.commercial_unsubscribe_url` instead.
+
+You can also generate the same signed URL and token on demand from your server using Knock's [token based preferences APIs](/api-reference/preference_center), for example when linking to preferences from your application rather than a notification template.
 
 ## Copying configuration between environments
 

--- a/content/preferences/overview.mdx
+++ b/content/preferences/overview.mdx
@@ -116,137 +116,35 @@ The `PreferenceSet` above models this preference grid in your application:
   }
 />
 
-## Build your preference center
+A preference center is a place where users can manage their notification preferences. For a no-code option, use the [hosted preference center](/preferences/hosted-preference-center). To build and host your own UI, see [Build your preference center](/preferences/build-your-preference-center) and the [Preference center API reference](/api-reference/preference_center).
 
-A preference center is a place where users can manage their notification preferences.
+## Create a default PreferenceSet
+
+A default preference set is the `PreferenceSet` users default to using when they first sign up for your product. Any users who don't have a preference set will default to using the default preference set. You can create a default preference set in the Knock dashboard under **Platform** > **Preferences**.
+
+<Image
+  src="/images/concepts/preferences/preferences default set environment.png"
+  alt="Creating a default preference set in Knock dashboard"
+  width={1331}
+  height={737}
+  className="mx-auto"
+/>
+
+The default preference set is environment-specific for testing purposes. You can copy the default preference set from one environment to another to keep your environments in sync.
 
 <Callout
   type="info"
-  title="Use the hosted preference center."
+  title="A note on merging preferences."
   text={
     <>
-      The fastest way to give your users a preference center is Knock's{" "}
-      <a href="/preferences/hosted-preference-center">
-        hosted preference center
-      </a>
-      , a no-code page you configure from the dashboard. Use the steps below when
-      you want to build and host your own UI within your application, or when you
-      need to support <a href="/preferences/tenant-preferences">
-        per-tenant preferences
-      </a>.
+      If you create either an environment or tenant default{" "}
+      <code>PreferenceSet</code>, those preferences will be merged with changes
+      a user makes in the UI, with the user-specified changes taking precedence.
+      See <a href="#merging-preferences">Merging preferences</a> for more
+      information.
     </>
   }
 />
-
-If you need more control over the experience, you can build your own preference center in your application. There are four steps to building a preference center with Knock:
-
-<Steps titleSize="h3">
-  <Step title="Create a default PreferenceSet">
-    A default preference set is the `PreferenceSet` users default to using when they first sign up for your product. Any users who don't have a preference set will default to using the default preference set. You can create a default preference set in the Knock dashboard under **Platform** > **Preferences**.
-
-    <Image
-      src="/images/concepts/preferences/preferences default set environment.png"
-      alt="Creating a default preference set in Knock dashboard"
-      width={1331}
-      height={737}
-      className="rounded-md mx-auto border border-gray-200"
-    />
-
-
-    The default preference set is environment-specific for testing purposes. You can copy the default preference set from one environment to another to keep your environments in sync.
-    <Callout
-
-type="info"
-title="A note on merging preferences."
-text={
-
-<>
-  If you create either an environment or tenant default{" "}
-  <code>PreferenceSet</code> those preferences will be merged with changes a
-  user makes in the UI, with the user-specified changes taking precedence. See{" "}
-  <a href="#merging-preferences">Merging preferences</a> for more information.
-</>
-} />
-
-  </Step>
-  {/* TODO: We need to scope and build this with Chris then can add this step.
-  <Step title="Create a PreferenceView">
-
-    A `PreferenceView` defines the user-facing labels for any workflows or categories in your default preference set. This enables you to introduce new keys into your default preference set and have them update in your preference center, without needing to make changes within your codebase.
-
-    You can create your `PreferenceView` in the Knock dashboard under **Platform** > **Preferences**. Your `PreferenceView` will be environment-specific for testing purposes. You can copy the `PreferenceView` from one environment to another to keep them in sync.
-
-  </Step> */}
-  <Step title="Get a user's preferences">
-    {/* TODO add once we have pre-built react component for prefs
-    You can use our pre-built React component to render your preference center in your application. Here's an example of how you can use the component:
-
-    ```jsx
-    TODO: We need this component built and documented.
-    ``` */}
-
-    Once you have your default `PreferenceSet` created, you will use the `getPreferences` method to retrieve a user's preferences for rendering in your application. If no preferences are set, this method will return the default preference set you created in the step above.
-
-    <MultiLangCodeBlock
-      title="Get preferences for a user"
-      snippet="users.getPreferences"
-    />
-
-  </Step>
-  <Step title="Render your preference center">
-    {/* TODO add once we have pre-built react component for prefs
-    You can use our pre-built React component to render your preference center in your application. Here's an example of how you can use the component:
-
-    ```jsx
-    TODO: We need this component built and documented.
-    ``` */}
-
-    Once you have loaded a user's preference, you'll need to render an interface in your application so they can update their notification preferences. Typically you encapsulate all of the getting and setting of preferences in a single component.
-
-    You can see an example of this below, but our [quickstart documentation on building preferences UI](/in-app-ui/react/preferences) provides an in-depth walkthrough of how to build a functional `PreferenceCenter` component.
-
-```jsx title="A basic preference center"
-<PreferenceCenter />
-```
-
-<Image
-  src="/images/concepts/preferences/preference-center.png"
-  alt="A basic preference center"
-  width={1184}
-  height={714}
-  className="rounded-md mx-auto border border-gray-200"
-/>
-
-  </Step>
-  <Step title="Set a user's preferences">
-    When a user makes changes to their preferences in your application, you will use the `setPreferences` method to save those changes back to Knock.
-
-    By default, the `setPreferences` method will overwrite any existing `PreferenceSet` with the new preferences provided. You can learn more about how to update a single preference in the [frequently asked questions](#frequently-asked-questions) section below.
-
-    <MultiLangCodeBlock
-      title="Set preferences for a user"
-      snippet="users.setPreferences"
-    />
-
-  </Step>
-</Steps>
-    You can learn more about rendering preferences to users in your application in the [Building In-app UI](/in-app-ui/overview) section of our documentation:
-<SdkCardGroup>
-  <SdkCard
-    title="Quickstart: Preference UIs in React"
-    linkUrl="/in-app-ui/react/preferences"
-    icon="react"
-    languages={["React"]}
-    isExternal={false}
-  />
-  <SdkCard
-    title="Javascript SDK preference reference"
-    linkUrl="/in-app-ui/javascript/sdk/reference#recipients/preferences"
-    icon="javascript"
-    languages={["JavaScript"]}
-    isExternal={false}
-  />
-</SdkCardGroup>
 
 ## Merging preferences
 

--- a/content/tutorials/implementation-guide.mdx
+++ b/content/tutorials/implementation-guide.mdx
@@ -166,7 +166,7 @@ text={
 
   </Step>
   <Step title="Preferences">
-    Once your recipients (both users and objects) and tenants have been migrated to Knock, you’ll want to consider delivery preferences for your notifications to give your users control of where and when they receive updates from your product. For more information on building a preference center in your app, check out the section on [Completing your client-side integration](#completing-your-client-side-integration) below.
+    Once your recipients (both users and objects) and tenants have been migrated to Knock, you’ll want to consider delivery preferences for your notifications to give your users control of where and when they receive updates from your product. For more information on building a preference center in your app, see [Build your preference center](/preferences/build-your-preference-center) or the [Completing your client-side integration](#completing-your-client-side-integration) section below.
 
     Knock’s powerful [Preferences](/preferences/overview) API allows your users to opt out of notifications based on the notification’s delivery `channel_type`, the `category` of the notification, the specific notification `workflow`, or a combination of these properties. You can also extend these preferences to be [tenant-specific](/multi-tenancy/per-tenant-preferences) or to [evaluate conditionally](/preferences/preference-conditions) at runtime.
 
@@ -226,7 +226,7 @@ Certain implementations will require some client-side work to [build in-app UI](
 Here are some use cases that will require additional client-side planning:
 
 - **In-app messaging.** If you’re planning to use Knock-powered in-app messaging (whether that’s a notification feed for web or mobile, other in-product notifications like modals and banners, or custom components powered by our [Message types](/in-app-ui/message-types) feature), you’ll need to build a way to display those messages to your users. For more information on your preferred language or framework, visit the **Building In-app UI** section of our navigation menu.
-- **User preferences.** In order to power [user preferences](/preferences/overview) in Knock, you need to [build a preference center](/in-app-ui/react/preferences) in your application that gives your user control over the types of notifications they receive.
+- **User preferences.** In order to power [user preferences](/preferences/overview) in Knock, you need to give your users a way to manage notification preferences in your application. For most applications, [build your preference center](/preferences/build-your-preference-center) using Knock's token based preferences APIs, or use the [hosted preference center](/preferences/hosted-preference-center) for a no-code option. If you need [per-tenant preferences](/multi-tenancy/per-tenant-preferences), use the [React preferences tutorial](/in-app-ui/react/preferences) instead.
 - **Chat app authentication.** Some delivery channels like Slack require a way for your users to authenticate your app or bot into their workspace. Knock provides drop-in React components ([SlackKit](/in-app-ui/react/slack-kit) and [TeamsKit](/in-app-ui/react/teams-kit)) for both Slack and Microsoft Teams that will help manage the process of authentication and storing the necessary information (access tokens, etc.) as [channel data](/managing-recipients/setting-channel-data) in Knock so that we can deliver your notifications.
 
 ## Testing and observability

--- a/data/sidebars/apiOverviewSidebar.ts
+++ b/data/sidebars/apiOverviewSidebar.ts
@@ -6,6 +6,7 @@ export const RESOURCE_ORDER = [
   "messages",
   "channels",
   "users",
+  "preference_center",
   "objects",
   "tenants",
   "schedules",

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -197,6 +197,10 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
         slug: "/hosted-preference-center",
         title: "Hosted preference center",
       },
+      {
+        slug: "/build-your-preference-center",
+        title: "Build your preference center",
+      },
       { slug: "/object-preferences", title: "Object preferences" },
       { slug: "/preference-conditions", title: "Preferences conditions" },
       {

--- a/data/specs/api/customizations.yml
+++ b/data/specs/api/customizations.yml
@@ -89,6 +89,10 @@ resources:
     name: Workflow runs
     description: |-
       A workflow run represents an individual execution of a [workflow](/concepts/workflows) for a specific recipient. Use the workflow runs API to inspect the status and event history of a workflow run, including which steps were executed and any errors encountered.
+  preference_center:
+    name: Preference center
+    description: |-
+      The preference center APIs enable you to build a custom preference center UI in your application. Authenticate token-based requests with a signed preference center token from the [Create preference center signed URL](/api-reference/users/generate_preference_center_signed_url) endpoint. See [Build your preference center](/preferences/build-your-preference-center) for a full walkthrough.
   schedules:
     name: Schedules
     description: |-

--- a/data/specs/api/stainless.yml
+++ b/data/specs/api/stainless.yml
@@ -87,6 +87,10 @@ resources:
         type: http
         endpoint: delete /v1/users/{user_id}/channel_data/{channel_id}
         positional_params: [ user_id, channel_id ]
+      generate_preference_center_signed_url:
+        type: http
+        endpoint: post /v1/users/{user_id}/preference_center/signed_url
+        positional_params: [ user_id ]
     subresources:
       feeds:
         methods:
@@ -291,6 +295,20 @@ resources:
       get:
         type: http
         endpoint: get /v1/workflow_recipient_runs/{id}
+        positional_params: [ id ]
+  preference_center:
+    models:
+      preference_center_config_with_metadata: '#/components/schemas/PreferenceCenterConfigWithMetadata'
+      preference_center_signed_url_response: '#/components/schemas/PreferenceCenterSignedUrlResponse'
+    methods:
+      get_config:
+        endpoint: get /v1/preference_center/config
+      list_preference_sets:
+        endpoint: get /v1/preference_center/preferences
+        paginated: false
+      set_preference_set:
+        type: http
+        endpoint: put /v1/preference_center/preferences/{id}
         positional_params: [ id ]
   schedules:
     models:


### PR DESCRIPTION
Reflecting SB PR: https://github.com/knocklabs/switchboard/pull/6774

Replace **Build your own Preference Center** section with information about doing the same thing with Knock's "Token based Preferences APIs"

Promote this approch to a full standalone page (with a sidebar tab for it), it lives right under Hosted preference center (build your own is a natural counterpart me-thinks :owl:).





| **Page** | **Path** | **Change** |
| --- | --- | --- |
| **Build your preference center** _(new)_ | [**/preferences/build-your-preference-center**](https://docs.knock.app/preferences/build-your-preference-center) | New standalone page for token based preferences APIs |
| **Preferences overview** | [**/preferences/overview**](https://docs.knock.app/preferences/overview) | Removed old SDK build steps; added preference center blurb + restored **Create a default PreferenceSet** |
| **Hosted preference center** | [**/preferences/hosted-preference-center**](https://docs.knock.app/preferences/hosted-preference-center) | Links to new page; on-demand token generation note |
| **Commercial unsubscribe** | [**/preferences/commercial-unsubscribe**](https://docs.knock.app/preferences/commercial-unsubscribe) | Callout that custom domains apply to `manage_preferences_url` only, not commercial unsubscribe |
| **React preferences** | [**/in-app-ui/react/preferences**](https://docs.knock.app/in-app-ui/react/preferences) | Callout to use token based APIs first; kept for tenant prefs / SDK path |
| **Implementation guide** | [**/tutorials/implementation-guide**](https://docs.knock.app/tutorials/implementation-guide) | Preference center guidance points to token based + hosted paths |
| **Custom domains** | [**/manage-your-account/custom-domains**](https://docs.knock.app/manage-your-account/custom-domains) | Reworked for preference center custom domain setup _(separate commit on the same branch)_ |

