### PR TITLE
Add session_name to Ask AI PostHog events

### DIFF
--- a/components/AskAiContext.tsx
+++ b/components/AskAiContext.tsx
@@ -235,40 +235,55 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
     return sessionId;
   }, []);
 
+  // Helper to get current session title
+  const getCurrentSessionTitle = useCallback((): string | undefined => {
+    if (!currentChatId) return undefined;
+    const session = chatSessions.find((s) => s.id === currentChatId);
+    return session?.title;
+  }, [chatSessions, currentChatId]);
+
   const openSidebar = useCallback(() => {
     posthog.track("ask-ai-sidebar-opened-client", {
       source: "button",
+      session_name: getCurrentSessionTitle(),
     });
     setIsOpen(true);
-  }, []);
+  }, [getCurrentSessionTitle]);
 
   const closeSidebar = useCallback(() => {
-    posthog.track("ask-ai-sidebar-closed-client");
+    posthog.track("ask-ai-sidebar-closed-client", {
+      session_name: getCurrentSessionTitle(),
+    });
     setIsOpen(false);
-  }, []);
+  }, [getCurrentSessionTitle]);
 
   const toggleSidebar = useCallback(() => {
+    const sessionName = getCurrentSessionTitle();
     setIsOpen((prev) => {
       if (!prev) {
         posthog.track("ask-ai-sidebar-opened-client", {
           source: "button",
+          session_name: sessionName,
         });
       } else {
-        posthog.track("ask-ai-sidebar-closed-client");
+        posthog.track("ask-ai-sidebar-closed-client", {
+          session_name: sessionName,
+        });
       }
       return !prev;
     });
-  }, []);
+  }, [getCurrentSessionTitle]);
 
   const openSidebarWithPrompt = useCallback(
     (prompt: string) => {
+      // Create new session before setting prompt to ensure each query starts fresh
+      createNewSession();
       posthog.track("ask-ai-sidebar-opened-client", {
         source: "search",
         has_prompt: true,
         prompt_length: prompt.length,
+        session_name: "New chat", // New session is created, so title is always "New chat"
       });
-      // Create new session before setting prompt to ensure each query starts fresh
-      createNewSession();
       setInitialPrompt(prompt);
       setIsOpen(true);
     },
@@ -284,6 +299,7 @@ export function AskAiProvider({ children }: { children: ReactNode }) {
       if (session) {
         posthog.track("ask-ai-session-switched-client", {
           message_count: session.messages.length,
+          session_name: session.title,
         });
 
         // Abort any ongoing stream before switching sessions

--- a/hooks/useChatStream.ts
+++ b/hooks/useChatStream.ts
@@ -38,10 +38,18 @@ export function useChatStream(): UseChatStreamReturn {
     setError,
     clearMessages: contextClearMessages,
     currentChatId,
+    chatSessions,
     createNewSession,
     generateSessionTitle,
     registerBeforeSessionChange,
   } = useAskAi();
+
+  // Helper to get current session title
+  const getCurrentSessionTitle = (): string | undefined => {
+    if (!currentChatId) return undefined;
+    const session = chatSessions.find((s) => s.id === currentChatId);
+    return session?.title;
+  };
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -185,11 +193,15 @@ export function useChatStream(): UseChatStreamReturn {
       // A session is "new" if it was just created OR if it has no messages yet
       const isNewSession = wasNewSession || isFirstMessage;
 
+      // For new sessions, title is always "New chat"; for existing sessions, get current title
+      const sessionName = wasNewSession ? "New chat" : getCurrentSessionTitle();
+
       posthog.track("ask-ai-message-sent-client", {
         message_length: content.trim().length,
         is_first_message: isFirstMessage,
         is_new_session: isNewSession,
         conversation_length: messages.length,
+        session_name: sessionName,
       });
 
       // Add user message immediately
@@ -368,6 +380,7 @@ export function useChatStream(): UseChatStreamReturn {
     posthog.track("ask-ai-stream-stopped-client", {
       content_length: contentBufferRef.current.length,
       displayed_length: displayedLengthRef.current,
+      session_name: getCurrentSessionTitle(),
     });
 
     // Mark that user manually stopped the stream


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the `session_name` property to all Ask AI PostHog events to enable tracking which chat session users are interacting with.

## Changes

Updated the following PostHog events to include `session_name`:

| Event | File | Notes |
|-------|------|-------|
| `ask-ai-sidebar-opened-client` | `AskAiContext.tsx` | Current session title, or "New chat" for new sessions |
| `ask-ai-sidebar-closed-client` | `AskAiContext.tsx` | Current session title |
| `ask-ai-session-switched-client` | `AskAiContext.tsx` | Target session's title |
| `ask-ai-message-sent-client` | `useChatStream.ts` | Current session title, or "New chat" for new sessions |
| `ask-ai-stream-stopped-client` | `useChatStream.ts` | Current session title |

For new sessions, `session_name` is "New chat" until a title is generated after the first assistant response.

## Implementation details

- Added a `getCurrentSessionTitle()` helper in both files to look up the session title from `chatSessions` using `currentChatId`
- For events fired during new session creation (like `openSidebarWithPrompt`), the `session_name` is explicitly set to "New chat" since the session is created before tracking
- The mobile modal events (`ask-ai-mobile-modal-opened-client`) were not updated because they use Inkeep's external chat widget which has its own session management separate from our custom chat system

## Testing

- TypeScript type checking passes
- ESLint passes

Resolves KNO-14289
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14289](https://linear.app/knock/issue/KNO-14289/add-session-name-to-ask-ai-posthog-events)

<div><a href="https://cursor.com/agents/bc-708a90a6-a906-459e-a242-0f481a5e133f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-708a90a6-a906-459e-a242-0f481a5e133f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

