### PR TITLE
docs: add recipient schemas (schema management)

### DIFF
--- a/content/cli/schema.mdx
+++ b/content/cli/schema.mdx
@@ -1,0 +1,157 @@
+---
+title: Schemas
+description: Commands for managing recipient schemas in the Knock CLI.
+---
+
+<Section path="/schema">
+<ContentColumn>
+
+Schema commands enable you to sync your [recipient schemas](/managing-recipients/schemas)—for users, tenants, and object collections—between a Knock environment and your local file system, so you can keep your schema configuration in version control.
+
+</ContentColumn>
+</Section>
+
+<Section title="Schema file structure" path="/schema/file-structure">
+<ContentColumn>
+
+When schemas are pulled from Knock, they are stored in a `schemas/` directory. User and tenant schemas are stored at the top level, and object collection schemas are stored under an `objects/` subdirectory, named by their collection key.
+
+{/* prettier-ignore */}
+<PreTextDiagram description="Local schema files structure">
+{`schemas/
+├── user.json
+├── tenant.json
+└── objects/
+    └── projects.json`}
+</PreTextDiagram>
+
+Each file describes the schema's properties, including the curated `visible`, `label`, `description`, and example (`preview_text`) values. A property's inferred `type` and `source` are read-only.
+
+</ContentColumn>
+</Section>
+
+<Section title="knock schema pull [itemType] [flags]" path="/schema/pull">
+<ContentColumn>
+
+Pull one or more recipient schemas from an environment into your local file system. Pass an item type (`user`, `tenant`, or `object`) to pull a single schema, or use `--all` to pull every schema in the environment.
+
+Use an `--environment` flag to specify the target environment; if omitted, the Knock CLI defaults to the development environment.
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--environment"
+    type="string"
+    description="The environment to use. Defaults to development."
+  />
+  <Attribute
+    name="--branch"
+    type="string"
+    description="The branch to use. Defaults to the main branch."
+  />
+  <Attribute
+    name="--all"
+    type="boolean"
+    description="Pull all schemas from the environment. Cannot be combined with an item type."
+  />
+  <Attribute
+    name="--collection"
+    type="string"
+    description="The object collection key. Required when the item type is object."
+  />
+  <Attribute
+    name="--schemas-dir"
+    type="string"
+    description="The target schemas directory path."
+  />
+  <Attribute
+    name="--force"
+    type="boolean"
+    description="Overwrite local schema files without prompting for confirmation. Defaults to false."
+  />
+</Attributes>
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="Pull all schemas"
+knock schema pull --all
+```
+
+```bash title="Pull the user schema"
+knock schema pull user
+```
+
+```bash title="Pull an object collection schema"
+knock schema pull object --collection projects
+```
+
+</ExampleColumn>
+</Section>
+
+<Section title="knock schema push [itemType] [flags]" path="/schema/push">
+<ContentColumn>
+
+Push one or more local recipient schemas to an environment. Pass an item type (`user`, `tenant`, or `object`) to push a single schema, or use `--all` to push every schema in your local schemas directory.
+
+Pushing a schema applies your curation—hidden properties, labels, descriptions, and example values—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
+
+<Callout
+  type="info"
+  title="Schemas cannot be pushed to a branch"
+  text={
+    <>
+      Branch environments inherit their schema from the parent environment and
+      are read-only for schema changes. Push to the parent environment instead.
+    </>
+  }
+/>
+
+### Flags
+
+<Attributes>
+  <Attribute
+    name="--environment"
+    type="string"
+    description="The environment to use. Defaults to development."
+  />
+  <Attribute
+    name="--branch"
+    type="string"
+    description="The branch to use. Defaults to the main branch."
+  />
+  <Attribute
+    name="--all"
+    type="boolean"
+    description="Push all schemas from the local schemas directory. Cannot be combined with an item type."
+  />
+  <Attribute
+    name="--collection"
+    type="string"
+    description="The object collection key. Required when the item type is object."
+  />
+  <Attribute
+    name="--schemas-dir"
+    type="string"
+    description="The target schemas directory path."
+  />
+</Attributes>
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="Push all schemas to production"
+knock schema push --all --environment production
+```
+
+```bash title="Push the user schema"
+knock schema push user --environment production
+```
+
+```bash title="Push an object collection schema"
+knock schema push object --collection projects --environment production
+```
+
+</ExampleColumn>
+</Section>

