### PR TITLE
docs(KNO-14128): document KnockProvider enabled prop and useKnockAuthState

### DIFF
--- a/content/in-app-ui/expo/sdk/reference.mdx
+++ b/content/in-app-ui/expo/sdk/reference.mdx
@@ -56,7 +56,7 @@ Accepts `KnockProviderProps`
 
 `KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
 
-This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 
 ```jsx
 <KnockProvider
@@ -262,7 +262,7 @@ Subscribes to a `Knock` client's authentication state, re-rendering when the use
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is currently signed in to the client."
+    description="Whether a user is signed in to the client."
   />
   <Attribute
     name="userId"

--- a/content/in-app-ui/expo/sdk/reference.mdx
+++ b/content/in-app-ui/expo/sdk/reference.mdx
@@ -69,7 +69,7 @@ This is the recommended way to gate the provider on a complete identity — for 
 </KnockProvider>
 ```
 
-Auto push-notification registration also waits for `enabled` to become `true`, so a logged-out user isn't shown the OS permission prompt until sign-in completes (the prompt is deferred, not skipped). When `enabled` becomes `true`, feed components remount and reload their data. To react to these transitions in your own components, use the [`useKnockAuthState`](#useknockauthstate) hook.
+Auto push-notification registration also waits for `enabled` to become `true`, so a user isn't shown the OS permission prompt until client authentication completes. When `enabled` becomes `true`, feed components remount and reload their data. To react to these transitions in your own components, use the [`useKnockAuthState`](#useknockauthstate) hook.
 
 ### `KnockFeedProvider`
 
@@ -124,7 +124,7 @@ Accepts `KnockExpoPushNotificationProviderProps`:
   <Attribute
     name="autoRegister"
     type="boolean"
-    description="When true, the Expo provider retrieves a push token from Expo and stores it as channel data on the user. Registration waits until the client is authenticated, so a logged-out user isn't shown the OS permission prompt until sign-in completes."
+    description="When true, the Expo provider retrieves a push token from Expo and stores it as channel data on the user. Registration waits until the client is authenticated, so a user isn't shown the OS permission prompt until sign-in completes."
   />
 </Attributes>
 
@@ -262,17 +262,17 @@ Subscribes to a `Knock` client's authentication state, re-rendering when the use
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is signed in to the client."
+    description="Whether a user is authenticated to the client."
   />
   <Attribute
     name="userId"
     type="string | undefined | null"
-    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+    description="The ID of the authenticated user, or `undefined` when no user is authenticated."
   />
   <Attribute
     name="userToken"
     type="string | undefined"
-    description="The user token in use for the signed-in user, when one was provided."
+    description="The user token in use for the authenticated user, when one was provided."
   />
 </Attributes>
 

--- a/content/in-app-ui/expo/sdk/reference.mdx
+++ b/content/in-app-ui/expo/sdk/reference.mdx
@@ -36,6 +36,11 @@ Accepts `KnockProviderProps`
     description="A JWT that identifies the authenticated user, signed with the private key provided in the Knock dashboard. Required to secure your production environment. [Learn more.](https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security)"
   />
   <Attribute
+    name="enabled"
+    type="boolean"
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+  />
+  <Attribute
     name="host"
     type="string"
     description="A custom API host for Knock."
@@ -46,6 +51,25 @@ Accepts `KnockProviderProps`
     description="An optional set of translations to override the default `en` translations used in the feed components."
   />
 </Attributes>
+
+#### Deferring activity with `enabled`
+
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+
+```jsx
+<KnockProvider
+  apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+  user={{ id: userId }}
+  userToken={userToken}
+  enabled={Boolean(userId && userToken)}
+>
+  {/* ... */}
+</KnockProvider>
+```
+
+Auto push-notification registration also waits for `enabled` to become `true`, so a logged-out user isn't shown the OS permission prompt until sign-in completes (the prompt is deferred, not skipped). When `enabled` becomes `true`, feed components remount and reload their data. To react to these transitions in your own components, use the [`useKnockAuthState`](#useknockauthstate) hook.
 
 ### `KnockFeedProvider`
 
@@ -100,7 +124,7 @@ Accepts `KnockExpoPushNotificationProviderProps`:
   <Attribute
     name="autoRegister"
     type="boolean"
-    description="When true, the Expo provider automatically retrieves a push token from Expo and stores it as channel data on the user."
+    description="When true, the Expo provider retrieves a push token from Expo and stores it as channel data on the user. Registration waits until the client is authenticated, so a logged-out user isn't shown the OS permission prompt until sign-in completes."
   />
 </Attributes>
 
@@ -223,6 +247,43 @@ const MyComponent = () => {
     { id: user.id },
     user.knockToken,
   );
+
+  return null;
+};
+```
+
+### `useKnockAuthState`
+
+Subscribes to a `Knock` client's authentication state, re-rendering when the user signs in, signs out, or switches. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
+
+**Returns**: `KnockAuthState`
+
+<Attributes>
+  <Attribute
+    name="status"
+    type="'authenticated' | 'unauthenticated'"
+    description="Whether a user is currently signed in to the client."
+  />
+  <Attribute
+    name="userId"
+    type="string | undefined | null"
+    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+  />
+  <Attribute
+    name="userToken"
+    type="string | undefined"
+    description="The user token in use for the signed-in user, when one was provided."
+  />
+</Attributes>
+
+**Example**:
+
+```jsx
+import { useKnock, useKnockAuthState } from "@knocklabs/expo";
+
+const MyComponent = () => {
+  const knock = useKnock();
+  const { status, userId } = useKnockAuthState(knock);
 
   return null;
 };

--- a/content/in-app-ui/expo/sdk/reference.mdx
+++ b/content/in-app-ui/expo/sdk/reference.mdx
@@ -38,7 +38,7 @@ Accepts `KnockProviderProps`
   <Attribute
     name="enabled"
     type="boolean"
-    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` authenticates and connects the client; flipping it back to `false` disconnects it and clears its data. Use it to defer activity until you have a complete identity (see below)."
   />
   <Attribute
     name="host"
