### PR TITLE
Expand MultiLangCodeBlock snippets in agent-facing markdown exports.

### DIFF
--- a/components/ui/MultiLangCodeBlock.tsx
+++ b/components/ui/MultiLangCodeBlock.tsx
@@ -6,6 +6,10 @@ import { useEffect, useMemo } from "react";
 import { useIsMounted } from "../../hooks/useIsMounted";
 import useLocalStorage from "../../hooks/useLocalStorage";
 import { useEventEmitter } from "../../lib/eventEmitter";
+import {
+  snippets,
+  SNIPPET_LANGUAGE_ORDER,
+} from "../../data/code/snippetRegistry";
 import { CodeBlock, SupportedLanguage } from "./CodeBlock";
 
 type Props = {
@@ -15,142 +19,6 @@ type Props = {
 
 export const LOCAL_STORAGE_KEY = "@knocklabs/example-lang";
 export const EVENT_NAME = "language.change";
-
-const snippets = {
-  "api.idempotency": require("../../data/code/api/idempotency").default,
-  "sdks.install": require("../../data/code/sdks/install").default,
-  // Users
-  "users.bulkIdentify": require("../../data/code/users/bulk-identify").default,
-  "users.bulkDelete": require("../../data/code/users/bulk-delete").default,
-  "users.identify": require("../../data/code/users/identify").default,
-  "users.get": require("../../data/code/users/get").default,
-  "users.delete": require("../../data/code/users/delete").default,
-  "users.merge": require("../../data/code/users/merge").default,
-  "users.messages": require("../../data/code/users/messages").default,
-  "users.setPreferences": require("../../data/code/users/set-preferences")
-    .default,
-  "users.setPreferences.conditions":
-    require("../../data/code/users/set-preferences-with-conditions").default,
-  "users.setPreferences.perTenant":
-    require("../../data/code/users/set-preferences-per-tenant").default,
-  "users.bulkSetPreferences":
-    require("../../data/code/users/bulk-set-preferences").default,
-  "users.listPreferences": require("../../data/code/users/list-preferences")
-    .default,
-  "users.getPreferences": require("../../data/code/users/get-preferences")
-    .default,
-  "users.getChannelData": require("../../data/code/users/get-channel-data")
-    .default,
-  "users.setChannelData": require("../../data/code/users/set-channel-data")
-    .default,
-  "users.setChannelDataDevices":
-    require("../../data/code/users/set-channel-data-devices").default,
-  "users.setChannelData-push":
-    require("../../data/code/users/set-channel-data-push").default,
-  "users.setChannelData-one-signal":
-    require("../../data/code/users/set-channel-data-one-signal").default,
-  "users.setChannelData-aws-sns":
-    require("../../data/code/users/set-channel-data-aws-sns").default,
-  "users.unsetChannelData": require("../../data/code/users/unset-channel-data")
-    .default,
-  "users.identifyChannelData":
-    require("../../data/code/users/identify-channel-data").default,
-
-  // Messages
-  "messages.list": require("../../data/code/messages/list").default,
-  "messages.get": require("../../data/code/messages/get").default,
-  "messages.getActivities": require("../../data/code/messages/get-activities")
-    .default,
-  "messages.getContent": require("../../data/code/messages/get-content")
-    .default,
-  "messages.getEvents": require("../../data/code/messages/get-events").default,
-
-  // Objects
-  "objects.list": require("../../data/code/objects/list").default,
-  "objects.set": require("../../data/code/objects/set").default,
-  "objects.get": require("../../data/code/objects/get").default,
-  "objects.delete": require("../../data/code/objects/delete").default,
-  "objects.bulkSet": require("../../data/code/objects/bulk-set").default,
-  "objects.bulkDelete": require("../../data/code/objects/bulk-delete").default,
-  "objects.messages": require("../../data/code/objects/messages").default,
-  "objects.setChannelData.slack":
-    require("../../data/code/objects/set-channel-data-slack").default,
-  "objects.setChannelData.msTeams":
-    require("../../data/code/objects/set-channel-data-ms-teams").default,
-  "objects.setChannelData.discord.webhook":
-    require("../../data/code/objects/set-channel-data-discord-webhook").default,
-  "objects.setChannelData.discord.bot":
-    require("../../data/code/objects/set-channel-data-discord-bot").default,
-  "objects.unsetChannelData":
-    require("../../data/code/objects/unset-channel-data").default,
-  "objects.getChannelData": require("../../data/code/objects/get-channel-data")
-    .default,
-  "objects.listPreferences": require("../../data/code/objects/list-preferences")
-    .default,
-  "objects.getPreferences": require("../../data/code/objects/get-preferences")
-    .default,
-  "objects.setPreferences": require("../../data/code/objects/set-preferences")
-    .default,
-
-  // Tenants
-  "tenants.list": require("../../data/code/tenants/list").default,
-  "tenants.get": require("../../data/code/tenants/get").default,
-  "tenants.set": require("../../data/code/tenants/set").default,
-  "tenants.delete": require("../../data/code/tenants/delete").default,
-
-  // Workflows
-  "workflows.cancel": require("../../data/code/workflows/cancel").default,
-  "workflows.cancel-with-recipients":
-    require("../../data/code/workflows/cancel-with-recipients").default,
-  "workflows.trigger": require("../../data/code/workflows/trigger").default,
-  "workflows.trigger-with-identification":
-    require("../../data/code/workflows/trigger-with-identification").default,
-  "workflows.trigger-with-user-identification":
-    require("../../data/code/workflows/trigger-with-user-identification")
-      .default,
-  "workflows.trigger-with-object-identification":
-    require("../../data/code/workflows/trigger-with-object-identification")
-      .default,
-  "workflows.trigger-with-actor":
-    require("../../data/code/workflows/trigger-with-actor").default,
-  "workflows.trigger-with-object-as-recipient":
-    require("../../data/code/workflows/trigger-with-object-as-recipient")
-      .default,
-  "workflows.trigger-with-object-as-actor":
-    require("../../data/code/workflows/trigger-with-object-as-actor").default,
-  "workflows.trigger-with-tenant":
-    require("../../data/code/workflows/trigger-with-tenant").default,
-  "workflows.trigger-with-branding-tenant":
-    require("../../data/code/workflows/trigger-with-branding-tenant").default,
-  "workflows.trigger-with-attachment":
-    require("../../data/code/workflows/trigger-with-attachment").default,
-  "workflows.trigger-with-user-channel-data":
-    require("../../data/code/workflows/trigger-with-user-channel-data").default,
-  "workflows.trigger-with-user-preferences":
-    require("../../data/code/workflows/trigger-with-user-preferences").default,
-  "workflows.playground": require("../../data/code/workflows/playground")
-    .default,
-};
-/* eslint-enable */
-
-const DEFAULT_ORDER: SupportedLanguage[] = [
-  "curl",
-  "shell",
-  "node",
-  "javascript",
-  "jsweb",
-  "ruby",
-  "python",
-  "php",
-  "go",
-  "java",
-  "csharp",
-  "elixir",
-  "swift",
-  "kotlin",
-  "json",
-  "yaml",
-];
 
 const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet, ...props }) => {
   const isMounted = useIsMounted();
@@ -174,7 +42,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet, ...props }) => {
   // Set the list of languages in the switcher according to the languages in the snippet and ordered by the DEFAULT_ORDER
   const languages = useMemo(() => {
     const snippetCode = snippets[snippet];
-    return DEFAULT_ORDER.filter((key) => key in snippetCode);
+    return SNIPPET_LANGUAGE_ORDER.filter((key) => key in snippetCode);
   }, [snippet]);
 
   const content = useMemo(() => {

--- a/data/code/snippetRegistry.ts
+++ b/data/code/snippetRegistry.ts
@@ -1,0 +1,155 @@
+import type { SupportedLanguage } from "../../components/ui/CodeBlock";
+
+type SnippetLanguages = Partial<Record<SupportedLanguage, string>>;
+
+const snippets: Record<string, SnippetLanguages> = {
+  "api.idempotency": require("./api/idempotency").default,
+  "sdks.install": require("./sdks/install").default,
+  "users.bulkIdentify": require("./users/bulk-identify").default,
+  "users.bulkDelete": require("./users/bulk-delete").default,
+  "users.identify": require("./users/identify").default,
+  "users.get": require("./users/get").default,
+  "users.delete": require("./users/delete").default,
+  "users.merge": require("./users/merge").default,
+  "users.messages": require("./users/messages").default,
+  "users.setPreferences": require("./users/set-preferences").default,
+  "users.setPreferences.conditions":
+    require("./users/set-preferences-with-conditions").default,
+  "users.setPreferences.perTenant":
+    require("./users/set-preferences-per-tenant").default,
+  "users.bulkSetPreferences": require("./users/bulk-set-preferences").default,
+  "users.listPreferences": require("./users/list-preferences").default,
+  "users.getPreferences": require("./users/get-preferences").default,
+  "users.getChannelData": require("./users/get-channel-data").default,
+  "users.setChannelData": require("./users/set-channel-data").default,
+  "users.setChannelDataDevices":
+    require("./users/set-channel-data-devices").default,
+  "users.setChannelData-push": require("./users/set-channel-data-push").default,
+  "users.setChannelData-one-signal":
+    require("./users/set-channel-data-one-signal").default,
+  "users.setChannelData-aws-sns":
+    require("./users/set-channel-data-aws-sns").default,
+  "users.unsetChannelData": require("./users/unset-channel-data").default,
+  "users.identifyChannelData": require("./users/identify-channel-data").default,
+  "messages.list": require("./messages/list").default,
+  "messages.get": require("./messages/get").default,
+  "messages.getActivities": require("./messages/get-activities").default,
+  "messages.getContent": require("./messages/get-content").default,
+  "messages.getEvents": require("./messages/get-events").default,
+  "objects.list": require("./objects/list").default,
+  "objects.set": require("./objects/set").default,
+  "objects.get": require("./objects/get").default,
+  "objects.delete": require("./objects/delete").default,
+  "objects.bulkSet": require("./objects/bulk-set").default,
+  "objects.bulkDelete": require("./objects/bulk-delete").default,
+  "objects.messages": require("./objects/messages").default,
+  "objects.setChannelData.slack":
+    require("./objects/set-channel-data-slack").default,
+  "objects.setChannelData.msTeams":
+    require("./objects/set-channel-data-ms-teams").default,
+  "objects.setChannelData.discord.webhook":
+    require("./objects/set-channel-data-discord-webhook").default,
+  "objects.setChannelData.discord.bot":
+    require("./objects/set-channel-data-discord-bot").default,
+  "objects.unsetChannelData": require("./objects/unset-channel-data").default,
+  "objects.getChannelData": require("./objects/get-channel-data").default,
+  "objects.listPreferences": require("./objects/list-preferences").default,
+  "objects.getPreferences": require("./objects/get-preferences").default,
+  "objects.setPreferences": require("./objects/set-preferences").default,
+  "tenants.list": require("./tenants/list").default,
+  "tenants.get": require("./tenants/get").default,
+  "tenants.set": require("./tenants/set").default,
+  "tenants.delete": require("./tenants/delete").default,
+  "workflows.cancel": require("./workflows/cancel").default,
+  "workflows.cancel-with-recipients":
+    require("./workflows/cancel-with-recipients").default,
+  "workflows.trigger": require("./workflows/trigger").default,
+  "workflows.trigger-with-identification":
+    require("./workflows/trigger-with-identification").default,
+  "workflows.trigger-with-user-identification":
+    require("./workflows/trigger-with-user-identification").default,
+  "workflows.trigger-with-object-identification":
+    require("./workflows/trigger-with-object-identification").default,
+  "workflows.trigger-with-actor":
+    require("./workflows/trigger-with-actor").default,
+  "workflows.trigger-with-object-as-recipient":
+    require("./workflows/trigger-with-object-as-recipient").default,
+  "workflows.trigger-with-object-as-actor":
+    require("./workflows/trigger-with-object-as-actor").default,
+  "workflows.trigger-with-tenant":
+    require("./workflows/trigger-with-tenant").default,
+  "workflows.trigger-with-branding-tenant":
+    require("./workflows/trigger-with-branding-tenant").default,
+  "workflows.trigger-with-attachment":
+    require("./workflows/trigger-with-attachment").default,
+  "workflows.trigger-with-user-channel-data":
+    require("./workflows/trigger-with-user-channel-data").default,
+  "workflows.trigger-with-user-preferences":
+    require("./workflows/trigger-with-user-preferences").default,
+  "workflows.playground": require("./workflows/playground").default,
+};
+
+const SNIPPET_LANGUAGE_ORDER: SupportedLanguage[] = [
+  "curl",
+  "shell",
+  "node",
+  "javascript",
+  "jsweb",
+  "ruby",
+  "python",
+  "php",
+  "go",
+  "java",
+  "csharp",
+  "elixir",
+  "swift",
+  "kotlin",
+  "json",
+  "yaml",
+];
+
+const SNIPPET_LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
+  curl: "cURL",
+  shell: "Shell",
+  node: "Node.js",
+  javascript: "JavaScript",
+  jsweb: "JavaScript (browser)",
+  ruby: "Ruby",
+  python: "Python",
+  php: "PHP",
+  go: "Go",
+  java: "Java",
+  csharp: "C#",
+  elixir: "Elixir",
+  swift: "Swift",
+  kotlin: "Kotlin",
+  json: "JSON",
+  yaml: "YAML",
+};
+
+const SNIPPET_FENCE_LANGUAGES: Record<SupportedLanguage, string> = {
+  curl: "bash",
+  shell: "bash",
+  node: "javascript",
+  javascript: "javascript",
+  jsweb: "javascript",
+  ruby: "ruby",
+  python: "python",
+  php: "php",
+  go: "go",
+  java: "java",
+  csharp: "csharp",
+  elixir: "elixir",
+  swift: "swift",
+  kotlin: "kotlin",
+  json: "json",
+  yaml: "yaml",
+};
+
+export {
+  snippets,
+  SNIPPET_FENCE_LANGUAGES,
+  SNIPPET_LANGUAGE_LABELS,
+  SNIPPET_LANGUAGE_ORDER,
+};
+export type { SnippetLanguages };

--- a/lib/expandMultiLangCodeBlocks.ts
+++ b/lib/expandMultiLangCodeBlocks.ts
@@ -1,0 +1,61 @@
+import {
+  snippets,
+  SNIPPET_FENCE_LANGUAGES,
+  SNIPPET_LANGUAGE_LABELS,
+  SNIPPET_LANGUAGE_ORDER,
+} from "../data/code/snippetRegistry";
+
+const MULTI_LANG_CODE_BLOCK_REGEX =
+  /<MultiLangCodeBlock\b([^>]*)\/>/g;
+
+function parseMultiLangCodeBlockAttributes(attributes: string): {
+  snippet?: string;
+  title?: string;
+} {
+  const snippetMatch = attributes.match(/\bsnippet="([^"]+)"/);
+  const titleMatch = attributes.match(/\btitle="([^"]*)"/);
+
+  return {
+    snippet: snippetMatch?.[1],
+    title: titleMatch?.[1],
+  };
+}
+
+function renderSnippetMarkdown(snippetKey: string, title?: string): string {
+  const snippetCode = snippets[snippetKey];
+
+  if (!snippetCode) {
+    return `<!-- Unknown MultiLangCodeBlock snippet: ${snippetKey} -->`;
+  }
+
+  const languages = SNIPPET_LANGUAGE_ORDER.filter((key) => key in snippetCode);
+  const sections: string[] = [];
+
+  if (title) {
+    sections.push(`#### ${title}\n`);
+  }
+
+  for (const language of languages) {
+    const code = snippetCode[language]?.trim() ?? "";
+    const label = SNIPPET_LANGUAGE_LABELS[language];
+    const fenceLanguage = SNIPPET_FENCE_LANGUAGES[language];
+
+    sections.push(`**${label}**\n\n\`\`\`${fenceLanguage}\n${code}\n\`\`\`\n`);
+  }
+
+  return sections.join("\n");
+}
+
+function expandMultiLangCodeBlocks(content: string): string {
+  return content.replace(MULTI_LANG_CODE_BLOCK_REGEX, (_, attributes) => {
+    const { snippet, title } = parseMultiLangCodeBlockAttributes(attributes);
+
+    if (!snippet) {
+      return "<!-- MultiLangCodeBlock missing snippet attribute -->";
+    }
+
+    return renderSnippetMarkdown(snippet, title);
+  });
+}
+
+export { expandMultiLangCodeBlocks, renderSnippetMarkdown };