--- a/content/cli/schema.mdx
+++ b/content/cli/schema.mdx
@@ -6,7 +6,7 @@ description: Commands for managing recipient schemas in the Knock CLI.
 <Section path="/schema">
 <ContentColumn>
 
-Schema commands enable you to sync your [recipient schemas](/managing-recipients/schemas)—for users, tenants, and object collections—between a Knock environment and your local file system, so you can keep your schema configuration in version control.
+Schema commands enable you to sync your [recipient schemas](/managing-recipients/schemas) (for users, tenants, and object collections) between a Knock environment and your local file system, so you can keep your schema configuration in version control.
 
 </ContentColumn>
 </Section>
@@ -95,7 +95,7 @@ knock schema pull object --collection projects
 
 Push one or more local recipient schemas to an environment. Pass an item type (`user`, `tenant`, or `object`) to push a single schema, or use `--all` to push every schema in your local schemas directory.
 
-Pushing a schema applies your curation—hidden properties, labels, descriptions, and preview text—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
+Pushing a schema applies your curation (hidden properties, labels, descriptions, and preview text) to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
 
 <Callout
   type="info"

--- a/content/cli/schema.mdx
+++ b/content/cli/schema.mdx
@@ -84,7 +84,7 @@ knock schema pull user
 ```
 
 ```bash title="Pull an object collection schema"
-knock schema pull object --collection projects
+knock schema pull object --collection=projects
 ```
 
 </ExampleColumn>
@@ -99,7 +99,7 @@ Pushing a schema applies your curation (hidden properties, labels, descriptions,
 
 <Callout
   type="info"
-  title="Schemas cannot be pushed to a branch"
+  title="Schemas cannot be pushed to a branch."
   text={
     <>
       Branch environments inherit their schema from the parent environment and
@@ -142,15 +142,15 @@ Pushing a schema applies your curation (hidden properties, labels, descriptions,
 <ExampleColumn>
 
 ```bash title="Push all schemas to production"
-knock schema push --all --environment production
+knock schema push --all --environment=production
 ```
 
 ```bash title="Push the user schema"
-knock schema push user --environment production
+knock schema push user --environment=production
 ```
 
 ```bash title="Push an object collection schema"
-knock schema push object --collection projects --environment production
+knock schema push object --collection=projects --environment=production
 ```
 
 </ExampleColumn>

--- a/content/cli/schema.mdx
+++ b/content/cli/schema.mdx
@@ -25,7 +25,7 @@ When schemas are pulled from Knock, they are stored in a `schemas/` directory. U
     └── projects.json`}
 </PreTextDiagram>
 
-Each file describes the schema's properties, including the curated `visible`, `label`, `description`, and example (`preview_text`) values. A property's inferred `type` and `source` are read-only.
+Each file describes the schema's properties, including the curated `visible`, `label`, `description`, and placeholder (`preview_text`) values. A property's inferred `type` and `source` are read-only.
 
 </ContentColumn>
 </Section>
@@ -95,7 +95,7 @@ knock schema pull object --collection projects
 
 Push one or more local recipient schemas to an environment. Pass an item type (`user`, `tenant`, or `object`) to push a single schema, or use `--all` to push every schema in your local schemas directory.
 
-Pushing a schema applies your curation—hidden properties, labels, descriptions, and example values—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
+Pushing a schema applies your curation—hidden properties, labels, descriptions, and placeholder values—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
 
 <Callout
   type="info"

