### PR TITLE
feat: empty commits (allow_empty) for CLI and Management API

### DIFF
--- a/content/cli/audience.mdx
+++ b/content/cli/audience.mdx
@@ -203,6 +203,7 @@ Note:
 
 - You must be directly above the target audience directory when running the `audience push` command, so the CLI can locate the `audience.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
 - Use `--force` to bypass environment restrictions and overwrite content in any environment. If you're using this on a non-development environment, you should also ensure you commit the changes.
 
 See the [Audience file structure](/cli/audience/file-structure) section for details on how audience files are organized.
@@ -229,6 +230,11 @@ See the [Audience file structure](/cli/audience/file-structure) section for deta
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"

--- a/content/cli/audience.mdx
+++ b/content/cli/audience.mdx
@@ -203,7 +203,7 @@ Note:
 
 - You must be directly above the target audience directory when running the `audience push` command, so the CLI can locate the `audience.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
-- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 - Use `--force` to bypass environment restrictions and overwrite content in any environment. If you're using this on a non-development environment, you should also ensure you commit the changes.
 
 See the [Audience file structure](/cli/audience/file-structure) section for details on how audience files are organized.

--- a/content/cli/commit.mdx
+++ b/content/cli/commit.mdx
@@ -151,12 +151,12 @@ Note:
 
 ### Error cases
 
-| Scenario | Result |
-| -------- | ------ |
-| `--allow-empty` without both `--resource-type` and `--resource-id` | 422 — `allow_empty` must be used with a single `resource_type` and `resource_id` |
-| Resource not found | 404 |
-| Resource has no current version | Error — cannot create an empty commit without a current version |
-| Commit message required by account | 422 — message can't be blank when account has `control-commit-msg-required` enabled |
+| Scenario                                                           | Result                                                                              |
+| ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `--allow-empty` without both `--resource-type` and `--resource-id` | 422 — `allow_empty` must be used with a single `resource_type` and `resource_id`    |
+| Resource not found                                                 | 404                                                                                 |
+| Resource has no current version                                    | Error — cannot create an empty commit without a current version                     |
+| Commit message required by account                                 | 422 — message can't be blank when account has `control-commit-msg-required` enabled |
 
 </ContentColumn>
 <ExampleColumn>

--- a/content/cli/commit.mdx
+++ b/content/cli/commit.mdx
@@ -52,7 +52,7 @@ List all commits in the environment. Use an `--environment` flag to specify the 
   <Attribute
     name="--resource-type"
     type="string"
-    description="Filter commits by resource type. One of: `email_layout`, `guide`, `message_type`, `partial`, `translation`, `workflow`. Can be used alone or together with `--resource-id`."
+    description="Filter commits by resource type. One of: `audience`, `email_layout`, `guide`, `message_type`, `partial`, `translation`, `workflow`. Can be used alone or together with `--resource-id`."
   />
   <Attribute
     name="--resource-id"
@@ -106,6 +106,14 @@ knock commit get 69cdde18-830a-42e0-ad4b-a230943bdc90
 
 You can commit all changes across all resources in the development environment with the commit command. Use `--resource-type` to commit only changes for a specific resource type, and optionally `--resource-id` to scope it further to a single resource.
 
+Use `--allow-empty` to create an empty commit for a single resource that is already published with no unpublished changes. This produces a new commit log entry with identical content, which you can promote downstream. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
+
+Note:
+
+- `--allow-empty` requires both `--resource-type` and `--resource-id`. You cannot use `--allow-empty` without scoping to a single resource.
+- When the resource has unpublished changes, `--allow-empty` is ignored and a normal commit happens instead.
+- `-m, --commit-message` is optional and stored in commit audit metadata. Your account may require a commit message.
+
 ### Flags
 
 <Attributes>
@@ -127,20 +135,47 @@ You can commit all changes across all resources in the development environment w
   <Attribute
     name="--resource-type"
     type="string"
