### PR TITLE
Fix docs next/previous page navigation

### DIFF
--- a/layouts/CliReferenceLayout.tsx
+++ b/layouts/CliReferenceLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Page } from "@/components/ui/Page";
-import { slugToPaths } from "../lib/content";
+import { getPathsFromRouter } from "../lib/content";
 import Meta from "../components/Meta";
 import { useRouter } from "next/router";
 import { useInitialScrollState } from "../components/ui/Page/helpers";
@@ -25,7 +25,7 @@ export const CliReferenceLayout = ({
 }: CliReferenceLayoutProps) => {
   const router = useRouter();
   useInitialScrollState();
-  let paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   useScrollToTop(paths);
 

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -9,13 +9,16 @@ import { Box } from "@telegraph/layout";
 
 const DocsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
+  // Use asPath-based paths so next/prev update across client-side navigations.
+  // query.slug alone is often empty after soft nav on catch-all routes.
   const paths = getPathsFromRouter(router);
 
   const { content: sidebarContent, parentSection } = useSidebarContent();
 
+  const pathKey = paths.join("/");
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getSidebarInfo(paths, sidebarContent, parentSection),
-    [paths, sidebarContent, parentSection],
+    [pathKey, paths, sidebarContent, parentSection],
   );
 
   return (

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -1,21 +1,21 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { useRouter } from "next/router";
 import { Page } from "../components/ui/Page";
 import { useSidebarContent } from "../hooks/useSidebarContent";
 
 import Meta from "../components/Meta";
-import { getSidebarInfo, slugToPaths } from "../lib/content";
+import { getPathsFromRouter, getSidebarInfo } from "../lib/content";
 import { Box } from "@telegraph/layout";
 
 const DocsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   const { content: sidebarContent, parentSection } = useSidebarContent();
 
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getSidebarInfo(paths, sidebarContent, parentSection),
-    [paths, sidebarContent],
+    [paths, sidebarContent, parentSection],
   );
 
   return (

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -16,7 +16,7 @@ import {
   type SdkSpecificContent,
 } from "../data/sidebars/inAppSidebar";
 import Meta from "../components/Meta";
-import { getInAppSidebar, slugToPaths } from "../lib/content";
+import { getInAppSidebar, getPathsFromRouter } from "../lib/content";
 import { Box } from "@telegraph/layout";
 import { Stack } from "@telegraph/layout";
 import { Select } from "@telegraph/select";
@@ -140,7 +140,7 @@ const InAppSidebar = ({
 
 const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   const [selectedSdk, setSelectedSdk] = useState<Language>(() => {
@@ -154,7 +154,6 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
-  // @ts-expect-error we do get these, need to come back to breadcrumbs
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getInAppSidebar(paths, allSidebarContent, selectedSdkContent),
     [paths, allSidebarContent, selectedSdkContent],

--- a/layouts/IntegrationsLayout.tsx
+++ b/layouts/IntegrationsLayout.tsx
@@ -15,6 +15,7 @@ const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
 
   useScrollToTop(paths);
 
+  const pathKey = paths.join("/");
   const { breadcrumbs, nextPage, prevPage } = useMemo(() => {
     // Merge the first two path segments for all pages but the integrations overview
     // so that the paths match the slugs in the integrations sidebar content.
@@ -28,7 +29,7 @@ const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
     }
 
     return getSidebarInfo(sidebarPaths, INTEGRATIONS_SIDEBAR, parentSection);
-  }, [paths]);
+  }, [pathKey, paths]);
 
   return (
     <Page.Container>

--- a/layouts/IntegrationsLayout.tsx
+++ b/layouts/IntegrationsLayout.tsx
@@ -5,13 +5,13 @@ import {
   parentSection,
 } from "../data/sidebars/integrationsSidebar";
 import Meta from "../components/Meta";
-import { getSidebarInfo, slugToPaths } from "../lib/content";
+import { getPathsFromRouter, getSidebarInfo } from "../lib/content";
 import { Page } from "@/components/ui/Page";
 import { useScrollToTop } from "../hooks/useScrollToTop";
 
 const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  let paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   useScrollToTop(paths);
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -12,6 +12,23 @@ export const slugToPaths = (slug: string | string[] | undefined): string[] => {
   }
 };
 
+// Converts a Next.js asPath (e.g. "/concepts/workflows?x=1#hash") to path segments
+export const asPathToPaths = (asPath: string): string[] =>
+  asPath.split("#")[0].split("?")[0].split("/").filter(Boolean);
+
+// Prefer router.query.slug when present; fall back to asPath when query is not
+// ready yet (common on the first client render of statically generated pages).
+export const getPathsFromRouter = (router: {
+  query: { slug?: string | string[] };
+  asPath: string;
+}): string[] => {
+  const fromQuery = slugToPaths(router.query.slug);
+  if (fromQuery.length > 0) {
+    return fromQuery;
+  }
+  return asPathToPaths(router.asPath);
+};
+
 // TODO: Make this generic. This is a hack right now and it won't work for arbitrary paths.
 export function getInAppSidebar(
   paths: string[],
@@ -21,6 +38,10 @@ export function getInAppSidebar(
   if (!paths.includes(selectedSdkContent.value)) {
     return getSidebarInfo(paths, allSidebarContent);
   }
+
+  // Resolve adjacent pages from the full sidebar so SDK-specific pages get
+  // next/previous navigation as well as breadcrumbs.
+  const { prevPage, nextPage } = getSidebarInfo(paths, allSidebarContent);
 
   // Get the deepest page that matches the paths
   const { section, page } = depthFirstSidebarInfo(paths, allSidebarContent);
@@ -50,6 +71,8 @@ export function getInAppSidebar(
           ]
         : []),
     ],
+    prevPage,
+    nextPage,
   };
 }
 