@@ -54,7 +54,7 @@ Accepts `KnockProviderProps`
 
 #### Deferring activity with `enabled`
 
-`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client authenticates and connects; set it to `false` again and it disconnects and clears its data.
 
 This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 
@@ -124,7 +124,7 @@ Accepts `KnockExpoPushNotificationProviderProps`:
   <Attribute
     name="autoRegister"
     type="boolean"
-    description="When true, the Expo provider retrieves a push token from Expo and stores it as channel data on the user. Registration waits until the client is authenticated, so a user isn't shown the OS permission prompt until sign-in completes."
+    description="When true, the Expo provider retrieves a push token from Expo and stores it as channel data on the user. Registration waits until the client is authenticated, so a user isn't shown the OS permission prompt until client authentication completes."
   />
 </Attributes>
 
@@ -254,7 +254,7 @@ const MyComponent = () => {
 
 ### `useKnockAuthState`
 
-Subscribes to a `Knock` client's authentication state, re-rendering when the user signs in, signs out, or switches. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
+Subscribes to a `Knock` client's authentication state, re-rendering when the authenticated user changes. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
 
 **Returns**: `KnockAuthState`
 

--- a/content/in-app-ui/react-native/sdk/reference.mdx
+++ b/content/in-app-ui/react-native/sdk/reference.mdx
@@ -56,7 +56,7 @@ Accepts `KnockProviderProps`
 
 `KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
 