-    description="Commit only changes for the given resource type. One of: `email_layout`, `guide`, `message_type`, `partial`, `translation`, `workflow`. Can be used alone or together with `--resource-id`."
+    description="Commit only changes for the given resource type. One of: `audience`, `email_layout`, `guide`, `message_type`, `partial`, `translation`, `workflow`. Can be used alone or together with `--resource-id`."
   />
   <Attribute
     name="--resource-id"
     type="string"
     description="Commit only changes for the given resource identifier. Must be used together with `--resource-type`."
   />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Create an empty commit for a single resource when it is already published with no unpublished changes. Requires both `--resource-type` and `--resource-id`. Defaults to false."
+  />
 </Attributes>
+
+### Error cases
+
+| Scenario | Result |
+| -------- | ------ |
+| `--allow-empty` without both `--resource-type` and `--resource-id` | 422 — `allow_empty` must be used with a single `resource_type` and `resource_id` |
+| Resource not found | 404 |
+| Resource has no current version | Error — cannot create an empty commit without a current version |
+| Commit message required by account | 422 — message can't be blank when account has `control-commit-msg-required` enabled |
 
 </ContentColumn>
 <ExampleColumn>
 
 ```bash title="Basic usage"
 knock commit -m "Commit message"
+```
+
+```bash title="Empty commit on an already-published workflow"
+knock commit \
+  --resource-type=workflow \
+  --resource-id=my-workflow \
+  --allow-empty \
+  -m "Empty touch for promotion"
+```
+
+```bash title="Verify metadata.empty in the latest commit"
+knock commit list --resource-type=workflow --resource-id=my-workflow --limit=1
+knock commit get <commit_id>
 ```
 
 </ExampleColumn>

--- a/content/cli/email-layout.mdx
+++ b/content/cli/email-layout.mdx
@@ -252,7 +252,7 @@ By default this command will resolve to the email layouts resource directory via
 
 See the [Layout file structure](/cli/email-layout/file-structure) section for details on how layout files are organized.
 
-You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 ### Flags
 

--- a/content/cli/email-layout.mdx
+++ b/content/cli/email-layout.mdx
@@ -252,6 +252,8 @@ By default this command will resolve to the email layouts resource directory via
 
 See the [Layout file structure](/cli/email-layout/file-structure) section for details on how layout files are organized.
 
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+
 ### Flags
 
 <Attributes>
@@ -264,6 +266,11 @@ See the [Layout file structure](/cli/email-layout/file-structure) section for de
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"

--- a/content/cli/guide.mdx
+++ b/content/cli/guide.mdx
@@ -280,7 +280,7 @@ Note:
 - The `guide push` command only pushes guides into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target guide directory when running the `guide push` command, so the CLI can locate the `guide.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
-- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 See the [Guide file structure](/cli/guide/file-structure) section for details on how guide files are organized.
 

--- a/content/cli/guide.mdx
+++ b/content/cli/guide.mdx
@@ -280,6 +280,7 @@ Note:
 - The `guide push` command only pushes guides into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target guide directory when running the `guide push` command, so the CLI can locate the `guide.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
 
 See the [Guide file structure](/cli/guide/file-structure) section for details on how guide files are organized.
 
@@ -300,6 +301,11 @@ See the [Guide file structure](/cli/guide/file-structure) section for details on
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"

--- a/content/cli/message-type.mdx
+++ b/content/cli/message-type.mdx
@@ -274,6 +274,7 @@ Note:
 - The `message-type push` command only pushes message types into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target message type directory when running the `message-type push` command, so the CLI can locate the `message_type.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
 
 See the [Message type file structure](/cli/message-type/file-structure) section for details on how message type files are organized.
 
@@ -294,6 +295,11 @@ See the [Message type file structure](/cli/message-type/file-structure) section 
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"

--- a/content/cli/message-type.mdx
+++ b/content/cli/message-type.mdx
@@ -274,7 +274,7 @@ Note:
 - The `message-type push` command only pushes message types into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target message type directory when running the `message-type push` command, so the CLI can locate the `message_type.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
-- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 See the [Message type file structure](/cli/message-type/file-structure) section for details on how message type files are organized.
 

--- a/content/cli/partial.mdx
+++ b/content/cli/partial.mdx
@@ -278,6 +278,7 @@ Note:
 - The `partial push` command only pushes partials into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target partial directory when running the `partial push` command, so the CLI can locate the `partial.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
 
 ### Flags
 
@@ -296,6 +297,11 @@ Note:
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"

--- a/content/cli/partial.mdx
+++ b/content/cli/partial.mdx
@@ -278,7 +278,7 @@ Note:
 - The `partial push` command only pushes partials into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target partial directory when running the `partial push` command, so the CLI can locate the `partial.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
-- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 ### Flags
 

--- a/content/cli/resources.mdx
+++ b/content/cli/resources.mdx
@@ -90,7 +90,7 @@ Pushes all local resource files (workflows, partials, email layouts, translation
 
 Resources will be pushed to the target directory path set either by your `knock.json` file or by the `--knock-dir` flag. See the [Directory structure](/cli/overview/directory-structure) section for details on the directory structure used by `push` and `pull` commands.
 
-You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 ### Flags
 

--- a/content/cli/resources.mdx
+++ b/content/cli/resources.mdx
@@ -90,6 +90,8 @@ Pushes all local resource files (workflows, partials, email layouts, translation
 
 Resources will be pushed to the target directory path set either by your `knock.json` file or by the `--knock-dir` flag. See the [Directory structure](/cli/overview/directory-structure) section for details on the directory structure used by `push` and `pull` commands.
 
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+
 ### Flags
 
 <Attributes>
@@ -107,6 +109,11 @@ Resources will be pushed to the target directory path set either by your `knock.
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--force"

--- a/content/cli/translation.mdx
+++ b/content/cli/translation.mdx
@@ -233,7 +233,7 @@ By default this command will resolve to the translations resource directory via 
 
 See the [Translation file structure](/cli/translation/file-structure) section for details on how translation files are organized.
 
-You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 ### Flags
 

--- a/content/cli/translation.mdx
+++ b/content/cli/translation.mdx
@@ -233,6 +233,8 @@ By default this command will resolve to the translations resource directory via 
 
 See the [Translation file structure](/cli/translation/file-structure) section for details on how translation files are organized.
 
+You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+
 ### Flags
 
 <Attributes>
@@ -245,6 +247,11 @@ See the [Translation file structure](/cli/translation/file-structure) section fo
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--branch"

--- a/content/cli/workflow.mdx
+++ b/content/cli/workflow.mdx
@@ -290,6 +290,7 @@ Note:
 - The `workflow push` command only pushes workflows into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target workflow directory when running the `workflow push` command, so the CLI can locate the `workflow.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
 
 See the [Workflow file structure](/cli/workflow/file-structure) section for details on how workflow files are organized.
 
@@ -310,6 +311,11 @@ See the [Workflow file structure](/cli/workflow/file-structure) section for deta
     name="-m, --commit-message"
     type="string"
     description="The commit message to pass when using the `--commit` flag."
+  />
+  <Attribute
+    name="--allow-empty"
+    type="boolean"
+    description="Only meaningful with `--commit`. When the resource is already published with no unpublished changes, create an empty commit instead of a no-op publish. Defaults to false."
   />
   <Attribute
     name="--all"
@@ -339,6 +345,13 @@ knock workflow push my-workflow
 knock workflow push my-workflow \
   --commit \
   -m "Commit message"
+```
+
+```bash title="Empty commit on an unchanged workflow"
+knock workflow push my-workflow \
+  --commit \
+  --allow-empty \
+  -m "Empty touch"
 ```
 
 ```bash title="Pushing all workflows from ./workflows directory"

--- a/content/cli/workflow.mdx
+++ b/content/cli/workflow.mdx
@@ -290,7 +290,7 @@ Note:
 - The `workflow push` command only pushes workflows into the `development` environment by default. Use `--force` to bypass this restriction and overwrite content in any environment.
 - You must be directly above the target workflow directory when running the `workflow push` command, so the CLI can locate the `workflow.json` file.
 - You can also pass in the `--commit` flag (with an optional `--commit-message` flag) to commit the upserted changes immediately.
-- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits).
+- You can pass `--allow-empty` with `--commit` to create an empty commit when re-upserting an unchanged resource. See [empty commits](/version-control/commits#empty-commits) for more on when and why to use this.
 
 See the [Workflow file structure](/cli/workflow/file-structure) section for details on how workflow files are organized.
 

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -64,3 +64,44 @@ curl -X POST https://control.knock.app/v1/workflows/my-workflow/steps/my-step/pr
   }
 }
 ```
+
+### Committing changes
+
+You can commit and promote changes between your Knock environments using the management API. This includes [empty commits](/version-control/commits#empty-commits), which let you publish a versioned resource without changing its content.
+
+#### Targeted empty commit
+
+Use `PUT /v1/commits` with `allow_empty=true` to create an empty commit for a single resource that is already published with no unpublished changes. You must specify both `resource_type` and `resource_id`.
+
+```bash title="An example request to create an empty commit"
+curl -X PUT "https://control.knock.app/v1/commits?environment=development&allow_empty=true&resource_type=workflow&resource_id=my-workflow-key&commit_message=Empty%20touch" \
+  -H "Authorization: Bearer $SERVICE_TOKEN"
+```
+
+<br />
+
+```json title="An example response from the commit endpoint"
+{
+  "result": "success"
+}
+```
+
+See the [commit all changes endpoint](/mapi-reference/commits/commit_all) for the full list of query parameters.
+
+#### Upsert and empty commit
+
+You can also create an empty commit when upserting a resource by passing `commit=true` and `allow_empty=true` as query parameters on the resource PUT route. This is useful when you re-upsert an unchanged resource payload and want to produce a new commit log entry.
+
+```bash title="An example request to upsert and create an empty commit"
+curl -X PUT "https://control.knock.app/v1/workflows/my-workflow?environment=development&commit=true&allow_empty=true&commit_message=Empty%20touch" \
+  -H "Authorization: Bearer $SERVICE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @workflow.json
+```
+
+Query parameters:
+
+- **`allow_empty`** — Optional boolean. On `PUT /v1/commits`, requires a single `resource_type` and `resource_id`. On versioned resource PUT routes, use alongside `commit=true`.
+- **`commit_message`** — Optional message stored in commit audit metadata. Your account may require a commit message.
+
+This pattern applies to PUT routes for workflows, partials, email layouts, guides, audiences, message types, and translations.

--- a/content/developer-tools/management-api.mdx
+++ b/content/developer-tools/management-api.mdx
@@ -71,7 +71,7 @@ You can commit and promote changes between your Knock environments using the man
 
 #### Targeted empty commit
 
-Use `PUT /v1/commits` with `allow_empty=true` to create an empty commit for a single resource that is already published with no unpublished changes. You must specify both `resource_type` and `resource_id`.
+Use `PUT /v1/commits` with `allow_empty=true` to create an empty commit for a single resource that has already been published and has no unpublished changes. You must specify both `resource_type` and `resource_id`.
 
 ```bash title="An example request to create an empty commit"
 curl -X PUT "https://control.knock.app/v1/commits?environment=development&allow_empty=true&resource_type=workflow&resource_id=my-workflow-key&commit_message=Empty%20touch" \
