### PR TITLE
chore(kno-14126): clarify warehouse sync backfill timelines

### DIFF
--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -57,6 +57,8 @@ We currently support the following destination database types:
 
 Our data warehouse connector syncs data from our `messages` table. Each `message` represents a notification that was executed for a single recipient. You can read more about messages as a concept [here](/concepts/messages).
 
+The backfill of messages on initial connection will include all historical message data that is available in Knock.
+
 Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 
 <AccordionGroup>
@@ -341,6 +343,8 @@ Below is a description of the columns included in the table and the data type of
 
 The `message_events` export contains the event-level records behind message delivery and engagement. Each row captures one delivery or engagement event for a message, along with the workflow, channel, and recipient context around it. You can read more about [message events](/send-notifications/message-statuses#message-events).
 
+The historical backfill of message events on initial connection will include the previous 90 days of data.
+
 Use the column reference below to understand the fields included in this export. To see how these data types map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 
 <AccordionGroup>
@@ -495,7 +499,7 @@ Each row has an `event_type` indicating how the event was generated. Possible va
 - `recipient.snapshot` - is emitted every time a recipient's properties or preferences are updated, and contains the complete set of properties and preferences at that moment in time. This event may also be generated manually for all or a subset of recipients (by ID) by contacting support.
 - `recipient.deleted` - contains no properties or preferences, but indicates when a recipient was deleted. A recipient may be re-identified after being deleted, which will generate another recipient.created event
 
-Events in the recipient change stream table are retained for 7 days.
+Events in the recipient change stream table are retained for 7 days. The historical backfill on initial connection will include the previous 7 days of data.
 
 Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 

--- a/content/integrations/extensions/data-sync.mdx
+++ b/content/integrations/extensions/data-sync.mdx
@@ -499,7 +499,7 @@ Each row has an `event_type` indicating how the event was generated. Possible va
 - `recipient.snapshot` - is emitted every time a recipient's properties or preferences are updated, and contains the complete set of properties and preferences at that moment in time. This event may also be generated manually for all or a subset of recipients (by ID) by contacting support.
 - `recipient.deleted` - contains no properties or preferences, but indicates when a recipient was deleted. A recipient may be re-identified after being deleted, which will generate another recipient.created event
 
-Events in the recipient change stream table are retained for 7 days. The historical backfill on initial connection will include the previous 7 days of data.
+Events in the recipient change stream table are retained for 7 days. The data available on initial connection will include a snapshot of the current state of all recipients, but no historical data.
 
 Below is a description of the columns included in the table and the data type of each. To see how this data type will map onto the data types of your destination table, check the <a href="https://docs.prequel.co/docs/data-types#destination-type-mapping" target="_blank">destination type mapping table</a>.
 


### PR DESCRIPTION
### Description

Adds explicit mentions of how much historical data is synced for each warehouse table upon initial sync:

- `messages`: Full message history that is available in Knock
- `message_events`: 90 days of historical data
- `recipient_change_stream`: A snapshot of current user state