-This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 
 ```jsx
 <KnockProvider
@@ -244,7 +244,7 @@ Subscribes to a `Knock` client's authentication state, re-rendering when the use
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is currently signed in to the client."
+    description="Whether a user is signed in to the client."
   />
   <Attribute
     name="userId"

--- a/content/in-app-ui/react-native/sdk/reference.mdx
+++ b/content/in-app-ui/react-native/sdk/reference.mdx
@@ -36,6 +36,11 @@ Accepts `KnockProviderProps`
     description="A JWT that identifies the authenticated user, signed with the private key provided in the Knock dashboard. Required to secure your production environment. [Learn more.](https://docs.knock.app/in-app-ui/security-and-authentication#authentication-with-enhanced-security)"
   />
   <Attribute
+    name="enabled"
+    type="boolean"
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+  />
+  <Attribute
     name="host"
     type="string"
     description="A custom API host for Knock."
@@ -46,6 +51,25 @@ Accepts `KnockProviderProps`
     description="An optional set of translations to override the default `en` translations used in the feed components."
   />
 </Attributes>
+
+#### Deferring activity with `enabled`
+
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+
+```jsx
+<KnockProvider
+  apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+  user={{ id: userId }}
+  userToken={userToken}
+  enabled={Boolean(userId && userToken)}
+>
+  {/* ... */}
+</KnockProvider>
+```
+
+When `enabled` becomes `true`, feed components remount and reload their data, and Slack and Microsoft Teams connection status re-checks for the authenticated user. To react to these transitions in your own components, use the [`useKnockAuthState`](#useknockauthstate) hook.
 
 ### `KnockFeedProvider`
 
@@ -205,6 +229,43 @@ const MyComponent = () => {
     { id: user.id },
     user.knockToken,
   );
+
+  return null;
+};
+```
+
+### `useKnockAuthState`
+
+Subscribes to a `Knock` client's authentication state, re-rendering when the user signs in, signs out, or switches. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
+
+**Returns**: `KnockAuthState`
+
+<Attributes>
+  <Attribute
+    name="status"
+    type="'authenticated' | 'unauthenticated'"
+    description="Whether a user is currently signed in to the client."
+  />
+  <Attribute
+    name="userId"
+    type="string | undefined | null"
+    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+  />
+  <Attribute
+    name="userToken"
+    type="string | undefined"
+    description="The user token in use for the signed-in user, when one was provided."
+  />
+</Attributes>
+
+**Example**:
+
+```jsx
+import { useKnock, useKnockAuthState } from "@knocklabs/react-native";
+
+const MyComponent = () => {
+  const knock = useKnock();
+  const { status, userId } = useKnockAuthState(knock);
 
   return null;
 };

--- a/content/in-app-ui/react-native/sdk/reference.mdx
+++ b/content/in-app-ui/react-native/sdk/reference.mdx
@@ -38,7 +38,7 @@ Accepts `KnockProviderProps`
   <Attribute
     name="enabled"
     type="boolean"
-    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` authenticates and connects the client; flipping it back to `false` disconnects it and clears its data. Use it to defer activity until you have a complete identity (see below)."
   />
   <Attribute
     name="host"
@@ -54,7 +54,7 @@ Accepts `KnockProviderProps`
 
 #### Deferring activity with `enabled`
 
-`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client authenticates and connects; set it to `false` again and it disconnects and clears its data.
 
 This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 
@@ -236,7 +236,7 @@ const MyComponent = () => {
 
 ### `useKnockAuthState`
 
-Subscribes to a `Knock` client's authentication state, re-rendering when the user signs in, signs out, or switches. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
+Subscribes to a `Knock` client's authentication state, re-rendering when the authenticated user changes. Use it to react to the [`enabled` prop on `KnockProvider`](#knockprovider) flipping between states.
 
 **Returns**: `KnockAuthState`
 

--- a/content/in-app-ui/react-native/sdk/reference.mdx
+++ b/content/in-app-ui/react-native/sdk/reference.mdx
@@ -244,17 +244,17 @@ Subscribes to a `Knock` client's authentication state, re-rendering when the use
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is signed in to the client."
+    description="Whether a user is authenticated to the client."
   />
   <Attribute
     name="userId"
     type="string | undefined | null"
-    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+    description="The ID of the authenticated user, or `undefined` when no user is authenticated."
   />
   <Attribute
     name="userToken"
     type="string | undefined"
-    description="The user token in use for the signed-in user, when one was provided."
+    description="The user token in use for the authenticated user, when one was provided."
   />
 </Attributes>
 

--- a/content/in-app-ui/react/sdk/hooks/use-knock-auth-state.mdx
+++ b/content/in-app-ui/react/sdk/hooks/use-knock-auth-state.mdx
@@ -1,0 +1,7 @@
+---
+title: useKnockAuthState
+description:
+section: SDKs
+---
+
+<Typedoc file="react-core/hooks/use-knock-auth-state" />

--- a/data/sidebars/inAppSidebar.ts
+++ b/data/sidebars/inAppSidebar.ts
@@ -154,6 +154,7 @@ const SHARED_REACT_HOOKS = [
     slug: "/use-authenticated-knock-client",
     title: "useAuthenticatedKnockClient",
   },
+  { slug: "/use-knock-auth-state", title: "useKnockAuthState" },
   { slug: "/use-translations", title: "useTranslations" },
   // Feed hooks
   { slug: "/use-notifications", title: "useNotifications" },

--- a/typedocs/react-core/components/knock-provider.mdx
+++ b/typedocs/react-core/components/knock-provider.mdx
@@ -68,7 +68,7 @@ function App() {
 
 `KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
 