@@ -88,9 +88,9 @@ curl -X PUT "https://control.knock.app/v1/commits?environment=development&allow_
 
 See the [commit all changes endpoint](/mapi-reference/commits/commit_all) for the full list of query parameters.
 
-#### Upsert and empty commit
+#### Upsert with an empty commit
 
-You can also create an empty commit when upserting a resource by passing `commit=true` and `allow_empty=true` as query parameters on the resource PUT route. This is useful when you re-upsert an unchanged resource payload and want to produce a new commit log entry.
+You can also create an empty commit when upserting a resource by passing `commit=true` and `allow_empty=true` as query parameters on the resource PUT route. This is useful when you re-upsert an unchanged resource payload and want to create a new commit log entry.
 
 ```bash title="An example request to upsert and create an empty commit"
 curl -X PUT "https://control.knock.app/v1/workflows/my-workflow?environment=development&commit=true&allow_empty=true&commit_message=Empty%20touch" \

--- a/content/tutorials/integrating-into-cicd.mdx
+++ b/content/tutorials/integrating-into-cicd.mdx
@@ -164,6 +164,16 @@ jobs:
 
 Once you've verified staging, promote your Knock changes to production. Tie this to whatever event represents a production deploy in your pipeline: a published release, a manual workflow dispatch, or a push to a release branch are all common choices. Using a deliberate trigger (rather than promoting automatically on PR merge) gives you a chance to verify staging before changes reach production.
 
+If you need to re-promote an unchanged resource across environments (for example, to unblock a stale promotion diff), you can create an [empty commit](/version-control/commits#empty-commits) before promoting:
+
+```bash title="Create an empty commit for a workflow"
+knock commit \
+  --resource-type=workflow \
+  --resource-id=my-workflow \
+  --allow-empty \
+  -m "Empty touch for promotion"
+```
+
 ```yaml title="Promote changes to your Knock production environment on deploy"
 name: Promote Knock changes to production
 

