### PR TITLE
feat: auth examples cont

### DIFF
--- a/content/in-app-ui/flutter/sdk/quick-start.mdx
+++ b/content/in-app-ui/flutter/sdk/quick-start.mdx
@@ -35,7 +35,7 @@ That command resolves to the current 1.x line. If you are upgrading from `0.1.x`
 import 'package:knock_flutter/knock_flutter.dart';
 
 final knock = Knock(
-  const String.fromEnvironment('KNOCK_API_KEY'),
+  const String.fromEnvironment('KNOCK_PUBLIC_API_KEY'),
   // Optional: override the API host (e.g. for staging).
   // options: KnockOptions(host: 'https://api.knock.app'),
 );

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -32,6 +32,8 @@ There are three ways of setting channel data for a given recipient:
 
     If no user exists in the current environment for the given `user_id`, Knock will create the user entry as part of this request.
 
+    User channel data is a public-key endpoint. Mobile and web clients typically register it via the client SDKs. See [Security and authentication](/in-app-ui/security-and-authentication), [iOS push notifications](/in-app-ui/ios/sdk/push-notifications), [Android push notifications](/in-app-ui/android/sdk/push-notifications), and [Flutter push registration](/in-app-ui/flutter/sdk/reference#registertokenforchannel). The snippet below shows server-side registration.
+
     In the example below, we're setting a user's device token when they download our mobile app so we can send them push notifications. If this token wasn't set for the user, they wouldn't receive push notifications from our notification workflows.
 
     <MultiLangCodeBlock

--- a/content/multi-tenancy/per-tenant-preferences.mdx
+++ b/content/multi-tenancy/per-tenant-preferences.mdx
@@ -119,6 +119,39 @@ A `PreferenceSet` has an `id`. When you [set a given user's preferences](/api-re
 
 To set per-tenant preferences for a recipient, you'll use the ID of the tenant that they should be associated with as the `PreferenceSet`'s ID.
 
+<Callout
+  type="info"
+  title="Build per-tenant preference UIs in your application."
+  text={
+    <>
+      A user's own per-tenant preferences are public-key endpoints. You can read
+      and write them from your application using your public API key and a
+      signed user token, with the tenant id as the preference set id. See{" "}
+      <a href="/preferences/overview#build-your-preference-center">
+        Build your preference center
+      </a>{" "}
+      and{" "}
+      <a href="/in-app-ui/security-and-authentication">
+        Security and authentication
+      </a>{" "}
+      for details.
+    </>
+  }
+/>
+
+```javascript title="Get tenant preferences from your application"
+import Knock from "@knocklabs/client";
+
+const knockClient = new Knock(process.env.KNOCK_PUBLIC_API_KEY);
+knockClient.authenticate({ id: user.id, userToken });
+
+const preferences = await knockClient.user.getPreferences({
+  preferenceSet: "tenant-id",
+});
+```
+
+The examples below use the server-side Node SDK with a secret API key. Use them when you manage preferences from your backend.
+
 ```javascript title="Set tenant preferences for a user"
 import Knock from "@knocklabs/node";
 const knock = new Knock({ apiKey: process.env.KNOCK_API_KEY });

--- a/content/multi-tenancy/per-tenant-preferences.mdx
+++ b/content/multi-tenancy/per-tenant-preferences.mdx
@@ -143,12 +143,14 @@ To set per-tenant preferences for a recipient, you'll use the ID of the tenant t
 import Knock from "@knocklabs/client";
 
 const knockClient = new Knock(process.env.KNOCK_PUBLIC_API_KEY);
-knockClient.authenticate({ id: user.id, userToken });
+knockClient.authenticate({ id: user.id }, userToken);
 
 const preferences = await knockClient.user.getPreferences({
   preferenceSet: "tenant-id",
 });
 ```
+
+For the default preference set, use `knockClient.preferences.get()`. Per-tenant preferences live in a separate preference set, so pass the tenant id as the `preferenceSet` parameter on `knockClient.user.getPreferences()`.
 
 The examples below use the server-side Node SDK with a secret API key. Use them when you manage preferences from your backend.
 

--- a/content/preferences/preference-conditions.mdx
+++ b/content/preferences/preference-conditions.mdx
@@ -47,7 +47,7 @@ Below is an example of a workflow preference that has conditions applied to dete
 
 ## Set preference conditions for a user
 
-Here's how to set preference conditions for a user.
+Here's how to set preference conditions for a user. Setting preferences, including conditions, is a public-key endpoint, so you can also call it from your application with a public API key and signed user token. See [Security and authentication](/in-app-ui/security-and-authentication) for details.
 
 <MultiLangCodeBlock
   title="Set preferences with conditions for a user"


### PR DESCRIPTION
## Summary

Follow-up to #1526. Extends public-key auth guidance to adjacent docs that were still missing client-side context or used inconsistent env var names.

- **Per-tenant preferences.** Adds a callout and client-side get example for building per-tenant preference UIs with a public API key and signed user token. Clarifies that tenant-scoped reads use `user.getPreferences({ preferenceSet })` rather than `preferences.get()`, which returns the default set only. Server-side Node examples are labeled as backend-only.
- **Preference conditions.** Notes that setting preferences (including conditions) is a public-key endpoint callable from the application.
- **Setting channel data.** Notes that user channel data is a public-key endpoint and links to client SDK push registration docs.
- **Flutter quick start.** Renames `KNOCK_API_KEY` to `KNOCK_PUBLIC_API_KEY` to match other in-app SDK docs.