### PR TITLE
Extend sitemap to include API and Management API reference routes.

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,20 +6,25 @@ import {
   DOCS_FILE_EXTENSIONS,
 } from "../lib/content.server";
 import { BASE_URL } from "../lib/constants";
+import { getAllApiReferenceSitemapEntries } from "../lib/sitemapEntries";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const filePaths = getAllFilesInDir(CONTENT_DIR, [], DOCS_FILE_EXTENSIONS);
 
-  const pages = filePaths.map((path) => {
-    const slug = path.replace(CONTENT_DIR, "").replace(/\.mdx?$/, "");
+  const pages = filePaths
+    .filter((path) => !path.includes("/__"))
+    .map((path) => {
+      const slug = path.replace(CONTENT_DIR, "").replace(/\.mdx?$/, "");
 
-    return {
-      url: `${BASE_URL}/${slug}`,
-      lastModified: new Date(),
-      priority: 1,
-      changeFrequency: "daily",
-    };
-  });
+      return {
+        url: `${BASE_URL}/${slug}`,
+        lastModified: new Date(),
+        priority: 1,
+        changeFrequency: "daily" as const,
+      };
+    });
+
+  const apiReferencePages = await getAllApiReferenceSitemapEntries();
 
   return [
     {
@@ -28,5 +33,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
       changeFrequency: "daily",
     },
-  ].concat(pages) as MetadataRoute.Sitemap;
+    ...pages,
+    ...apiReferencePages,
+  ];
 }

--- a/lib/sitemapEntries.ts
+++ b/lib/sitemapEntries.ts
@@ -1,0 +1,92 @@
+import { MetadataRoute } from "next";
+
+import {
+  API_REFERENCE_OVERVIEW_CONTENT,
+} from "@/data/sidebars/apiOverviewSidebar";
+import {
+  MAPI_REFERENCE_OVERVIEW_CONTENT,
+} from "@/data/sidebars/mapiOverviewSidebar";
+import { BASE_URL } from "./constants";
+import {
+  ApiReferencePath,
+  getAllApiReferencePaths,
+  SpecName,
+} from "./openApiSpec";
+
+type SitemapEntry = MetadataRoute.Sitemap[number];
+
+function createSitemapEntry(path: string): SitemapEntry {
+  return {
+    url: `${BASE_URL}${path}`,
+    lastModified: new Date(),
+    priority: 1,
+    changeFrequency: "daily",
+  };
+}
+
+function apiReferencePathToUrl(
+  basePath: string,
+  apiPath: ApiReferencePath,
+): string {
+  const { resource, slug } = apiPath.params;
+
+  if (!slug || slug.length === 0) {
+    return `${basePath}/${resource}`;
+  }
+
+  return `${basePath}/${resource}/${slug.join("/")}`;
+}
+
+function getOverviewPaths(
+  basePath: string,
+  overviewPages: { slug: string }[],
+): string[] {
+  const paths = new Set<string>([basePath, `${basePath}/overview`]);
+
+  for (const page of overviewPages) {
+    if (page.slug === "/") {
+      continue;
+    }
+
+    paths.add(`${basePath}/overview${page.slug}`);
+  }
+
+  return Array.from(paths);
+}
+
+async function getApiReferenceSitemapEntries(
+  specName: SpecName,
+): Promise<SitemapEntry[]> {
+  const basePath = specName === "api" ? "/api-reference" : "/mapi-reference";
+  const overviewContent =
+    specName === "api"
+      ? API_REFERENCE_OVERVIEW_CONTENT
+      : MAPI_REFERENCE_OVERVIEW_CONTENT;
+  const overviewPages = overviewContent[0]?.pages ?? [];
+  const paths = new Set<string>(getOverviewPaths(basePath, overviewPages));
+  const apiPaths = await getAllApiReferencePaths(specName);
+
+  for (const apiPath of apiPaths) {
+    paths.add(apiReferencePathToUrl(basePath, apiPath));
+  }
+
+  return Array.from(paths)
+    .sort()
+    .map(createSitemapEntry);
+}
+
+async function getAllApiReferenceSitemapEntries(): Promise<SitemapEntry[]> {
+  const [apiEntries, mapiEntries] = await Promise.all([
+    getApiReferenceSitemapEntries("api"),
+    getApiReferenceSitemapEntries("mapi"),
+  ]);
+
+  return [...apiEntries, ...mapiEntries];
+}
+
+export {
+  apiReferencePathToUrl,
+  createSitemapEntry,
+  getAllApiReferenceSitemapEntries,
+  getApiReferenceSitemapEntries,
+};


### PR DESCRIPTION
Generate sitemap entries from the same path data used for static API reference pages, and exclude internal __content source files from content-based entries.