--- a/content/version-control/commits.mdx
+++ b/content/version-control/commits.mdx
@@ -40,7 +40,11 @@ A few additional notes:
 
 An empty commit lets you commit (publish) a versioned resource without changing its content. This is similar to `git commit --allow-empty`.
 
-Promotion diffing keys off `ref` and `version_id`. When a resource is already committed (`current_version_id == published_version_id`), a normal commit is a no-op and nothing new is promotable. An empty commit clones the current version into a new version row (with a new `version_id` but identical content), then publishes that row. The result is a new commit log entry that you can promote downstream, even though the resource content is unchanged.
+Empty commits are useful when you need to promote a resource to another environment, but the resource has no unpublished changes in the current environment.
+
+Knock tracks promotable changes by comparing each resource's identifier (`ref`) and version (`version_id`). If a resource already points to the published version (`current_version_id == published_version_id`), a standard commit does not create a new promotable change.
+
+An empty commit solves this by creating a new version with the same content, then publishing that version. This gives Knock a new `version_id` to include in promotion diffs, so you can promote the commit downstream even though the resource content has not changed.
 
 ```mermaid
 flowchart LR
@@ -49,9 +53,9 @@ flowchart LR
   publish --> promotable["New commit appears in promotion diffs"]
 ```
 
-**When the resource has unpublished changes**, the empty-clone step is skipped and a normal publish happens instead.
+When the resource has **unpublished changes**, the empty-clone step is skipped and a normal publish happens instead.
 
-**When the resource is already published with no changes**, an empty commit creates a new version with identical content.
+When the resource is **already published with no changes**, an empty commit creates a new version with identical content.
 
 Commit log entries for empty commits include audit metadata with `empty: true` and an optional message.
 
@@ -67,7 +71,7 @@ Supported resource types on the bulk commit endpoint (`PUT /v1/commits`):
 - `guide`
 - `audience`
 
-`reusable_step` is not supported on the bulk commit endpoint. To create an empty commit for a reusable step, use a resource upsert with `commit=true` and `allow_empty=true`, or publish via the dashboard.
+The bulk commit endpoint does not support `reusable_step`. To create an empty commit for a reusable step, use a resource upsert with `commit=true` and `allow_empty=true`, or publish via the dashboard.
 
 For translations, the `resource_id` can be a locale (`es`), a locale and namespace (`es/courses`), or a locale, namespace, and tenant (`es/courses~tenant`).
 