--- a/content/cli/schema.mdx
+++ b/content/cli/schema.mdx
@@ -25,7 +25,7 @@ When schemas are pulled from Knock, they are stored in a `schemas/` directory. U
     └── projects.json`}
 </PreTextDiagram>
 
-Each file describes the schema's properties, including the curated `visible`, `label`, `description`, and placeholder (`preview_text`) values. A property's inferred `type` and `source` are read-only.
+Each file describes the schema's properties, including the curated `visible`, `label`, `description`, and `preview_text` values. A property's inferred `type` and `source` are read-only.
 
 </ContentColumn>
 </Section>
@@ -95,7 +95,7 @@ knock schema pull object --collection projects
 
 Push one or more local recipient schemas to an environment. Pass an item type (`user`, `tenant`, or `object`) to push a single schema, or use `--all` to push every schema in your local schemas directory.
 
-Pushing a schema applies your curation—hidden properties, labels, descriptions, and placeholder values—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
+Pushing a schema applies your curation—hidden properties, labels, descriptions, and preview text—to the target environment immediately. A property's inferred type and source are read-only and are not changed by a push.
 
 <Callout
   type="info"

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -1,10 +1,10 @@
 ---
 title: Recipient schemas
-description: Curate the schemas Knock infers for your users, tenants, and objects. Hide properties, add labels and descriptions, and set example values.
+description: Curate the schemas Knock infers for your users, tenants, and objects. Hide properties, add labels and descriptions, and set placeholder values.
 section: Managing recipients
 ---
 
-Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and example values from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set example values that are used when previewing templates.
+Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and placeholder values from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set placeholder values that are used when previewing templates.
 
 Curating a schema shapes how recipient properties appear across the Knock dashboard: in the template editor, in condition and segment builders, and in recipient tables. It also makes your data legible to the Knock agent, which reads your schema to understand what properties exist and what they mean.
 
@@ -15,7 +15,7 @@ As you [identify recipients](/managing-recipients/identifying-recipients), Knock
 - **Key.** The property name, such as `plan` or `address.city`.
 - **Type.** The data type Knock inferred from your data, such as `string`, `number`, `boolean`, `object`, or `array`. Types are read-only.
 - **Source.** Whether Knock inferred the property from your data or it is a built-in system property, such as `email` on a user. This is read-only.
-- **Example.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
+- **Placeholder.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
 
 Schemas are generated per [environment](/version-control/environments), the same way recipient data is. A property that only appears in production will not show up on your development schema until Knock sees it there.
 
@@ -33,7 +33,7 @@ Schemas are generated per [environment](/version-control/environments), the same
 
 ## Curate a schema in the dashboard
 
-Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and example.
+Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and placeholder.
 
 ### Hide or show a property
 
@@ -56,15 +56,15 @@ Toggle a property's visibility to control where Knock offers it. When you hide a
 
 Give a property a **label** to set a human-readable display name, and a **description** to explain what the property is for and how it should be used. Labels and descriptions help your team choose the right property, and they give the Knock agent context about your data.
 
-### Set an example value
+### Set a placeholder value
 
-Set an **example** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data.
+Set a **placeholder** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data.
 
 ## Where curated schemas appear
 
 Once you curate a schema, it drives every place Knock surfaces recipient properties, including:
 
-- **Template editor.** Variable suggestions offer only visible properties, and previews use your example values.
+- **Template editor.** Variable suggestions offer only visible properties, and previews use your placeholder values.
 - **Condition and segment builders.** Property pickers for [conditions](/designing-workflows/step-conditions) and [audiences](/concepts/audiences) list only visible properties.
 - **Recipient tables.** Column options reflect the curated schema.
 
@@ -75,7 +75,7 @@ Access to schema management is governed by three permissions, each tied to a [ro
 | Capability                                          | Permission            | Roles                |
 | --------------------------------------------------- | --------------------- | -------------------- |
 | View schemas                                        | `item_schemas:read`   | Member, Admin, Owner |
-| Set an example value, or add a property             | `item_schemas:edit`   | Member, Admin, Owner |
+| Set a placeholder value, or add a property          | `item_schemas:edit`   | Member, Admin, Owner |
 | Hide or show a property, add a label or description | `item_schemas:manage` | Admin, Owner         |
 
 ## Environments and branches
@@ -123,7 +123,7 @@ The curatable fields on a property are:
 | `visible`      | boolean | Whether the property is offered across the dashboard. Defaults to `true`. |
 | `label`        | string  | An optional human-readable display name.                                  |
 | `description`  | string  | An optional description of the property.                                  |
-| `preview_text` | string  | The example value, JSON-encoded, used to preview templates.               |
+| `preview_text` | string  | The placeholder value, JSON-encoded, used to preview templates.           |
 
 A property's `type` and `source` are inferred by Knock and are read-only.
 
@@ -133,7 +133,7 @@ A property's `type` and `source` are inferred by Knock and are read-only.
   text={
     <>
       Reads require <code>item_schemas:read</code>. Changing a property's
-      example or adding a property requires <code>item_schemas:edit</code>.
+      placeholder or adding a property requires <code>item_schemas:edit</code>.
       Hiding or showing a property, or setting a label or description, requires{" "}
       <code>item_schemas:manage</code>.
     </>

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -1,10 +1,10 @@
 ---
 title: Recipient schemas
-description: Curate the schemas Knock infers for your users, tenants, and objects. Hide properties, add labels and descriptions, and set placeholder values.
+description: Curate the schemas Knock infers for your users, tenants, and objects. Hide properties, add labels and descriptions, and set preview text.
 section: Managing recipients
 ---
 
-Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and placeholder values from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set placeholder values that are used when previewing templates.
+Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and preview text from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set preview text that is used when previewing templates.
 
 Curating a schema shapes how recipient properties appear across the Knock dashboard: in the template editor, in condition and segment builders, and in recipient tables. It also makes your data legible to the Knock agent, which reads your schema to understand what properties exist and what they mean.
 
@@ -15,7 +15,7 @@ As you [identify recipients](/managing-recipients/identifying-recipients), Knock
 - **Key.** The property name, such as `plan` or `address.city`.
 - **Type.** The data type Knock inferred from your data, such as `string`, `number`, `boolean`, `object`, or `array`. Types are read-only.
 - **Source.** Whether Knock inferred the property from your data or it is a built-in system property, such as `email` on a user. This is read-only.
-- **Placeholder.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
+- **Preview text.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
 
 Schemas are generated per [environment](/version-control/environments), the same way recipient data is. A property that only appears in production will not show up on your development schema until Knock sees it there.
 
@@ -33,7 +33,7 @@ Schemas are generated per [environment](/version-control/environments), the same
 
 ## Curate a schema in the dashboard
 
-Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and placeholder.
+Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and preview text.
 
 ### Hide or show a property
 
@@ -56,15 +56,15 @@ Toggle a property's visibility to control where Knock offers it. When you hide a
 
 Give a property a **label** to set a human-readable display name, and a **description** to explain what the property is for and how it should be used. Labels and descriptions help your team choose the right property, and they give the Knock agent context about your data.
 
-### Set a placeholder value
+### Set the preview text
 
-Set a **placeholder** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data. In the Management API and CLI, the placeholder is a property's `preview_text` field.
+Set the **preview text** for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data. In the Management API and CLI, this is the property's `preview_text` field.
 
 ## Where curated schemas appear
 
 Once you curate a schema, it drives every place Knock surfaces recipient properties, including:
 
-- **Template editor.** Variable suggestions offer only visible properties, and previews use your placeholder values.
+- **Template editor.** Variable suggestions offer only visible properties, and previews use your preview text.
 - **Condition and segment builders.** Property pickers for [conditions](/designing-workflows/step-conditions) and [audiences](/concepts/audiences) list only visible properties.
 - **Recipient tables.** Column options reflect the curated schema.
 
@@ -75,7 +75,7 @@ Access to schema management is governed by three permissions, each tied to a [ro
 | Capability                                          | Permission            | Roles                |
 | --------------------------------------------------- | --------------------- | -------------------- |
 | View schemas                                        | `item_schemas:read`   | Member, Admin, Owner |
-| Set a placeholder value, or add a property          | `item_schemas:edit`   | Member, Admin, Owner |
+| Set the preview text, or add a property             | `item_schemas:edit`   | Member, Admin, Owner |
 | Hide or show a property, add a label or description | `item_schemas:manage` | Admin, Owner         |
 
 ## Environments and branches
@@ -123,7 +123,7 @@ The curatable fields on a property are:
 | `visible`      | boolean | Whether the property is offered across the dashboard. Defaults to `true`. |
 | `label`        | string  | An optional human-readable display name.                                  |
 | `description`  | string  | An optional description of the property.                                  |
-| `preview_text` | string  | The placeholder value, JSON-encoded, used to preview templates.           |
+| `preview_text` | string  | The preview text, JSON-encoded, used to preview templates.                |
 
 A property's `type` and `source` are inferred by Knock and are read-only.
 
@@ -133,7 +133,7 @@ A property's `type` and `source` are inferred by Knock and are read-only.
   text={
     <>
       Reads require <code>item_schemas:read</code>. Changing a property's
-      placeholder or adding a property requires <code>item_schemas:edit</code>.
+      preview text or adding a property requires <code>item_schemas:edit</code>.
       Hiding or showing a property, or setting a label or description, requires{" "}
       <code>item_schemas:manage</code>.
     </>

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -17,11 +17,11 @@ As you [identify recipients](/managing-recipients/identifying-recipients), Knock
 - **Source.** Whether Knock inferred the property from your data or it is a built-in system property, such as `email` on a user. This is read-only.
 - **Preview text.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
 
-Schemas are generated per [environment](/version-control/environments), the same way recipient data is. A property that only appears in production will not show up on your development schema until Knock sees it there.
+Schemas are logically isolated per [environment](/version-control/environments), the same way recipient data is. A property that only appears in production will not show up on your development schema until Knock sees it there.
 
 <Callout
   type="info"
-  title="Recipient schemas cover recipients"
+  title="Recipient schemas cover recipients."
   text={
     <>
       Schema management applies to recipient data: users, tenants, and object
@@ -33,15 +33,15 @@ Schemas are generated per [environment](/version-control/environments), the same
 
 ## Curate a schema in the dashboard
 
-Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and preview text.
+Go to <a href="https://dashboard.knock.app/~/settings/schemas" target="_blank">**Settings** > **Schemas**</a> and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and preview text.
 
 ### Hide or show a property
 
-Toggle a property's visibility to control where Knock offers it. When you hide a property, Knock stops offering it across the dashboard: template variable suggestions, condition and segment builders, and recipient table columns no longer list it.
+Toggle a property's visibility to control where Knock offers it. When you hide a property, Knock stops offering it across the dashboard: template variable suggestions, condition and audience segment builders, and recipient table columns no longer list it.
 
 <Callout
   type="info"
-  title="Hiding never breaks anything"
+  title="Hiding never breaks anything."
   text={
     <>
       Hiding a property controls where it is offered, not whether it exists.
@@ -70,17 +70,17 @@ Once you curate a schema, it drives every place Knock surfaces recipient propert
 
 ## Permissions
 
-Access to schema management is governed by three permissions, each tied to a [role](/manage-your-account/roles-and-permissions).
+Access to schema management is tied to your [role](/manage-your-account/roles-and-permissions).
 
-| Capability                                          | Permission            | Roles                |
-| --------------------------------------------------- | --------------------- | -------------------- |
-| View schemas                                        | `item_schemas:read`   | Member, Admin, Owner |
-| Set the preview text, or add a property             | `item_schemas:edit`   | Member, Admin, Owner |
-| Hide or show a property, add a label or description | `item_schemas:manage` | Admin, Owner         |
+| Capability                                          | Roles                |
+| --------------------------------------------------- | -------------------- |
+| View schemas                                        | Member, Admin, Owner |
+| Set the preview text, or add a property             | Member, Admin, Owner |
+| Hide or show a property, add a label or description | Admin, Owner         |
 
 ## Environments and branches
 
-Schema configuration is scoped to an environment and applies immediately, the same way [environment variables](/concepts/variables) do, rather than through commit and promote. Curate the schema in the environment whose data you want to manage.
+Schema configuration is scoped to an environment and applies immediately when saved, the same way [environment variables](/concepts/variables) do, rather than through commit and promote. Curate the schema in the environment whose data you want to manage.
 
 [Branch](/version-control/branches) environments inherit the schema and curation from their parent environment and are read-only for schema changes. Editing a schema from a branch is rejected with a pointer to the parent environment. Manage the schema from the parent environment instead.
 
@@ -129,13 +129,13 @@ A property's `type` and `source` are inferred by Knock and are read-only.
 
 <Callout
   type="info"
-  title="Permissions apply to the Management API too"
+  title="Permissions apply to the Management API too."
   text={
     <>
-      Reads require <code>item_schemas:read</code>. Changing a property's
-      preview text or adding a property requires <code>item_schemas:edit</code>.
-      Hiding or showing a property, or setting a label or description, requires{" "}
-      <code>item_schemas:manage</code>.
+      The same role-based permissions govern the Management API: any member can
+      read schemas, set preview text, and add properties, while hiding or
+      showing a property or setting a label or description requires an admin or
+      owner.
     </>
   }
 />
@@ -149,10 +149,10 @@ The [Knock CLI](/cli/overview) can pull schemas from an environment to local fil
 knock schema pull --all
 
 # Push a single recipient schema to an environment
-knock schema push user --environment production
+knock schema push user --environment=production
 
 # Push an object collection schema
-knock schema push object --collection projects --environment production
+knock schema push object --collection=projects --environment=production
 ```
 
 Schemas are stored in a `schemas/` directory, one file per recipient type. See the [schema CLI reference](/cli/schema) for the full set of commands and flags.

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -1,0 +1,165 @@
+---
+title: Recipient schemas
+description: Curate the schemas Knock infers for your users, tenants, and objects. Hide properties, add labels and descriptions, and set example values.
+section: Managing recipients
+---
+
+Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and example values from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set example values that are used when previewing templates.
+
+Curating a schema shapes how recipient properties appear across the Knock dashboard: in the template editor, in condition and segment builders, and in recipient tables. It also makes your data legible to the Knock agent, which reads your schema to understand what properties exist and what they mean.
+
+## How recipient schemas work
+
+As you [identify recipients](/managing-recipients/identifying-recipients), Knock observes the properties on that data and records them on the schema for that recipient type. Each property carries:
+
+- **Key.** The property name, such as `plan` or `address.city`.
+- **Type.** The data type Knock inferred from your data, such as `string`, `number`, `boolean`, `object`, or `array`. Types are read-only.
+- **Source.** Whether Knock inferred the property from your data or it is a built-in system property, such as `email` on a user. This is read-only.
+- **Example.** A value Knock has seen for the property, used to render realistic previews of templates that reference it.
+
+Schemas are generated per [environment](/version-control/environments), the same way recipient data is. A property that only appears in production will not show up on your development schema until Knock sees it there.
+
+<Callout
+  type="info"
+  title="Recipient schemas cover recipients"
+  text={
+    <>
+      Schema management applies to recipient data: users, tenants, and object
+      collections. Source events, workflow trigger data, and broadcast data are
+      not part of recipient schemas.
+    </>
+  }
+/>
+
+## Curate a schema in the dashboard
+
+Go to **Settings** > **Schemas** and select a recipient type: users, tenants, or one of your object collections. You will see every property Knock has inferred for that type, along with its type, source, and example.
+
+### Hide or show a property
+
+Toggle a property's visibility to control where Knock offers it. When you hide a property, Knock stops offering it across the dashboard: template variable suggestions, condition and segment builders, and recipient table columns no longer list it.
+
+<Callout
+  type="info"
+  title="Hiding never breaks anything"
+  text={
+    <>
+      Hiding a property controls where it is offered, not whether it exists.
+      Anything that already references a hidden property keeps working, and the
+      property is still returned by the API. Because nothing can break, you can
+      hide freely to tidy up the properties your team sees.
+    </>
+  }
+/>
+
+### Add a label and description
+
+Give a property a **label** to set a human-readable display name, and a **description** to explain what the property is for and how it should be used. Labels and descriptions help your team choose the right property, and they give the Knock agent context about your data.
+
+### Set an example value
+
+Set an **example** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data.
+
+## Where curated schemas appear
+
+Once you curate a schema, it drives every place Knock surfaces recipient properties, including:
+
+- **Template editor.** Variable suggestions offer only visible properties, and previews use your example values.
+- **Condition and segment builders.** Property pickers for [conditions](/designing-workflows/step-conditions) and [audiences](/concepts/audiences) list only visible properties.
+- **Recipient tables.** Column options reflect the curated schema.
+
+## Permissions
+
+Access to schema management is governed by three permissions, each tied to a [role](/manage-your-account/roles-and-permissions).
+
+| Capability                                          | Permission            | Roles                |
+| --------------------------------------------------- | --------------------- | -------------------- |
+| View schemas                                        | `item_schemas:read`   | Member, Admin, Owner |
+| Set an example value, or add a property             | `item_schemas:edit`   | Member, Admin, Owner |
+| Hide or show a property, add a label or description | `item_schemas:manage` | Admin, Owner         |
+
+## Environments and branches
+
+Schema configuration is scoped to an environment and applies immediately, the same way [environment variables](/concepts/variables) do, rather than through commit and promote. Curate the schema in the environment whose data you want to manage.
+
+[Branch](/version-control/branches) environments inherit the schema and curation from their parent environment and are read-only for schema changes. Editing a schema from a branch is rejected with a pointer to the parent environment. Manage the schema from the parent environment instead.
+
+## Sync schemas with the Management API
+
+You can read and update recipient schemas with the [Management API](/developer-tools/management-api). This is useful for version-controlling your schema configuration or for applying the same curation across environments.
+
+| Method and path                        | Description                                    |
+| -------------------------------------- | ---------------------------------------------- |
+| `GET /v1/schemas`                      | List the schemas in an environment.            |
+| `GET /v1/schemas/{item_type}`          | Retrieve the schema for a recipient type.      |
+| `PUT /v1/schemas/{item_type}`          | Update the schema for a recipient type.        |
+| `PUT /v1/schemas/{item_type}/validate` | Validate a schema payload without applying it. |
+
+`item_type` is `user`, `tenant`, or `object`. For object schemas, pass the collection with a `collection` query parameter.
+
+Each schema is a list of properties:
+
+```json title="A user schema"
+{
+  "item_type": "user",
+  "item_id": null,
+  "properties": [
+    {
+      "key": "plan",
+      "type": "string",
+      "preview_text": "\"enterprise\"",
+      "visible": true,
+      "label": "Plan",
+      "description": "The account's current billing plan."
+    }
+  ]
+}
+```
+
+The curatable fields on a property are:
+
+| Field          | Type    | Description                                                               |
+| -------------- | ------- | ------------------------------------------------------------------------- |
+| `visible`      | boolean | Whether the property is offered across the dashboard. Defaults to `true`. |
+| `label`        | string  | An optional human-readable display name.                                  |
+| `description`  | string  | An optional description of the property.                                  |
+| `preview_text` | string  | The example value, JSON-encoded, used to preview templates.               |
+
+A property's `type` and `source` are inferred by Knock and are read-only.
+
+<Callout
+  type="info"
+  title="Permissions apply to the Management API too"
+  text={
+    <>
+      Reads require <code>item_schemas:read</code>. Changing a property's
+      example or adding a property requires <code>item_schemas:edit</code>.
+      Hiding or showing a property, or setting a label or description, requires{" "}
+      <code>item_schemas:manage</code>.
+    </>
+  }
+/>
+
+## Sync schemas with the CLI
+
+The [Knock CLI](/cli/overview) can pull schemas from an environment to local files and push local changes back, so you can keep your schema configuration in version control alongside your other Knock resources.
+
+```bash title="Pull and push schemas"
+# Pull every schema in the environment into a local schemas directory
+knock schema pull --all
+
+# Push a single recipient schema to an environment
+knock schema push user --environment production
+
+# Push an object collection schema
+knock schema push object --collection projects --environment production
+```
+
+Schemas are stored in a `schemas/` directory, one file per recipient type. See the [schema CLI reference](/cli/schema) for the full set of commands and flags.
+
+## Limitations
+
+- Hidden properties are still returned by the API. Hiding affects where a property is offered in the dashboard, not API responses.
+- Property types are inferred and read-only.
+- Schemas cover recipients only: users, tenants, and objects. Source events, workflow trigger data, and broadcast data are not yet included.
+- Knock does not yet track where a property is used or validate incoming data against your schema.

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -58,7 +58,7 @@ Give a property a **label** to set a human-readable display name, and a **descri
 
 ### Set a placeholder value
 
