### PR TITLE
chore(kno-14317): clarify ms teams channel data docs to match slack updates

### DIFF
--- a/content/integrations/chat/microsoft-teams/overview.mdx
+++ b/content/integrations/chat/microsoft-teams/overview.mdx
@@ -228,6 +228,17 @@ Here's an example of setting channel data on an `Object` in Knock.
   }
 />
 
+### How Teams delivery works
+
+When you're sending as a Microsoft Teams bot, every notification needs two things, and Knock lets them live in different places:
+
+- **Scope** — which Microsoft Entra tenant to reach: the `ms_teams_tenant_id`.
+- **Destination** — where the message goes: a `ms_teams_channel_id` (a channel) or a `ms_teams_user_id` (a direct message).
+
+The **destination** is stored on the recipient (a [`User`](/concepts/users) or [`Object`](/concepts/objects)). The **scope** can be stored on the recipient too — or, in a multi-workspace product, once on the [tenant](#tenant-channel-data-requirements), so every recipient in that tenant shares the same Entra tenant ID. The two sections below cover each location.
+
+If you're using an incoming webhook instead of a bot, none of the above applies: the webhook URL is self-contained and requires no scope or destination.
+
 ### Recipient channel data requirements
 
 Here's an overview of the data requirements for [setting recipient channel data](/send-notifications/setting-channel-data) for either an incoming webhook URL or a Microsoft Teams bot connection. Both will need to live under the `connections` key.
@@ -263,7 +274,9 @@ An `MsTeamsConnection` can have one of two schemas, depending on whether you're 
 
 ### Tenant channel data requirements
 
-When you [map a Microsoft Entra tenant to a Knock tenant](/integrations/chat/microsoft-teams/sending-a-message-to-channels#key-concepts), you'll store the ID of the Microsoft Entra tenant as `channel_data` on the Knock tenant. Then, when you apply the Knock `tenant` to your workflow triggers, Knock will [combine that Microsoft Entra tenant ID with the recipient's](/integrations/chat/microsoft-teams/sending-a-message-to-channels#merging-channel-data) `channel_data` to send notifications to the correct Microsoft Teams channel within a Microsoft Entra tenant. For this implementation method, the `ms_teams_tenant_id` on the recipient's `MsTeamsConnection[]` data above is not required.
+When you [map a Microsoft Entra tenant to a Knock tenant](/integrations/chat/microsoft-teams/sending-a-message-to-channels#key-concepts) (as our [TeamsKit](/in-app-ui/react/teams-kit) components do), you store that Entra tenant's ID as `channel_data` on the Knock tenant. At send time, when you trigger a workflow with that `tenant`, Knock takes the [destination](#how-teams-delivery-works) from the recipient's `channel_data` (the `ms_teams_channel_id` or `ms_teams_user_id`) and uses the tenant's `ms_teams_tenant_id` for scope: the tenant provides the scope, the recipient provides the destination. If the recipient also carries an `ms_teams_tenant_id`, the tenant's takes precedence — so the `ms_teams_tenant_id` on the recipient's `MsTeamsConnection[]` above is not required when a tenant holds one.
+
+**Do you need a tenant?** Store the Entra tenant ID on a Knock tenant when one Microsoft Entra tenant connection should serve every recipient or object in that Knock tenant. This keeps the Entra tenant ID in one place while each recipient or object stores only its Teams destination (`ms_teams_channel_id` or `ms_teams_user_id`), which is useful as you add more destinations within the same Entra tenant later. You don't need a Knock tenant if you post to a single internal workspace (use an incoming webhook — there's no Entra tenant ID to share) or only ever use one Entra tenant's ID and prefer to store it directly on each recipient or object. Knock never auto-creates a `tenant` for you (though TeamsKit can, on the fly), so use one when a shared Entra tenant ID should live at the `tenant` level.
 
 Here's an overview of the data requirements for setting channel data when storing a Microsoft Entra tenant ID on a Knock tenant.
 

--- a/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-direct-message.mdx
@@ -20,7 +20,7 @@ TeamsKit connects multiple concepts in Knock to make it easier for your applicat
 
 ### About tenants
 
-[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a typical implementation using TeamsKit, you'll store <a href="https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant" target="_blank">the ID of a Microsoft Entra tenant</a> on a corresponding tenant in Knock.
+[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a typical implementation using TeamsKit, you'll store <a href="https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant" target="_blank">the ID of a Microsoft Entra tenant</a> on a corresponding tenant in Knock. See [how the tenant's Entra tenant ID is used at send time](/integrations/chat/microsoft-teams/overview#tenant-channel-data-requirements) for the full model.
 
 If you already use Knock's tenant concept to power other 'account-based' features, you likely create tenants in Knock when an account or organization is created in your application. If you don't already use tenants in Knock, TeamsKit can create tenants for you on the fly if they don't already exist.
 
@@ -42,7 +42,7 @@ If you already use Knock's tenant concept to power other 'account-based' feature
 
 In this implementation, we'll actually store [the required channel data](/integrations/chat/microsoft-teams/overview#how-to-set-channel-data-for-a-microsoft-teams-integration-in-knock) for an `MsTeamsConnection` across two different entities in Knock: a `Tenant` and an `User`. This is because we want to store the `ms_teams_tenant_id` for the Microsoft Entra tenant on the Knock `Tenant` and the `ms_teams_user_id` for the Microsoft Teams user on the Knock `User`.
 
-When you trigger a workflow using this recipient and tenant, Knock will merge the channel data from the `Tenant` and the `User` to send the message to the correct Microsoft Teams user. By storing the `ms_teams_tenant_id` on the Knock `Tenant`, your customers only need to complete the OAuth flow once to connect their Microsoft Teams instances to Knock. From there, you can create UI that allows users to link their Microsoft Teams user ID to their Knock user ID or automate this process during user registration.
+When you trigger a workflow using this recipient and tenant, Knock uses the destination stored on the `User` (the `ms_teams_user_id`) and the Entra tenant ID (`ms_teams_tenant_id`) stored on the `Tenant` for scope — if the user also carries an Entra tenant ID, the tenant's takes precedence (see [scope vs. destination](/integrations/chat/microsoft-teams/overview#how-teams-delivery-works)). By storing the `ms_teams_tenant_id` on the Knock `Tenant`, your customers only need to complete the OAuth flow once to connect their Microsoft Entra tenant to Knock. From there, you can create UI that allows users to link their Microsoft Teams user ID to their Knock user ID or automate this process during user registration.
 
 ## Adding required scopes to your app's manifest
 

--- a/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
+++ b/content/integrations/chat/microsoft-teams/sending-a-message-to-channels.mdx
@@ -31,7 +31,7 @@ TeamsKit connects multiple concepts in Knock to make it easier for your users to
 
 ### About tenants
 
-[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a typical implementation using TeamsKit, you'll store <a href="https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant" target="_blank">the ID of a Microsoft Entra tenant</a> on a corresponding tenant in Knock.
+[Tenants](/concepts/tenants) in Knock are meant to represent groups of users who typically share the same resources. You might call these "accounts," "organizations," "workspaces," or something similar. In a typical implementation using TeamsKit, you'll store <a href="https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-create-new-tenant" target="_blank">the ID of a Microsoft Entra tenant</a> on a corresponding tenant in Knock. See [how the tenant's Entra tenant ID is used at send time](/integrations/chat/microsoft-teams/overview#tenant-channel-data-requirements) for the full model.
 
 If you already use Knock's tenant concept to power other 'account-based' features, you likely create tenants in Knock when an account or organization is created in your application. If you don't already use tenants in Knock, TeamsKit can create tenants for you on the fly if they don't already exist.
 
@@ -92,7 +92,7 @@ await knockClient.workflows.trigger("new-issue", {
 
 In this implementation, we'll actually store [the required channel data](/integrations/chat/microsoft-teams/overview#how-to-set-channel-data-for-a-microsoft-teams-integration-in-knock) for an `MsTeamsConnection` across two different entities in Knock: a `Tenant` and an `Object`. This is because we want to store the `ms_teams_tenant_id` for the Microsoft Entra tenant on the Knock `Tenant` and the `ms_teams_channel_id` for the Microsoft Teams channel on the Knock `Object`.
 
-When you trigger a workflow using this recipient and tenant, Knock will merge the channel data from the `Tenant` and the `Object` to send the message to the correct Microsoft Teams channel. By storing the `ms_teams_tenant_id` on the Knock `Tenant`, your customers only need to complete the OAuth flow once to connect their Microsoft Teams instances to Knock.
+When you trigger a workflow using this recipient and tenant, Knock uses the destination stored on the `Object` (the `ms_teams_channel_id`) and the Entra tenant ID (`ms_teams_tenant_id`) stored on the `Tenant` for scope — if the object also carries an Entra tenant ID, the tenant's takes precedence (see [scope vs. destination](/integrations/chat/microsoft-teams/overview#how-teams-delivery-works)). By storing the `ms_teams_tenant_id` on the Knock `Tenant`, your customers only need to complete the OAuth flow once to connect their Microsoft Entra tenant to Knock.
 
 ## Adding required scopes to your app's manifest
 

--- a/content/managing-recipients/setting-channel-data.mdx
+++ b/content/managing-recipients/setting-channel-data.mdx
@@ -254,12 +254,12 @@ The `PushDevice` object is used to optionally set device-level metadata for a pu
     `ms_teams_channel_id` or `ms_teams_user_id` depending on whether you're storing connection data to message
     a channel or user in Microsoft Teams:
 
-    | Property            | Type     | Description                    |
-    | ------------------- | -------- | ------------------------------ |
-    | ms_teams_tenant_id  | `string` | A Microsoft Entra tenant ID    |
-    | ms_teams_team_id    | `string` | A Microsoft Teams team ID      |
-    | ms_teams_channel_id | `string` | A Microsoft Teams channel ID   |
-    | ms_teams_user_id    | `string` | A Microsoft Teams user ID      |
+    | Property            | Type     | Description                                                                                                                              |
+    | ------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+    | ms_teams_tenant_id  | `string` | A Microsoft Entra tenant ID. Not required when stored on a [tenant](/integrations/chat/microsoft-teams/overview#tenant-channel-data-requirements). |
+    | ms_teams_team_id    | `string` | A Microsoft Teams team ID                                                                                                                    |
+    | ms_teams_channel_id | `string` | A Microsoft Teams channel ID                                                                                                                 |
+    | ms_teams_user_id    | `string` | A Microsoft Teams user ID                                                                                                                    |
 
     If you're using an incoming webhook, your `MsTeamsConnection` schema is quite simple:
 


### PR DESCRIPTION
### Description

This PR adds similar clarifications for MS Teams channel data as the ones made in #1543.

- New **"How Teams delivery works"** section on the Teams overview splits a bot-based Teams connection into its two halves — scope (the Microsoft Entra ms_teams_tenant_id) and destination (`ms_teams_channel_id`/`ms_teams_user_id`) — and says where each lives.
- Rewrites the **"Tenant channel data requirements"** section to state the actual precedence rule — the tenant's `ms_teams_tenant_id` wins over any Entra tenant ID on the recipient (verified against the send-path code, which overwrites the recipient's `ms_teams_tenant_id` with the tenant's on every connection) — instead of the ambiguous "combine." Adds a **"Do you need a tenant?"** note so readers with a single internal workspace aren't over-steered toward tenants.
- Fixes the cross-referencing gap across the **"Merging channel data"** sections in both the sending-to-channels and direct-message pages, replacing "merge" language with the explicit scope/destination precedence and adding a parenthetical `ms_teams_tenant_id` reference so readers can tie the prose back to the schema. Also links back to the canonical section from each page's **"About tenants."**
- Fixes the setting-channel-data schema gap — the `ms_teams_tenant_id` row in the Microsoft Teams `channel_data` table had no note that it's unnecessary on the recipient when a tenant holds it.