### PR TITLE
feat(kno-14125): add billing and usage management page

### DIFF
--- a/content/manage-your-account/managing-usage.mdx
+++ b/content/manage-your-account/managing-usage.mdx
@@ -1,0 +1,39 @@
+---
+title: "Managing usage"
+description: "Understand how Knock meters usage across plans and how to manage usage in your account."
+tags: ["billing", "pricing", "sandbox mode", "usage"]
+section: Manage your account
+---
+
+Knock plans vary in terms of usage models: notification-based plans meter usage on messages sent, while recipient-based plans meter usage based on monthly notified recipients. See our [pricing page](https://knock.app/pricing) for current plan pricing and included volumes. [Contact support](mailto:support@knock.app?subject=Billing%20question) for questions about your Knock plan, or [contact sales](mailto:sales@knock.app?subject=Enterprise%20pricing) to discuss enterprise pricing.
+
+## Message counts
+
+A message is counted each time a notification is successfully delivered to a single user on a single channel. A workflow that notifies a user by both email and in-app results in two messages. If a channel step is not executed, there is no associated message. A channel step may be skipped due to user preferences, missing data, or other workflow logic.
+
+Due to the nature of [guides](/concepts/guides), guides usage is metered separately and based on active guides users. A user is considered an active guides user if they have received at least one guide in a given month.
+
+## Non-production usage
+
+While using Knock, you'll often send messages in non-production environments to test changes. To avoid unexpected usage from testing, we recommend using [sandbox mode](/integrations/overview#sandbox-mode) or setting [channel conditions](/integrations/overview#channel-conditions) in your non-production environments.
+
+### Sandbox mode
+
+When a channel is in [sandbox mode](/integrations/overview#sandbox-mode), Knock does not pass messages downstream for delivery. Sandboxed messages are rendered for preview in the Knock dashboard, but do not count toward usage.
+
+Enable sandbox mode in a channel's configuration to apply it across an environment, or use the workflow [test runner's sandbox setting](/send-notifications/testing-workflows#test-run-settings) to apply it for a single run, regardless of how the channel itself is configured.
+
+### Channel conditions
+
+[Channel conditions](/integrations/overview#channel-conditions) enable you to scope a channel's delivery to specific conditions per environment. For example, you might set a condition on your email channel to restrict sending to recipients on your own domain while in a non-production environment. Unlike sandbox mode, channel conditions gate delivery selectively rather than suppress it entirely. Any message that satisfies a channel condition may contribute to usage.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="How can I sandbox in-app feed messages?">
+    The in-app channel doesn't support sandbox mode — Knock manages in-app delivery, so there's no downstream provider handoff to suppress. Use [channel conditions](/integrations/overview#channel-conditions) to manage when messages are created for in-app steps in your non-production environments.
+  </Accordion>
+  <Accordion title="How can I sandbox in-app guide messages?">
+    The guides channel does not support sandbox mode. To manage usage, use audience-limiting [targeting rules](/in-app-ui/guides/create-guides#targeting) while testing in non-production environments.
+  </Accordion>
+</AccordionGroup>

--- a/content/manage-your-account/managing-usage.mdx
+++ b/content/manage-your-account/managing-usage.mdx
@@ -31,9 +31,16 @@ Enable sandbox mode in a channel's configuration to apply it across an environme
 
 <AccordionGroup>
   <Accordion title="How can I sandbox in-app feed messages?">
-    The in-app channel doesn't support sandbox mode — Knock manages in-app delivery, so there's no downstream provider handoff to suppress. Use [channel conditions](/integrations/overview#channel-conditions) to manage when messages are created for in-app steps in your non-production environments.
+    The in-app channel doesn't support sandbox mode — Knock manages in-app
+    delivery, so there's no downstream provider handoff to suppress. Use
+    [channel conditions](/integrations/overview#channel-conditions) to manage
+    when messages are created for in-app steps in your non-production
+    environments.
   </Accordion>
   <Accordion title="How can I sandbox in-app guide messages?">
-    The guides channel does not support sandbox mode. To manage usage, use audience-limiting [targeting rules](/in-app-ui/guides/create-guides#targeting) while testing in non-production environments.
+    The guides channel does not support sandbox mode. To manage usage, use
+    audience-limiting [targeting
+    rules](/in-app-ui/guides/create-guides#targeting) while testing in
+    non-production environments.
   </Accordion>
 </AccordionGroup>

--- a/content/manage-your-account/managing-usage.mdx
+++ b/content/manage-your-account/managing-usage.mdx
@@ -19,13 +19,13 @@ While using Knock, you'll often send messages in non-production environments to 
 
 ### Sandbox mode
 
-When a channel is in [sandbox mode](/integrations/overview#sandbox-mode), Knock does not pass messages downstream for delivery. Sandboxed messages are rendered for preview in the Knock dashboard, but do not count toward usage.
+When a channel is in sandbox mode, Knock does not pass messages downstream for delivery. Sandboxed messages are rendered for preview in the Knock dashboard, but do not count toward usage.
 
 Enable sandbox mode in a channel's configuration to apply it across an environment, or use the workflow [test runner's sandbox setting](/send-notifications/testing-workflows#test-run-settings) to apply it for a single run, regardless of how the channel itself is configured.
 
 ### Channel conditions
 
-[Channel conditions](/integrations/overview#channel-conditions) enable you to scope a channel's delivery to specific conditions per environment. For example, you might set a condition on your email channel to restrict sending to recipients on your own domain while in a non-production environment. Unlike sandbox mode, channel conditions gate delivery selectively rather than suppress it entirely. Any message that satisfies a channel condition may contribute to usage.
+Channel conditions enable you to scope a channel's delivery to specific conditions per environment. For example, you might set a condition on your email channel to restrict sending to recipients on your own domain while in a non-production environment. Unlike sandbox mode, channel conditions gate delivery selectively rather than suppress it entirely. Any message that satisfies a channel condition may contribute to usage.
 
 ## Frequently asked questions
 

--- a/content/manage-your-account/managing-usage.mdx
+++ b/content/manage-your-account/managing-usage.mdx
@@ -37,7 +37,7 @@ Channel conditions enable you to scope a channel's delivery to specific conditio
     when messages are created for in-app steps in your non-production
     environments.
   </Accordion>
-  <Accordion title="How can I sandbox in-app guide messages?">
+  <Accordion title="How can I sandbox guide messages?">
     The guides channel does not support sandbox mode. To manage usage, use
     audience-limiting [targeting
     rules](/in-app-ui/guides/create-guides#targeting) while testing in

--- a/content/manage-your-account/managing-usage.mdx
+++ b/content/manage-your-account/managing-usage.mdx
@@ -5,7 +5,7 @@ tags: ["billing", "pricing", "sandbox mode", "usage"]
 section: Manage your account
 ---
 
-Knock plans vary in terms of usage models: notification-based plans meter usage on messages sent, while recipient-based plans meter usage based on monthly notified recipients. See our [pricing page](https://knock.app/pricing) for current plan pricing and included volumes. [Contact support](mailto:support@knock.app?subject=Billing%20question) for questions about your Knock plan, or [contact sales](mailto:sales@knock.app?subject=Enterprise%20pricing) to discuss enterprise pricing.
+Knock plans vary in terms of usage models: notification-based plans meter usage on messages sent, while recipient-based plans meter usage based on monthly notified recipients. Regardless of plan, usage may be accrued in any Knock [environment](/version-control/environments). See our [pricing page](https://knock.app/pricing) for current plan pricing and included volumes. [Contact support](mailto:support@knock.app?subject=Billing%20question) for questions about your Knock plan, or [contact sales](mailto:sales@knock.app?subject=Enterprise%20pricing) to discuss enterprise pricing.
 
 ## Message counts
 
@@ -31,7 +31,7 @@ Channel conditions enable you to scope a channel's delivery to specific conditio
 
 <AccordionGroup>
   <Accordion title="How can I sandbox in-app feed messages?">
-    The in-app channel doesn't support sandbox mode — Knock manages in-app
+    The in-app channel doesn't support sandbox mode. Knock manages in-app
     delivery, so there's no downstream provider handoff to suppress. Use
     [channel conditions](/integrations/overview#channel-conditions) to manage
     when messages are created for in-app steps in your non-production

--- a/data/sidebars/platformSidebar.ts
+++ b/data/sidebars/platformSidebar.ts
@@ -236,6 +236,7 @@ export const PLATFORM_SIDEBAR: SidebarSection[] = [
       { slug: "/data-retention", title: "Data retention" },
       { slug: "/custom-domains", title: "Custom domains" },
       { slug: "/managing-assets", title: "Managing assets" },
+      { slug: "/managing-usage", title: "Managing usage" },
       { slug: "/account-deletion", title: "Account deletion" },
     ],
   },


### PR DESCRIPTION
## KNO-14125: [Docs] Add pricing page explaining sandbox mode best practices

### Summary
Adds a new page explaining at a high level how Knock meters usage and how sandbox mode and channel conditions can be used to manage usage. 


### Changes
- `content/manage-your-account/managing-usage.mdx` — new page described above
- `data/sidebars/platformSidebar.ts` — added "Managing usage" entry to Manage your account section