-Set a **placeholder** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data.
+Set a **placeholder** value for a property to control how it renders in template previews. When you preview a template that references the property, Knock uses this value so the preview reflects realistic data. In the Management API and CLI, the placeholder is a property's `preview_text` field.
 
 ## Where curated schemas appear
 

--- a/content/managing-recipients/schemas.mdx
+++ b/content/managing-recipients/schemas.mdx
@@ -4,7 +4,7 @@ description: Curate the schemas Knock infers for your users, tenants, and object
 section: Managing recipients
 ---
 
-Knock builds a schema for each type of recipient in your environment—your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection—by inferring the properties, types, and preview text from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set preview text that is used when previewing templates.
+Knock builds a schema for each type of recipient in your environment (your [users](/concepts/users), your [tenants](/multi-tenancy/overview), and each [object](/concepts/objects) collection) by inferring the properties, types, and preview text from the recipient data you send. Schema management gives you control over that schema. You can hide properties you don't want to surface, add human-readable labels and descriptions, and set preview text that is used when previewing templates.
 
 Curating a schema shapes how recipient properties appear across the Knock dashboard: in the template editor, in condition and segment builders, and in recipient tables. It also makes your data legible to the Knock agent, which reads your schema to understand what properties exist and what they mean.
 
@@ -47,7 +47,7 @@ Toggle a property's visibility to control where Knock offers it. When you hide a
       Hiding a property controls where it is offered, not whether it exists.
       Anything that already references a hidden property keeps working, and the
       property is still returned by the API. Because nothing can break, you can