--- a/content/version-control/commits.mdx
+++ b/content/version-control/commits.mdx
@@ -38,30 +38,18 @@ A few additional notes:
 
 ## Empty commits
 
-An empty commit lets you commit (publish) a versioned resource without changing its content. This is similar to `git commit --allow-empty`.
+An empty commit lets you commit (publish) a versioned resource without changing its content, similar to `git commit --allow-empty`. Empty commits are useful when you need to promote a resource to another environment, but the resource has no unpublished changes in the current environment.
 
-Empty commits are useful when you need to promote a resource to another environment, but the resource has no unpublished changes in the current environment.
+Knock tracks promotable changes by comparing each resource's identifier (`ref`) and version (`version_id`). If a resource already points to the published version (`current_version_id == published_version_id`), a standard commit does not create a new promotable change. An empty commit solves this by creating a new version with the same content, then publishing that version, giving Knock a new `version_id` to include in promotion diffs, so you can promote the commit downstream even though the resource content has not changed.
 
-Knock tracks promotable changes by comparing each resource's identifier (`ref`) and version (`version_id`). If a resource already points to the published version (`current_version_id == published_version_id`), a standard commit does not create a new promotable change.
+What happens when you create an empty commit depends on the resource's current state:
 
-An empty commit solves this by creating a new version with the same content, then publishing that version. This gives Knock a new `version_id` to include in promotion diffs, so you can promote the commit downstream even though the resource content has not changed.
-
-```mermaid
-flowchart LR
-  published["published_version_id == current_version_id"] --> emptyClone["Clone version row"]
-  emptyClone --> publish["Publish new version_id"]
-  publish --> promotable["New commit appears in promotion diffs"]
-```
-
-When the resource has **unpublished changes**, the empty-clone step is skipped and a normal publish happens instead.
-
-When the resource is **already published with no changes**, an empty commit creates a new version with identical content.
+- **The resource has unpublished changes.** The empty-clone step is skipped, and a normal publish happens instead.
+- **The resource is already published with no changes.** An empty commit creates a new version with identical content.
 
 Commit log entries for empty commits include audit metadata with `empty: true` and an optional message.
 
