### PR TITLE
docs: clarify how tenants hold the Slack access token

### DIFF
--- a/content/integrations/chat/slack/overview.mdx
+++ b/content/integrations/chat/slack/overview.mdx
@@ -169,6 +169,15 @@ Here's an example of setting channel data on an `Object` in Knock.
   }
 />
 
+### How Slack delivery works
+
+Every Slack notification needs two things, and Knock lets them live in different places:
+
+- **Auth** — permission to post: either a bot **access token** (`xoxb-…`) from Slack's OAuth flow, or a self-contained **incoming webhook URL**. A bot token authorizes exactly one Slack workspace.
+- **Destination** — where the message goes: a `channel_id` (a channel) or a `user_id` (a direct message).
+
+The **destination** is stored on the recipient (a [`User`](/concepts/users) or [`Object`](/concepts/objects)). The **auth** can be stored on the recipient too — or, in a multi-workspace product, once on the [tenant](#tenant-channel-data-requirements), so every recipient in that tenant shares a single connection. The two sections below cover each location.
+
 ### Recipient channel data requirements
 
 Here's an overview of the data requirements for [setting recipient channel data](/send-notifications/setting-channel-data) for either an incoming webhook or an access token Slack connection. Both will need to live under the `connections` key.
@@ -229,7 +238,9 @@ Here's an overview of the data requirements for [setting recipient channel data]
 
 ### Tenant channel data requirements
 
-When you [map a Slack workspace to a tenant](/integrations/chat/slack/sending-a-message-to-channels#key-concepts) in Knock (as our [SlackKit](/in-app-ui/react/slack-kit) components do), you'll store the access token for that workspace as `channel_data` on the tenant. Then, when you apply the `tenant` to your workflow triggers Knock will [combine that access token with the recipient's](/integrations/chat/slack/sending-a-message-to-channels#merging-channel-data) `channel_data` to send notifications to the correct Slack workspace and channel. For this implementation method, the `access_token` on the recipient's `SlackConnection[]` data above is not required.
+When you [map a Slack workspace to a tenant](/integrations/chat/slack/sending-a-message-to-channels#key-concepts) in Knock (as our [SlackKit](/in-app-ui/react/slack-kit) components do), you store that workspace's access token as `channel_data` on the tenant. At send time, when you trigger a workflow with that `tenant`, Knock takes the [destination](#how-slack-delivery-works) from the recipient's `channel_data` (the `channel_id` or `user_id`) and uses the tenant's access token for auth: the tenant provides the auth, the recipient provides the destination. If the recipient also carries an `access_token`, the tenant's takes precedence — so the `access_token` on the recipient's `SlackConnection[]` above is not required when a tenant holds one.
+
+**Do you need a tenant?** Store the token on a tenant when one Slack workspace connection should serve every recipient or object in that tenant. This keeps the workspace access token in one place while each recipient or object stores only its Slack destination (`channel_id` or `user_id`), which is useful as you add more destinations in the same workspace later. You don't need a tenant if you post to a single internal workspace (use an incoming webhook — there's no token to share) or only ever use one workspace's token and prefer to store it directly on each recipient or object. Knock never auto-creates a tenant for you (though SlackKit can, on the fly), so use one when shared workspace auth should live at the tenant level.
 
 Here's an overview of the data requirements for setting channel data when storing an access token on a tenant.
 

--- a/content/integrations/chat/slack/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/slack/sending-a-message-to-channels.mdx
@@ -16,7 +16,7 @@ SlackKit connects multiple concepts in Knock to make it easier for your users to
 
 ### About tenants
 
-[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a standard SlackKit implementation, you'll store a Slack workspace's `access_token` on a corresponding tenant in Knock.
+[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a standard SlackKit implementation, you'll store a Slack workspace's `access_token` on a corresponding tenant in Knock. See [how the tenant access token is used at send time](/integrations/chat/slack/overview#tenant-channel-data-requirements) for the full model.
 
 If you already use Knock's tenant concept to power other 'account-based' features, you likely create tenants in Knock when an account or organization is created in your application. If you don't already use tenants in Knock, SlackKit can create tenants for you on the fly if they don't already exist.
 
@@ -76,7 +76,7 @@ await knockClient.workflows.trigger("new-issue", {
 
 In this implementation, we'll actually store [the required channel data](/in-app-ui/react/slack-kit#channel-data-requirements) for a `SlackConnection` across two different entities in Knock: a `Tenant` and an `Object`. This is because we want to store the `access_token` for the Slack workspace on the `Tenant` and the `channel_id` for the Slack channel on the `Object`.
 
-When you trigger a workflow using this recipient and tenant, Knock will merge the channel data from the `Tenant` and the `Object` to send the message to the correct Slack channel. By storing the `access_token` on the `Tenant`, your customers only need to complete the OAuth flow once to connect their Slack workspace to Knock.
+When you trigger a workflow using this recipient and tenant, Knock uses the destination stored on the `Object` (the `channel_id`) and the access token stored on the `Tenant` for auth — if the object also carries a token, the tenant's takes precedence (see [auth vs. destination](/integrations/chat/slack/overview#how-slack-delivery-works)). By storing the `access_token` on the `Tenant`, your customers only need to complete the OAuth flow once to connect their Slack workspace to Knock.
 
 ## Implementing SlackKit
 

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -7,7 +7,7 @@ section: Managing recipients
 
 Some channel integrations require user and channel-specific data to send notifications. Push channels like APNs (Apple Push Notification Service) and FCM (Firebase Cloud Messaging) are good examples, where both require that there are device-specific tokens that target the user in a push notification. Slack is another good example, where the channel data from a Slack integration in your product is stored on a Knock [object](/concepts/objects).
 
-At Knock we call this concept <a href="/api-reference/recipients/channel_data">`ChannelData`</a>. `ChannelData` lives under a [user](/concepts/users) or an [object](/concepts/objects) and stores channel-specific data to be used when that user or object is included as a recipient on a [triggered workflow](/send-notifications/triggering-workflows).
+At Knock we call this concept <a href="/api-reference/recipients/channel_data">`ChannelData`</a>. For most channels, `ChannelData` lives under a [user](/concepts/users) or an [object](/concepts/objects) and stores channel-specific data to be used when that user or object is included as a recipient on a [triggered workflow](/send-notifications/triggering-workflows). For chat providers that support tenant-stored credentials, `ChannelData` can also live on a [tenant](/multi-tenancy/overview) to provide shared auth while the recipient stores the destination.
 
 ## Things to know about channel data
 
@@ -217,11 +217,11 @@ The `PushDevice` object is used to optionally set device-level metadata for a pu
     If you're using standard Slack OAuth with access token scopes, your `SlackConnection` schema looks like this. You'll use
     either a `channel_id` or `user_id` depending on whether you're storing connection data to message a channel or user in Slack:
 
-    | Property     | Type     | Description        |
-    | ------------ | -------- | ------------------ |
-    | access_token | `string` | A bot access token |
-    | channel_id   | `string` | A Slack channel ID |
-    | user_id      | `string` | A Slack user ID    |
+    | Property     | Type     | Description                                                                                                                            |
+    | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+    | access_token | `string` | A bot access token. Not required when the token is [stored on a tenant](/integrations/chat/slack/overview#tenant-channel-data-requirements). |
+    | channel_id   | `string` | A Slack channel ID                                                                                                                    |
+    | user_id      | `string` | A Slack user ID                                                                                                                       |
 
     If you're using a Slack app with the `incoming-webhook` scope your `SlackConnection` schema is quite simple:
 

--- a/content/multi-tenancy/overview.mdx
+++ b/content/multi-tenancy/overview.mdx
@@ -14,6 +14,7 @@ You use tenants in Knock to:
 - Apply [per-tenant branding](/multi-tenancy/per-tenant-branding) in emails.
 - Define [per-tenant preference defaults](/multi-tenancy/per-tenant-preferences#create-a-per-tenant-default-preferenceset) that apply to all users within that tenant and [per-user, per-tenant preferences](/multi-tenancy/per-tenant-preferences#set-a-per-tenant-user-preferenceset).
 - Apply [per-tenant translations](/multi-tenancy/per-tenant-translations).
+- Hold shared channel credentials as [channel data](/managing-recipients/setting-channel-data), so one integration connection can serve recipients and objects in the tenant.
 
 ## How tenants work
 


### PR DESCRIPTION
## Summary

The tenant-holds-the-Slack-token story is one of the most confusing parts of our Slack docs: the clearest explanation was buried, unlinked, and worded as a vague "merge." This makes the model explicit and gives it a single canonical home.

- **New "How Slack delivery works" section** on the Slack overview splits a Slack connection into its two halves — **auth** (a bot access token or an incoming webhook) and **destination** (`channel_id`/`user_id`) — and says where each lives.
- **Rewrites the "Tenant channel data requirements" section** to state the actual precedence rule — the tenant's token wins over any token on the recipient (verified against the send-path code, which overwrites the recipient's `access_token` with the tenant's) — instead of the ambiguous "combine." Adds a **"Do you need a tenant?"** note so readers with a single internal workspace aren't over-steered toward tenants.
- **Fixes the cross-referencing gap.** The canonical section had no inbound links from the pages where confused readers start. Adds links from the [tenants concept page](content/multi-tenancy/overview.mdx) (which never mentioned holding credentials), the SlackKit **"About tenants"** and **"Merging channel data"** sections, and the **setting-channel-data** Slack schema.

