### PR TITLE
chore(kno-14108): Update MCP server docs to match shipped consent UI capabilities

### DIFF
--- a/content/ai/mcp-server.mdx
+++ b/content/ai/mcp-server.mdx
@@ -71,14 +71,14 @@ claude mcp add --transport http knock https://mcp.knock.app/mcp
 
 When connecting to the Knock MCP server, you can choose exactly which capabilities to enable. The MCP server exposes a curated subset of Knock functionality — focused on reading and managing resources, running the Knock agent, inspecting environments, and searching documentation. Limiting the active capabilities to only what you need keeps the tool list manageable and reduces the risk of unintended changes.
 
-| Capability             | Description                                                                                           | Enabled by default |
-| ---------------------- | ----------------------------------------------------------------------------------------------------- | ------------------ |
-| **Read resources**     | Inspect Knock configuration via the Management API (GET requests)                                     | Yes                |
-| **Manage resources**   | Create and update Knock configuration via the Management API (write requests)                         | Yes                |
-| **Knock agent**        | Use the Knock agent to create and manage workflows, broadcasts, guides, and other resources           | Yes                |
-| **Debug**              | Inspect environments and view sent message logs                                                       | No                 |
-| **Manage data**        | Manage users, tenants, and object data                                                                | No                 |
-| **Documentation**      | Search Knock documentation                                                                            | No                 |
+| Capability           | Description                                                                                 | Enabled by default |
+| -------------------- | ------------------------------------------------------------------------------------------- | ------------------ |
+| **Read resources**   | Inspect Knock configuration via the Management API (GET requests)                           | Yes                |
+| **Manage resources** | Create and update Knock configuration via the Management API (write requests)               | Yes                |
+| **Knock agent**      | Use the Knock agent to create and manage workflows, broadcasts, guides, and other resources | Yes                |
+| **Debug**            | Inspect environments and view sent message logs                                             | No                 |
+| **Manage data**      | Manage users, tenants, and object data                                                      | No                 |
+| **Documentation**    | Search Knock documentation                                                                  | No                 |
 
 ### Knock agent capability
 

--- a/content/ai/mcp-server.mdx
+++ b/content/ai/mcp-server.mdx
@@ -67,17 +67,24 @@ claude mcp add --transport http knock https://mcp.knock.app/mcp
 
 2. Start Claude Code and run `/mcp` to authenticate with your Knock account.
 
-## Tool groups
+## Capabilities
 
-When connecting to the Knock MCP server, you can choose exactly which groups of tools to enable. The MCP server exposes a curated subset of Knock capabilities — focused on managing resources and data, inspecting environments, and committing or promoting changes. Limiting the active tool groups to only what you need keeps the tool list manageable and reduces the risk of unintended changes.
+When connecting to the Knock MCP server, you can choose exactly which capabilities to enable. The MCP server exposes a curated subset of Knock functionality — focused on reading and managing resources, running the Knock agent, inspecting environments, and searching documentation. Limiting the active capabilities to only what you need keeps the tool list manageable and reduces the risk of unintended changes.
 
-| Group                | Description                                                                                                     |
-| -------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Manage resources** | Create and manage notification workflows, channels, templates, email layouts, partials, and other configuration |
-| **Commits**          | Commit and promote changes across environments                                                                  |
-| **Debug**            | Inspect environments and view sent message logs                                                                 |
-| **Manage data**      | Manage users, tenants, and object data                                                                          |
-| **Documentation**    | Search Knock documentation                                                                                      |
+| Capability             | Description                                                                                           | Enabled by default |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- | ------------------ |
+| **Read resources**     | Inspect Knock configuration via the Management API (GET requests)                                     | Yes                |
+| **Manage resources**   | Create and update Knock configuration via the Management API (write requests)                         | Yes                |
+| **Knock agent**        | Use the Knock agent to create and manage workflows, broadcasts, guides, and other resources           | Yes                |
+| **Debug**              | Inspect environments and view sent message logs                                                       | No                 |
+| **Manage data**        | Manage users, tenants, and object data                                                                | No                 |
+| **Documentation**      | Search Knock documentation                                                                            | No                 |
+
+### Knock agent capability
+
+The **Knock agent** capability enables tools that invoke the same [Knock agent](/ai/agent) available in the dashboard. When enabled, your MCP client can start agent sessions to create and manage workflows, broadcasts, guides, and other resources through a conversational interface.
+
+This capability is useful when you want the agent to handle complex, multi-step tasks that benefit from its built-in knowledge of Knock best practices and resource relationships. For simpler, direct operations, the **Read resources** and **Manage resources** capabilities provide lower-level access through the Management API.
 
 If you need capabilities the MCP server doesn't expose — such as local file scaffolding for new resources, validating them before push, or working entirely offline against a checked-in repo — reach for the [Knock CLI](/ai/cli) instead.
 
@@ -132,9 +139,9 @@ See the [skills page](/ai/skills) for the full catalog of available skills and w
 <AccordionGroup>
   <Accordion title="Why do I see a warning about having too many tools?">
     Some MCP clients will warn you about having more than 50 tools. To address
-    this, enable only the tool groups you need for the task at hand. For
-    example, if you're only managing user data, enable the **Manage data** group
-    and leave the others disabled.
+    this, enable only the capabilities you need for the task at hand. For
+    example, if you're only managing user data, enable the **Manage data**
+    capability and leave the others disabled.
   </Accordion>
   <Accordion title="Why do I receive an error in Cursor when I try to use one of the available MCP tools?">
     If you see an error like _"The model returned an error. Try disabling MCP


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

This PR updates the "Tool groups" section of the MCP server documentation (`content/ai/mcp-server.mdx`) to match the shipped OAuth consent UI that users see when granting MCP consent.

**Changes:**
- Renamed the "Tool groups" section to "Capabilities" to match the shipped consent UI terminology
- Updated the table with the 6 current capabilities:
  - **Read resources** (enabled by default) - Inspect Knock configuration via the Management API (GET requests)
  - **Manage resources** (enabled by default) - Create and update Knock configuration via the Management API (write requests)
  - **Knock agent** (enabled by default) - Use the Knock agent to create and manage workflows, broadcasts, guides, and other resources
  - **Debug** (not enabled by default) - Inspect environments and view sent message logs
  - **Manage data** (not enabled by default) - Manage users, tenants, and object data
  - **Documentation** (not enabled by default) - Search Knock documentation
- Added "Enabled by default" column showing which capabilities are enabled by default
- Added "Knock agent capability" subsection explaining what the capability does and linking to `/ai/agent`
- Updated FAQ to use "capabilities" terminology instead of "tool groups"

**Why:**
The existing documentation was outdated and contradicted the MCP server's shipped OAuth consent screen. The legacy `manage-resources` and `commits` groups in the docs have been superseded by the new Management API code mode and Knock agent tools.

### Screenshots

**Capabilities table with all 6 capabilities and default states:**

[Capabilities table showing all 6 capabilities](https://cursor.com/agents/bc-c6e35f00-e2eb-44a1-b8f1-c13b16c35f2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_capabilities_table.webp)

**FAQ section:**

[Frequently asked questions section](https://cursor.com/agents/bc-c6e35f00-e2eb-44a1-b8f1-c13b16c35f2d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmcp_server_faq_section.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14108](https://linear.app/knock/issue/KNO-14108/docs-update-mcp-server-tool-groups-documentation-to-match-shipped)

<div><a href="https://cursor.com/agents/bc-c6e35f00-e2eb-44a1-b8f1-c13b16c35f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6e35f00-e2eb-44a1-b8f1-c13b16c35f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