-You can create empty commits using the [CLI](/cli/commit/all) or the [Management API](/developer-tools/management-api#committing-changes).
-
-Supported resource types on the bulk commit endpoint (`PUT /v1/commits`):
+You can create empty commits using the [CLI](/cli/commit/all) or the [Management API](/developer-tools/management-api#committing-changes). The bulk commit endpoint (`PUT /v1/commits`) supports the following resource types:
 
 - `workflow`
 - `email_layout`
@@ -71,9 +59,19 @@ Supported resource types on the bulk commit endpoint (`PUT /v1/commits`):
 - `guide`
 - `audience`
 
-The bulk commit endpoint does not support `reusable_step`. To create an empty commit for a reusable step, use a resource upsert with `commit=true` and `allow_empty=true`, or publish via the dashboard.
-
 For translations, the `resource_id` can be a locale (`es`), a locale and namespace (`es/courses`), or a locale, namespace, and tenant (`es/courses~tenant`).
+
+<Callout
+  title="Note:"
+  text={
+    <>
+      The bulk commit endpoint doesn't support <code>reusable_step</code>. To
+      create an empty commit for a reusable step, use a resource upsert with{" "}
+      <code>commit=true</code> and <code>allow_empty=true</code>, or publish via
+      the dashboard.
+    </>
+  }
+/>
 
 ## Visualizing commit changes
 

--- a/content/version-control/commits.mdx
+++ b/content/version-control/commits.mdx
@@ -36,6 +36,41 @@ A few additional notes:
 - **Account-level resources are not version controlled.** Channel configurations, branding, and variables do not need to be committed, as they live at the account-level. This means that if you make a change to a channel configuration, it will update immediately on notifications sent in that environment.
 - **You can commit changes using our CLI and management API.** We offer both a [Management API](/developer-tools/management-api) and a [command line interface](/developer-tools/knock-cli) for interacting with Knock resources programmatically, both of which support programmatic commits.
 
+## Empty commits
+
+An empty commit lets you commit (publish) a versioned resource without changing its content. This is similar to `git commit --allow-empty`.
+
+Promotion diffing keys off `ref` and `version_id`. When a resource is already committed (`current_version_id == published_version_id`), a normal commit is a no-op and nothing new is promotable. An empty commit clones the current version into a new version row (with a new `version_id` but identical content), then publishes that row. The result is a new commit log entry that you can promote downstream, even though the resource content is unchanged.
+
+```mermaid
+flowchart LR
+  published["published_version_id == current_version_id"] --> emptyClone["Clone version row"]
+  emptyClone --> publish["Publish new version_id"]
+  publish --> promotable["New commit appears in promotion diffs"]
+```
+
+**When the resource has unpublished changes**, the empty-clone step is skipped and a normal publish happens instead.
+
+**When the resource is already published with no changes**, an empty commit creates a new version with identical content.
+
+Commit log entries for empty commits include audit metadata with `empty: true` and an optional message.
+
+You can create empty commits using the [CLI](/cli/commit/all) or the [Management API](/developer-tools/management-api#committing-changes).
+
+Supported resource types on the bulk commit endpoint (`PUT /v1/commits`):
+
+- `workflow`
+- `email_layout`
+- `partial`
+- `translation`
+- `message_type`
+- `guide`
+- `audience`
+
+`reusable_step` is not supported on the bulk commit endpoint. To create an empty commit for a reusable step, use a resource upsert with `commit=true` and `allow_empty=true`, or publish via the dashboard.
+
+For translations, the `resource_id` can be a locale (`es`), a locale and namespace (`es/courses`), or a locale, namespace, and tenant (`es/courses~tenant`).
+
 ## Visualizing commit changes
 
 Clicking the "Commit to development" button will show you a view of changes between your current commit and the most recent version of the resource that you're updating. Commit diffs are also available on your full commit log (viewable on the "Commits" page in your dashboard), so you can view the commit history for a resource and know exactly what was changed with each commit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the new empty commit feature (`allow_empty`) across concept, CLI, and Management API pages. OpenAPI specs are intentionally left unchanged and will be updated separately.

## Changes

- **`content/version-control/commits.mdx`** — New "Empty commits" section explaining the use case, behavior, supported resource types, translation key formats, and audit metadata
- **`content/cli/commit.mdx`** — Documents `--allow-empty` flag on targeted commits, adds `audience` to resource type lists, includes examples and error cases
- **CLI push commands** (8 files) — Documents `--allow-empty` alongside `--commit` on workflow, partial, guide, message-type, email-layout, translation, audience, and bulk push commands
- **`content/developer-tools/management-api.mdx`** — New "Committing changes" use case with curl examples for `PUT /v1/commits` and resource upsert + empty commit
- **`content/tutorials/integrating-into-cicd.mdx`** — Brief empty commit example in the promotion section

## Notes

- Uses existing CLI conventions (`knock commit --resource-type --resource-id`, not the handoff's proposed `knock commits push --object-type` naming)
- MAPI auto-generated reference will pick up `allow_empty` once OpenAPI specs are updated independently

## Test plan

- [x] `yarn lint` passes
- [x] No changes under `data/specs/`
- [ ] Spot-check rendered pages at `/version-control/commits`, `/cli/commit/all`, and `/developer-tools/management-api`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6413099b-d7be-4c59-be16-3605d6076d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6413099b-d7be-4c59-be16-3605d6076d23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