--- a/scripts/generateLlmsTxt.ts
+++ b/scripts/generateLlmsTxt.ts
@@ -24,6 +24,7 @@ import {
 } from "../data/sidebars/inAppSidebar";
 import { getSidebarContent } from "../components/ui/ApiReference/helpers";
 
+import { expandMultiLangCodeBlocks } from "../lib/expandMultiLangCodeBlocks";
 import { readOpenApiSpec, readStainlessSpec } from "../lib/openApiSpec";
 import {
   MAPI_REFERENCE_OVERVIEW_CONTENT,
@@ -84,6 +85,10 @@ async function parseFrontmatter(markdownContent) {
   return yaml.parse(yamlNode.value);
 }
 
+function prepareMarkdownForExport(content: string): string {
+  return expandMultiLangCodeBlocks(content);
+}
+
 async function writePublicMarkdown(slug, content) {
   try {
     const publicPath = path.join(
@@ -93,7 +98,11 @@ async function writePublicMarkdown(slug, content) {
     );
     // Create directories if they don't exist
     fs.mkdirSync(path.dirname(publicPath), { recursive: true });
-    fs.writeFileSync(publicPath, content, "utf-8");
+    fs.writeFileSync(
+      publicPath,
+      prepareMarkdownForExport(content),
+      "utf-8",
+    );
   } catch (error) {
     console.warn(`Warning: Could not write public markdown for ${slug}`, error);
   }
@@ -179,7 +188,8 @@ async function processPages(
     fullContent.push(`## ${page.title}${betaTag}`);
     if (description) fullContent.push(description);
     if (pageContent) {
-      fullContent.push(pageContent);
+      const exportContent = prepareMarkdownForExport(pageContent);
+      fullContent.push(exportContent);
       // Write to public directory if we have content
       await writePublicMarkdown(fullHref, pageContent);
     }
@@ -232,7 +242,7 @@ async function processFlatContentItem(
   fullContent.push(`# ${section.title}${betaTag}`);
   if (description) fullContent.push(description);
   if (pageContent) {
-    fullContent.push(pageContent);
+    fullContent.push(prepareMarkdownForExport(pageContent));
     // Write to public directory so .md URLs work
     await writePublicMarkdown(fullHref, pageContent);
   }


### PR DESCRIPTION
Static .md files and llms-full.txt now render code examples from the shared snippet registry instead of leaving raw MDX component tags for agents to parse.