-This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 
 ```jsx
 <KnockProvider

--- a/typedocs/react-core/components/knock-provider.mdx
+++ b/typedocs/react-core/components/knock-provider.mdx
@@ -43,6 +43,11 @@ function App() {
     description="The JWT token for authenticating the user (required when using enhanced security mode)."
   />
   <Attribute
+    name="enabled"
+    type="boolean"
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+  />
+  <Attribute
     name="host"
     type="string"
     description="The Knock API host URL. Defaults to the production Knock API."
@@ -58,3 +63,30 @@ function App() {
     description="Child components that will have access to the Knock client."
   />
 </Attributes>
+
+## Deferring activity with `enabled`
+
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+
+This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that loads asynchronously — instead of conditionally mounting `KnockProvider`:
+
+```jsx
+<KnockProvider
+  apiKey={process.env.KNOCK_PUBLIC_API_KEY}
+  user={{ id: userId }}
+  userToken={userToken}
+  enabled={Boolean(userId && userToken)}
+>
+  {/* ... */}
+</KnockProvider>
+```
+
+Reach for `enabled` whenever you render the provider before authentication or consent is ready, such as feature-flagged rollouts, gated workspaces, or cookie consent flows.
+
+### Behavior when `enabled` changes
+
+- Feed components remount and reload their data when `enabled` becomes `true`.
+- Slack and Microsoft Teams connection status re-checks when the authenticated user changes.
+- Guides begin targeting once the client is authenticated. The `enabled` prop gates the whole client, while the [`readyToTarget` prop on `KnockGuideProvider`](/in-app-ui/react/sdk/components/knock-guide-provider) gates guide targeting on its own.
+
+To react to these transitions in your own components, subscribe to the client's authentication state with the [`useKnockAuthState`](/in-app-ui/react/sdk/hooks/use-knock-auth-state) hook.

--- a/typedocs/react-core/components/knock-provider.mdx
+++ b/typedocs/react-core/components/knock-provider.mdx
@@ -45,7 +45,7 @@ function App() {
   <Attribute
     name="enabled"
     type="boolean"
-    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` connects like a login; flipping it back to `false` disconnects and clears its data like a logout. Use it to defer activity until you have a complete identity (see below)."
+    description="Defaults to `true`. When `false`, children still render but the Knock client stays idle: no identify call, no API requests, and no websocket. Flipping it to `true` authenticates and connects the client; flipping it back to `false` disconnects it and clears its data. Use it to defer activity until you have a complete identity (see below)."
   />
   <Attribute
     name="host"
@@ -66,7 +66,7 @@ function App() {
 
 ## Deferring activity with `enabled`
 
-`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client connects like a login; set it to `false` again and it disconnects and clears its data like a logout.
+`KnockProvider` takes an `enabled` prop that defaults to `true`. When it's `false`, the provider still renders its children, but the Knock client sits idle: it doesn't identify the user, make any API requests, or open a websocket. Set it back to `true` and the client authenticates and connects; set it to `false` again and it disconnects and clears its data.
 
 This is the recommended way to gate the provider on a complete identity — for example, an enhanced-security user token that isn't ready on the first render — rather than mounting and unmounting `KnockProvider` as that identity changes:
 

--- a/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
+++ b/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
@@ -91,7 +91,7 @@ const knock = useAuthenticatedKnockClient(
 );
 ```
 
-This is the same lifecycle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider) manages for you. Prefer the prop when you're using `KnockProvider`, and reach for this option when you build a headless client with the hook directly.
+This is the same lifecycle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider) manages for you. Prefer the prop when you're using `KnockProvider`, and reach for this option when you build a headless client with the hook.
 
 ### Using string user ID (deprecated)
 