-      hide freely to tidy up the properties your team sees.
+      hide properties to tidy up what your team sees.
     </>
   }
 />

--- a/data/sidebars/cliSidebar.ts
+++ b/data/sidebars/cliSidebar.ts
@@ -132,6 +132,17 @@ export const CLI_SIDEBAR: SidebarContent[] = [
   },
 
   {
+    title: "Schemas",
+    slug: "/cli/schema",
+    pages: [
+      { slug: "/", title: "Overview" },
+      { slug: "/file-structure", title: "File structure" },
+      { slug: "/pull", title: "Pull schemas" },
+      { slug: "/push", title: "Push schemas" },
+    ],
+  },
+
+  {
     title: "Commits",
     slug: "/cli/commit",
     pages: [

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -169,6 +169,7 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
     pages: [
       { slug: "/overview", title: "Overview" },
       { slug: "/identifying-recipients", title: "Identifying recipients" },
+      { slug: "/schemas", title: "Recipient schemas" },
       { slug: "/setting-channel-data", title: "Setting channel data" },
       { slug: "/deleting-users", title: "Deleting users" },
       { slug: "/merging-users", title: "Merging users" },


### PR DESCRIPTION
## Summary

Documents schema management: curating the schemas Knock infers for users, tenants, and objects. Covers hiding/showing properties, labels, descriptions, and example values across the dashboard, Management API, and CLI.
