### PR TITLE
Add agent deep links documentation

### DIFF
--- a/content/developer-tools/agent-deep-links.mdx
+++ b/content/developer-tools/agent-deep-links.mdx
@@ -54,9 +54,9 @@ https://dashboard.knock.app/~/agents?q={prompt}&autoSubmit=false
 
 ## Parameters
 
-| Parameter    | Required | Default | Description |
-| ------------ | -------- | ------- | ----------- |
-| `q`          | Yes      | —       | The URL-encoded prompt to send to the agent. |
+| Parameter    | Required | Default | Description                                                               |
+| ------------ | -------- | ------- | ------------------------------------------------------------------------- |
+| `q`          | Yes      | —       | The URL-encoded prompt to send to the agent.                              |
 | `autoSubmit` | No       | `true`  | Set to `false` to pre-fill the composer instead of submitting the prompt. |
 
 ## Examples

--- a/content/developer-tools/agent-deep-links.mdx
+++ b/content/developer-tools/agent-deep-links.mdx
@@ -1,0 +1,70 @@
+---
+title: Agent deep links
+description: Kick off agents in the Knock dashboard directly from a URL.
+section: Developer tools
+---
+
+Agent deep links let you start an agent session in the Knock dashboard from a URL. Use them to kick off agents from docs, Slack messages, support replies, CLI output, or anywhere else you can share a link — the recipient lands in the dashboard with your prompt already submitted (or pre-filled) in the agent composer.
+
+## How it works
+
+The agents page accepts a prompt via the `q` query parameter:
+
+```
+https://dashboard.knock.app/{account}/agents?q={prompt}
+```
+
+When a user opens the link:
+
+1. If they aren't signed in, they're taken to the login page first and then redirected back to the deep link.
+2. By default, the prompt is auto-submitted: a new agent session is created and the user is navigated straight into it.
+3. The deep link parameters are stripped from the URL once they've been applied, so refreshing the page won't re-submit the prompt.
+
+The prompt value must be URL-encoded.
+
+## Choosing an account
+
+There are two ways to address the account in a deep link:
+
+### The `~` shorthand (recommended)
+
+Use `~` in place of an account slug and Knock will resolve the link against the user's current account:
+
+```
+https://dashboard.knock.app/~/agents?q={prompt}
+```
+
+This is the best option for links shared with a broad audience (docs, blog posts, integrations), since you usually won't know the recipient's account slug. Each user is routed into their own account.
+
+### Specifying an account
+
+If you know exactly which account the agent should run in — for example, in an internal tool or a notification scoped to one workspace — use the account slug directly:
+
+```
+https://dashboard.knock.app/acme-inc/agents?q={prompt}
+```
+
+## Pre-filling without submitting
+
+If you want the user to review or edit the prompt before it runs, add `autoSubmit=false`. The prompt is placed in the composer on the agents page, but nothing is submitted until the user hits send:
+
+```
+https://dashboard.knock.app/~/agents?q={prompt}&autoSubmit=false
+```
+
+## Parameters
+
+| Parameter    | Required | Default | Description |
+| ------------ | -------- | ------- | ----------- |
+| `q`          | Yes      | —       | The URL-encoded prompt to send to the agent. |
+| `autoSubmit` | No       | `true`  | Set to `false` to pre-fill the composer instead of submitting the prompt. |
+
+## Examples
+
+Kick off an agent that builds a workflow, resolving to the user's current account:
+
+[https://dashboard.knock.app/~/agents?q=Create%20a%20welcome%20email%20workflow%20for%20new%20signups](https://dashboard.knock.app/~/agents?q=Create%20a%20welcome%20email%20workflow%20for%20new%20signups)
+
+Pre-fill a prompt in a specific account so the user can review it before running:
+
+[https://dashboard.knock.app/acme-inc/agents?q=Audit%20my%20workflows%20for%20missing%20batch%20steps&autoSubmit=false](https://dashboard.knock.app/acme-inc/agents?q=Audit%20my%20workflows%20for%20missing%20batch%20steps&autoSubmit=false)

--- a/content/developer-tools/agent-deep-links.mdx
+++ b/content/developer-tools/agent-deep-links.mdx
@@ -26,7 +26,7 @@ The prompt value must be URL-encoded.
 
 There are two ways to address the account in a deep link:
 
-### The `~` shorthand (recommended)
+### The `~` shorthand
 
 Use `~` in place of an account slug and Knock will resolve the link against the user's current account:
 

--- a/data/sidebars/developerToolsSidebar.ts
+++ b/data/sidebars/developerToolsSidebar.ts
@@ -70,4 +70,8 @@ export const DEVELOPER_TOOLS_SIDEBAR_CONTENT: SidebarContent[] = [
     slug: `${baseSlug}/building-with-llms`,
     title: "Building with LLMs",
   },
+  {
+    slug: `${baseSlug}/agent-deep-links`,
+    title: "Agent deep links",
+  },
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR adds a new documentation page under "Developer tools" for agent deep links. The page explains how to kick off agents in the Knock dashboard directly from a URL.

The documentation covers:
- How agent deep links work
- Choosing an account (using `~` shorthand or specific account slug)
- Pre-filling prompts without auto-submitting
- Parameters (`q` and `autoSubmit`)
- Examples of deep link usage

### Screenshots

[Agent deep links documentation page](https://cursor.com/agents/bc-c76283dc-6802-4211-b3c4-963b1ca3012c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent-deep-links-page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14035](https://linear.app/knock/issue/KNO-14035/docs-agent-deep-links)

<div><a href="https://cursor.com/agents/bc-c76283dc-6802-4211-b3c4-963b1ca3012c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c76283dc-6802-4211-b3c4-963b1ca3012c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