--- a/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
+++ b/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
@@ -76,6 +76,23 @@ const knock = useAuthenticatedKnockClient(
 );
 ```
 
+### Deferring activity with the `enabled` option
+
+The `options` object accepts an `enabled` flag that defaults to `true`. When it's `false`, the hook creates the client but keeps it idle — no identify call, no API requests, and no websocket — until you have a complete identity. Set it to `true` to connect like a login, and back to `false` to disconnect like a logout.
+
+```tsx
+const knock = useAuthenticatedKnockClient(
+  "pk_test_12345",
+  { id: userId },
+  userToken,
+  {
+    enabled: Boolean(userId && userToken),
+  },
+);
+```
+
+This is the same lifecycle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider) manages for you. Prefer the prop when you're using `KnockProvider`, and reach for this option when you build a headless client with the hook directly.
+
 ### Using string user ID (deprecated)
 
 While you can pass a string user ID directly, it's recommended to use an object:

--- a/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
+++ b/typedocs/react-core/hooks/use-authenticated-knock-client.mdx
@@ -78,7 +78,7 @@ const knock = useAuthenticatedKnockClient(
 
 ### Deferring activity with the `enabled` option
 
-The `options` object accepts an `enabled` flag that defaults to `true`. When it's `false`, the hook creates the client but keeps it idle — no identify call, no API requests, and no websocket — until you have a complete identity. Set it to `true` to connect like a login, and back to `false` to disconnect like a logout.
+The `options` object accepts an `enabled` flag that defaults to `true`. When it's `false`, the hook creates the client but keeps it idle — no identify call, no API requests, and no websocket — until you have a complete identity. Set it to `true` to authenticate and connect the client, and back to `false` to disconnect it and clear its data.
 
 ```tsx
 const knock = useAuthenticatedKnockClient(

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -21,7 +21,7 @@ Returns a `KnockAuthState` object describing the client's current authentication
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is currently signed in to the client."
+    description="Whether a user is signed in to the client."
   />
   <Attribute
     name="userId"

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -21,17 +21,17 @@ Returns a `KnockAuthState` object describing the client's current authentication
   <Attribute
     name="status"
     type="'authenticated' | 'unauthenticated'"
-    description="Whether a user is signed in to the client."
+    description="Whether a user is authenticated to the client."
   />
   <Attribute
     name="userId"
     type="string | undefined | null"
-    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+    description="The ID of the authenticated user, or `undefined` when no user is authenticated."
   />
   <Attribute
     name="userToken"
     type="string | undefined"
-    description="The user token in use for the signed-in user, when one was provided."
+    description="The user token in use for the authenticated user, when one was provided."
   />
 </Attributes>
 

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -47,7 +47,7 @@ const AuthStatus = () => {
   const { status, userId } = useKnockAuthState(knock);
 
   if (status === "unauthenticated") {
-    return <span>Signing you in…</span>;
+    return <span>Authenticating…</span>;
   }
 
   return <span>Connected as {userId}</span>;

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -37,7 +37,7 @@ Returns a `KnockAuthState` object describing the client's current authentication
 
 ## Example
 
-The following example reads the authentication state to render different UI while a user signs in. It pairs well with the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider), which flips the client between signed-out and signed-in as the identity loads.
+The following example reads the authentication state to render different UI while a user signs in. It pairs well with the `enabled` prop on `KnockProvider`, which flips the client between signed-out and signed-in as the identity loads.
 
 ```tsx
 import { useKnockClient, useKnockAuthState } from "@knocklabs/react";

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -1,4 +1,4 @@
-The `useKnockAuthState` hook subscribes to a Knock client's authentication state, re-rendering your component when the user signs in, signs out, or switches. It's backed by the subscribable `authStore` on the client, so it stays correct even when the client is re-authenticated in place — for example, when you toggle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider).
+The `useKnockAuthState` hook subscribes to a Knock client's authentication state, re-rendering your component when the authenticated user changes. It's backed by the subscribable `authStore` on the client, so it stays correct even when the client is re-authenticated in place — for example, when you toggle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider).
 
 ## Parameters
 
@@ -37,7 +37,7 @@ Returns a `KnockAuthState` object describing the client's current authentication
 
 ## Example
 
-The following example reads the authentication state to render different UI while a user signs in. It pairs well with the `enabled` prop on `KnockProvider`, which flips the client between signed-out and signed-in as the identity loads.
+The following example reads the authentication state to render different UI while a user authenticates. It pairs well with the `enabled` prop on `KnockProvider`, which flips the client between unauthenticated and authenticated as the identity loads.
 
 ```tsx
 import { useKnockClient, useKnockAuthState } from "@knocklabs/react";

--- a/typedocs/react-core/hooks/use-knock-auth-state.mdx
+++ b/typedocs/react-core/hooks/use-knock-auth-state.mdx
@@ -1,0 +1,55 @@
+The `useKnockAuthState` hook subscribes to a Knock client's authentication state, re-rendering your component when the user signs in, signs out, or switches. It's backed by the subscribable `authStore` on the client, so it stays correct even when the client is re-authenticated in place — for example, when you toggle the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider).
+
+## Parameters
+
+This hook accepts a single argument:
+
+<Attributes>
+  <Attribute
+    name="knock"
+    type="Knock"
+    description="An authenticated Knock client, such as the instance returned by the `useKnockClient` hook."
+    isRequired
+  />
+</Attributes>
+
+## Returns
+
+Returns a `KnockAuthState` object describing the client's current authentication.
+
+<Attributes>
+  <Attribute
+    name="status"
+    type="'authenticated' | 'unauthenticated'"
+    description="Whether a user is currently signed in to the client."
+  />
+  <Attribute
+    name="userId"
+    type="string | undefined | null"
+    description="The ID of the signed-in user, or `undefined` when no user is authenticated."
+  />
+  <Attribute
+    name="userToken"
+    type="string | undefined"
+    description="The user token in use for the signed-in user, when one was provided."
+  />
+</Attributes>
+
+## Example
+
+The following example reads the authentication state to render different UI while a user signs in. It pairs well with the [`enabled` prop on `KnockProvider`](/in-app-ui/react/sdk/components/knock-provider), which flips the client between signed-out and signed-in as the identity loads.
+
+```tsx
+import { useKnockClient, useKnockAuthState } from "@knocklabs/react";
+
+const AuthStatus = () => {
+  const knock = useKnockClient();
+  const { status, userId } = useKnockAuthState(knock);
+
+  if (status === "unauthenticated") {
+    return <span>Signing you in…</span>;
+  }
+
+  return <span>Connected as {userId}</span>;
+};
+```


