### PR TITLE
fix(kno-14307): Fix docs next/previous page navigation

### DIFF
--- a/layouts/CliReferenceLayout.tsx
+++ b/layouts/CliReferenceLayout.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Page } from "@/components/ui/Page";
-import { slugToPaths } from "../lib/content";
+import { getPathsFromRouter } from "../lib/content";
 import Meta from "../components/Meta";
 import { useRouter } from "next/router";
 import { useInitialScrollState } from "../components/ui/Page/helpers";
@@ -25,7 +25,7 @@ export const CliReferenceLayout = ({
 }: CliReferenceLayoutProps) => {
   const router = useRouter();
   useInitialScrollState();
-  let paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   useScrollToTop(paths);
 

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -9,14 +9,16 @@ import { Box } from "@telegraph/layout";
 
 const DocsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = getPathsFromRouter(router);
+  // Key off asPath so client-side navigations recompute adjacent pages.
+  // Do not use router.query.slug here (KNO-14307).
+  const pathKey = router.asPath.split("#")[0].split("?")[0];
 
   const { content: sidebarContent, parentSection } = useSidebarContent();
 
-  const { breadcrumbs, nextPage, prevPage } = useMemo(
-    () => getSidebarInfo(paths, sidebarContent, parentSection),
-    [paths, sidebarContent, parentSection],
-  );
+  const { breadcrumbs, nextPage, prevPage } = useMemo(() => {
+    const paths = getPathsFromRouter({ asPath: pathKey });
+    return getSidebarInfo(paths, sidebarContent, parentSection);
+  }, [pathKey, sidebarContent, parentSection]);
 
   return (
     <Page.Container>

--- a/layouts/DocsLayout.tsx
+++ b/layouts/DocsLayout.tsx
@@ -1,21 +1,21 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useMemo } from "react";
 import { useRouter } from "next/router";
 import { Page } from "../components/ui/Page";
 import { useSidebarContent } from "../hooks/useSidebarContent";
 
 import Meta from "../components/Meta";
-import { getSidebarInfo, slugToPaths } from "../lib/content";
+import { getPathsFromRouter, getSidebarInfo } from "../lib/content";
 import { Box } from "@telegraph/layout";
 
 const DocsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   const { content: sidebarContent, parentSection } = useSidebarContent();
 
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getSidebarInfo(paths, sidebarContent, parentSection),
-    [paths, sidebarContent],
+    [paths, sidebarContent, parentSection],
   );
 
   return (

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -140,7 +140,8 @@ const InAppSidebar = ({
 
 const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = getPathsFromRouter(router);
+  const pathKey = router.asPath.split("#")[0].split("?")[0];
+  const paths = getPathsFromRouter({ asPath: pathKey });
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   const [selectedSdk, setSelectedSdk] = useState<Language>(() => {
@@ -154,10 +155,14 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
-  const { breadcrumbs, nextPage, prevPage } = useMemo(
-    () => getInAppSidebar(paths, allSidebarContent, selectedSdkContent),
-    [paths, allSidebarContent, selectedSdkContent],
-  );
+  const { breadcrumbs, nextPage, prevPage } = useMemo(() => {
+    const pathSegments = getPathsFromRouter({ asPath: pathKey });
+    return getInAppSidebar(
+      pathSegments,
+      allSidebarContent,
+      selectedSdkContent,
+    );
+  }, [pathKey, allSidebarContent, selectedSdkContent]);
 
   // Update URL state when the SDK changes
   const handleSdkChange = (value: Language) => {

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -157,11 +157,7 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
 
   const { breadcrumbs, nextPage, prevPage } = useMemo(() => {
     const pathSegments = getPathsFromRouter({ asPath: pathKey });
-    return getInAppSidebar(
-      pathSegments,
-      allSidebarContent,
-      selectedSdkContent,
-    );
+    return getInAppSidebar(pathSegments, allSidebarContent, selectedSdkContent);
   }, [pathKey, allSidebarContent, selectedSdkContent]);
 
   // Update URL state when the SDK changes

--- a/layouts/InAppUILayout.tsx
+++ b/layouts/InAppUILayout.tsx
@@ -16,7 +16,7 @@ import {
   type SdkSpecificContent,
 } from "../data/sidebars/inAppSidebar";
 import Meta from "../components/Meta";
-import { getInAppSidebar, slugToPaths } from "../lib/content";
+import { getInAppSidebar, getPathsFromRouter } from "../lib/content";
 import { Box } from "@telegraph/layout";
 import { Stack } from "@telegraph/layout";
 import { Select } from "@telegraph/select";
@@ -140,7 +140,7 @@ const InAppSidebar = ({
 
 const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
   const scrollerRef = useRef<HTMLDivElement>(null);
 
   const [selectedSdk, setSelectedSdk] = useState<Language>(() => {
@@ -154,7 +154,6 @@ const InAppUILayout = ({ frontMatter, sourcePath, children }) => {
   const selectedSdkContent = languageMap[selectedSdk];
   const allSidebarContent = [...IN_APP_UI_SIDEBAR, ...selectedSdkContent.items];
 
-  // @ts-expect-error we do get these, need to come back to breadcrumbs
   const { breadcrumbs, nextPage, prevPage } = useMemo(
     () => getInAppSidebar(paths, allSidebarContent, selectedSdkContent),
     [paths, allSidebarContent, selectedSdkContent],

--- a/layouts/IntegrationsLayout.tsx
+++ b/layouts/IntegrationsLayout.tsx
@@ -11,7 +11,8 @@ import { useScrollToTop } from "../hooks/useScrollToTop";
 
 const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  const paths = getPathsFromRouter(router);
+  const pathKey = router.asPath.split("#")[0].split("?")[0];
+  const paths = getPathsFromRouter({ asPath: pathKey });
 
   useScrollToTop(paths);
 
@@ -22,13 +23,17 @@ const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
     // For example, the Sources > Segment page has the following router slug:
     // ['integrations', 'sources', 'segment'] which needs to become
     // ['integrations/sources', 'segment'] so that it matches the sidebar content
-    let sidebarPaths = paths;
-    if (paths.length > 2) {
-      sidebarPaths = [`${paths[0]}/${paths[1]}`, ...paths.slice(2)];
+    const pathSegments = getPathsFromRouter({ asPath: pathKey });
+    let sidebarPaths = pathSegments;
+    if (pathSegments.length > 2) {
+      sidebarPaths = [
+        `${pathSegments[0]}/${pathSegments[1]}`,
+        ...pathSegments.slice(2),
+      ];
     }
 
     return getSidebarInfo(sidebarPaths, INTEGRATIONS_SIDEBAR, parentSection);
-  }, [paths]);
+  }, [pathKey]);
 
   return (
     <Page.Container>

--- a/layouts/IntegrationsLayout.tsx
+++ b/layouts/IntegrationsLayout.tsx
@@ -5,13 +5,13 @@ import {
   parentSection,
 } from "../data/sidebars/integrationsSidebar";
 import Meta from "../components/Meta";
-import { getSidebarInfo, slugToPaths } from "../lib/content";
+import { getPathsFromRouter, getSidebarInfo } from "../lib/content";
 import { Page } from "@/components/ui/Page";
 import { useScrollToTop } from "../hooks/useScrollToTop";
 
 const IntegrationsLayout = ({ frontMatter, sourcePath, children }) => {
   const router = useRouter();
-  let paths = slugToPaths(router.query.slug);
+  const paths = getPathsFromRouter(router);
 
   useScrollToTop(paths);
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -21,9 +21,8 @@ export const asPathToPaths = (asPath: string): string[] =>
 // can leave router.query.slug set to the /_next/data/... JSON fetch path
 // (e.g. ["_next", "data", "<buildId>", "concepts", "workflows.json"]) instead
 // of the real page slug. asPath stays correct across those transitions.
-export const getPathsFromRouter = (router: {
-  asPath: string;
-}): string[] => asPathToPaths(router.asPath);
+export const getPathsFromRouter = (router: { asPath: string }): string[] =>
+  asPathToPaths(router.asPath);
 
 // TODO: Make this generic. This is a hack right now and it won't work for arbitrary paths.
 export function getInAppSidebar(

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -12,6 +12,23 @@ export const slugToPaths = (slug: string | string[] | undefined): string[] => {
   }
 };
 
+// Converts a Next.js asPath (e.g. "/concepts/workflows?x=1#hash") to path segments
+export const asPathToPaths = (asPath: string): string[] =>
+  asPath.split("#")[0].split("?")[0].split("/").filter(Boolean);
+
+// Prefer router.query.slug when present; fall back to asPath when query is not
+// ready yet (common on the first client render of statically generated pages).
+export const getPathsFromRouter = (router: {
+  query: { slug?: string | string[] };
+  asPath: string;
+}): string[] => {
+  const fromQuery = slugToPaths(router.query.slug);
+  if (fromQuery.length > 0) {
+    return fromQuery;
+  }
+  return asPathToPaths(router.asPath);
+};
+
 // TODO: Make this generic. This is a hack right now and it won't work for arbitrary paths.
 export function getInAppSidebar(
   paths: string[],
@@ -21,6 +38,10 @@ export function getInAppSidebar(
   if (!paths.includes(selectedSdkContent.value)) {
     return getSidebarInfo(paths, allSidebarContent);
   }
+
+  // Resolve adjacent pages from the full sidebar so SDK-specific pages get
+  // next/previous navigation as well as breadcrumbs.
+  const { prevPage, nextPage } = getSidebarInfo(paths, allSidebarContent);
 
   // Get the deepest page that matches the paths
   const { section, page } = depthFirstSidebarInfo(paths, allSidebarContent);
@@ -50,6 +71,8 @@ export function getInAppSidebar(
           ]
         : []),
     ],
+    prevPage,
+    nextPage,
   };
 }
 
@@ -187,12 +210,17 @@ export const getSidebarInfo = (
     (page) => page.path === `/${paths.join("/")}`,
   );
 
-  if (flatIndex > 0) {
-    prevPage = flatSidebar[flatIndex - 1];
-  }
+  // flatIndex is -1 when the current path is not in the sidebar (including when
+  // paths is empty because router.query is not ready). Guard against treating
+  // -1 as a valid index, which would incorrectly set nextPage to the first item.
+  if (flatIndex >= 0) {
+    if (flatIndex > 0) {
+      prevPage = flatSidebar[flatIndex - 1];
+    }
 
-  if (flatIndex < flatSidebar.length - 1) {
-    nextPage = flatSidebar[flatIndex + 1];
+    if (flatIndex < flatSidebar.length - 1) {
+      nextPage = flatSidebar[flatIndex + 1];
+    }
   }
 
   return {

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -1,17 +1,6 @@
 import { SdkSpecificContent } from "@/data/sidebars/inAppSidebar";
 import { SidebarContent, SidebarPage, SidebarSection } from "../data/types";
 
-// Converts a Next.js router slug to a paths array
-export const slugToPaths = (slug: string | string[] | undefined): string[] => {
-  if (!slug) {
-    return [];
-  } else if (typeof slug == "string") {
-    return [slug];
-  } else {
-    return slug;
-  }
-};
-
 // Converts a Next.js asPath (e.g. "/concepts/workflows?x=1#hash") to path segments
 export const asPathToPaths = (asPath: string): string[] =>
   asPath.split("#")[0].split("?")[0].split("/").filter(Boolean);

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -16,18 +16,14 @@ export const slugToPaths = (slug: string | string[] | undefined): string[] => {
 export const asPathToPaths = (asPath: string): string[] =>
   asPath.split("#")[0].split("?")[0].split("/").filter(Boolean);
 
-// Prefer router.query.slug when present; fall back to asPath when query is not
-// ready yet (common on the first client render of statically generated pages).
+// Resolve path segments from the router for sidebar/adjacent-page lookups.
+// Always use asPath — on the root [...slug] catch-all, client-side navigations
+// can leave router.query.slug set to the /_next/data/... JSON fetch path
+// (e.g. ["_next", "data", "<buildId>", "concepts", "workflows.json"]) instead
+// of the real page slug. asPath stays correct across those transitions.
 export const getPathsFromRouter = (router: {
-  query: { slug?: string | string[] };
   asPath: string;
-}): string[] => {
-  const fromQuery = slugToPaths(router.query.slug);
-  if (fromQuery.length > 0) {
-    return fromQuery;
-  }
-  return asPathToPaths(router.asPath);
-};
+}): string[] => asPathToPaths(router.asPath);
 
 // TODO: Make this generic. This is a hack right now and it won't work for arbitrary paths.
 export function getInAppSidebar(


### PR DESCRIPTION
Fixes forward / back buttons:
<img width="911" height="237" alt="Screenshot 2026-07-21 at 2 38 22 PM" src="https://github.com/user-attachments/assets/ed77d798-efb1-44d4-87a1-f12e2e0eddb9" />

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes incorrect bottom next/previous navigation on docs pages.

### Root cause

Two related bugs:

1. **Hard load / empty query.** When `router.query.slug` was empty, `getSidebarInfo` got `flatIndex === -1` and still treated that as a valid index, setting **Next** to the first sidebar page (often "Overview") with no **Previous**.

2. **Client-side navigation.** On the root `[...slug]` catch-all, soft navigations can leave `router.query.slug` set to the `/_next/data/<buildId>/...json` fetch path, e.g. `["_next", "data", "<buildId>", "concepts", "workflows.json"]`, while `asPath` correctly stays `/concepts/workflows`. Preferring `query.slug` then failed the sidebar lookup, so Previous/Next disappeared after clicking Next (only "Send feedback" remained).

### Changes

- Guard adjacent-page lookup so `flatIndex === -1` does not invent a next page
- Resolve path segments from `asPath` only (never `query.slug`) via `getPathsFromRouter`
- Key layout memoization off the cleaned `asPath` string
- Return `prevPage` / `nextPage` from `getInAppSidebar` for SDK-specific pages

Supersedes #1556 (that PR preferred `query.slug` and broke after client-side nav on the preview deployment).

## Test plan

- [x] Hard-load `/concepts/overview` — Previous: Example apps, Next: Workflows
- [x] Click **Next** (client-side nav) — Previous: Overview, Next: Broadcasts still render
- [x] Click **Next** again — Previous: Workflows, Next: Guides
- [x] Confirm polluted `query.slug` (`_next/data/...`) no longer breaks footer neighbors
- [ ] Hard-refresh `/developer-tools/api-keys` and `/tutorials/alerting` — no collapse to Next: Overview
- [ ] Confirm `/in-app-ui/react/overview` shows Previous and Next
- [ ] Confirm first sidebar page has no Previous, last page has no Next

### Verification screenshots (Vercel preview)

Hard load `/concepts/overview`:

[Overview footer nav](https://cursor.com/agents/bc-9a7b56ef-c8bc-4c04-906a-3bfa90e8c3b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Foverview-nav.webp)

After client-side Next → `/concepts/workflows`:

[Workflows footer nav after client nav](https://cursor.com/agents/bc-9a7b56ef-c8bc-4c04-906a-3bfa90e8c3b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fworkflows-nav-after-client-nav.webp)

After second client-side Next → `/concepts/broadcasts`:

[Broadcasts footer nav after second client nav](https://cursor.com/agents/bc-9a7b56ef-c8bc-4c04-906a-3bfa90e8c3b9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbroadcasts-nav-after-second-client-nav.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14307](https://linear.app/knock/issue/KNO-14307/docs-nextprevious-page-buttons-are-incorrect)

<div><a href="https://cursor.com/agents/bc-9a7b56ef-c8bc-4c04-906a-3bfa90e8c3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a7b56ef-c8bc-4c04-906a-3bfa90e8c3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