@@ -187,12 +210,17 @@ export const getSidebarInfo = (
     (page) => page.path === `/${paths.join("/")}`,
   );
 
-  if (flatIndex > 0) {
-    prevPage = flatSidebar[flatIndex - 1];
-  }
+  // flatIndex is -1 when the current path is not in the sidebar (including when
+  // paths is empty because router.query is not ready). Guard against treating
+  // -1 as a valid index, which would incorrectly set nextPage to the first item.
+  if (flatIndex >= 0) {
+    if (flatIndex > 0) {
+      prevPage = flatSidebar[flatIndex - 1];
+    }
 
-  if (flatIndex < flatSidebar.length - 1) {
-    nextPage = flatSidebar[flatIndex + 1];
+    if (flatIndex < flatSidebar.length - 1) {
+      nextPage = flatSidebar[flatIndex + 1];
+    }
   }
 
   return {

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -16,17 +16,25 @@ export const slugToPaths = (slug: string | string[] | undefined): string[] => {
 export const asPathToPaths = (asPath: string): string[] =>
   asPath.split("#")[0].split("?")[0].split("/").filter(Boolean);
 
-// Prefer router.query.slug when present; fall back to asPath when query is not
-// ready yet (common on the first client render of statically generated pages).
+// Resolve the current docs path from the router.
+// Prefer asPath: it tracks the browser URL across client-side navigations.
+// On catch-all routes, router.query.slug is often empty after soft navigation,
+// which previously made next/previous fall back to the first sidebar page.
 export const getPathsFromRouter = (router: {
   query: { slug?: string | string[] };
   asPath: string;
 }): string[] => {
-  const fromQuery = slugToPaths(router.query.slug);
-  if (fromQuery.length > 0) {
-    return fromQuery;
+  const fromAsPath = asPathToPaths(router.asPath);
+  // Ignore unresolved dynamic route patterns such as "/[...slug]" during prerender
+  const asPathIsResolved =
+    fromAsPath.length > 0 &&
+    !fromAsPath.some((segment) => segment.includes("[") || segment.includes("]"));
+
+  if (asPathIsResolved) {
+    return fromAsPath;
   }
-  return asPathToPaths(router.asPath);
+
+  return slugToPaths(router.query.slug);
 };
 
 // TODO: Make this generic. This is a hack right now and it won't work for arbitrary paths.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect bottom next/previous navigation on docs pages.

### Root cause

On catch-all `[...slug]` routes, `router.query.slug` is often **empty after client-side navigation**. `getSidebarInfo` then failed to find the current page (`flatIndex === -1`) and incorrectly set **Next** to the first sidebar item (e.g. "Overview" / "What is Knock?") with no Previous.

### Changes

- Resolve the current path from `asPath` (falls back to `query.slug` only for unresolved dynamic routes like `/[...slug]`)
- Guard adjacent-page lookup so `flatIndex === -1` does not invent a next page
- Return `prevPage` / `nextPage` from `getInAppSidebar` for SDK-specific pages

### Why the first revision looked worse

Guarding `flatIndex === -1` alone stopped the wrong "Overview" link, but left Previous/Next empty after soft nav. Preferring `asPath` fixes the underlying path resolution.

## Test plan

- [x] Hard refresh mid-section page; Previous/Next match sidebar order
- [x] Client-nav via sidebar (Workflows → Broadcasts → Guides); footer updates correctly
- [x] Tutorials client-nav keeps Previous/Next
- [x] Direct load of `/concepts/broadcasts` still works
- [x] In-app UI SDK pages show Previous/Next

### Verification (client-side nav)

After sidebar click to Broadcasts:

[client nav broadcasts footer](https://cursor.com/agents/bc-d0c97bf6-47cf-4f87-8a0d-bb316e91e55f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fclient-nav-broadcasts-fixed.webp)

After sidebar click to Guides:

[client nav guides footer](https://cursor.com/agents/bc-d0c97bf6-47cf-4f87-8a0d-bb316e91e55f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fclient-nav-guides-fixed.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14307](https://linear.app/knock/issue/KNO-14307/docs-nextprevious-page-buttons-are-incorrect)

<div><a href="https://cursor.com/agents/bc-d0c97bf6-47cf-4f87-8a0d-bb316e91e55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0c97bf6-47cf-4f87-8a0d-bb316e91e55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