### PR DESCRIPTION
### Description

Documents the new `enabled` prop on `KnockProvider` and the `useKnockAuthState` hook, shipped in the stable SDK release ([KNO-14095](https://linear.app/knock/issue/KNO-14095) / [knocklabs/javascript#1033](https://github.com/knocklabs/javascript/pull/1033), promoted to stable in [#1038](https://github.com/knocklabs/javascript/pull/1038)). The copy is adapted from the package READMEs updated in that work (`packages/react`, `packages/react-native`, `packages/expo`, `packages/client`).

**What's documented**

- **`enabled` prop on `KnockProvider`.** When `false`, children still render but the Knock client stays idle — no identify call, no API requests, and no websocket. Flipping to `true` behaves like a login; flipping to `false` behaves like a logout. Defaults to `true`. The recommended way to gate the provider on a complete identity (async user token, feature flags, gated workspaces, cookie consent) rather than mounting and unmounting the provider.
- **`useKnockAuthState()` hook.** Subscribable auth state (`status`, `userId`, `userToken`) for reacting to login, logout, and user switches.
- **Behavior notes.** Feeds remount and reload when `enabled` flips to `true`; Slack and Microsoft Teams connection status re-checks when the authenticated user changes; Expo `autoRegister` waits until the client is authenticated (the OS permission prompt is deferred, not skipped); and for guides, `enabled` gates the whole client while `readyToTarget` still gates guide targeting on its own.

**Files changed**

- `typedocs/react-core/components/knock-provider.mdx` — `enabled` prop + "Deferring activity" section with behavior notes.
- `typedocs/react-core/hooks/use-authenticated-knock-client.mdx` — `enabled` option for headless clients.
- `typedocs/react-core/hooks/use-knock-auth-state.mdx` + `content/in-app-ui/react/sdk/hooks/use-knock-auth-state.mdx` + `data/sidebars/inAppSidebar.ts` — new `useKnockAuthState` hook page and sidebar entry.
- `content/in-app-ui/react-native/sdk/reference.mdx` and `content/in-app-ui/expo/sdk/reference.mdx` — `enabled` prop on `KnockProvider` and a `useKnockAuthState` hook section (Expo also notes the `autoRegister` deferral).

### Todos

- [x] Hold for the stable (non-RC) SDK release before merging — shipped [2026-07-14](https://github.com/knocklabs/javascript/pull/1038).
- [x] Confirm the shipped versions: `@knocklabs/react@0.12.0`, `@knocklabs/react-core@0.14.0`, `@knocklabs/client@0.22.0`, `@knocklabs/react-native@0.10.0`, `@knocklabs/expo@0.7.0` — verified against `main`.

All documented API surface (prop, option, hook signature, `KnockAuthState` types, package exports, Expo `autoRegister` auth-gating) verified against `knocklabs/javascript@main` post-stable-release.

### Tasks

[KNO-14128](https://linear.app/knock/issue/KNO-14128/document-the-knockprovider-enabled-prop-on-the-docs-site)
