### PR TITLE
docs: add workflow recipient run webhook events

### DIFF
--- a/content/developer-tools/outbound-webhooks/event-types.mdx
+++ b/content/developer-tools/outbound-webhooks/event-types.mdx
@@ -274,6 +274,64 @@ Occurs when a link is clicked by the message recipient. This is only available w
   </Attribute>
 </Attributes>
 
+## Workflow recipient run events
+
+<Callout
+  type="beta"
+  title="Beta feature."
+  text={
+    <>
+      Workflow recipient run webhooks are currently in beta and enabled on an
+      on-demand basis. To request access for your account,{" "}
+      <a href="mailto:support@knock.app?subject=Workflow recipient run webhooks">
+        get in touch
+      </a>
+      .
+    </>
+  }
+/>
+
+A [workflow recipient run](/concepts/workflows#workflow-runs-and-recipients) represents the execution of a workflow for a single recipient. Use these events to respond when a recipient's workflow run starts, completes, or encounters an error. You can also inspect runs via the [workflow recipient runs API](/api-reference/workflow_recipient_runs).
+
+### `workflow_recipient_run.started`
+
+Occurs when a workflow recipient run begins execution.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="WorkflowRecipientRun"
+    description="The associated workflow recipient run."
+    typeSlug="/api-reference/workflow_recipient_runs/schemas/workflow_recipient_run"
+  />
+</Attributes>
+
+### `workflow_recipient_run.completed`
+
+Occurs when a workflow recipient run completes.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="WorkflowRecipientRun"
+    description="The associated workflow recipient run."
+    typeSlug="/api-reference/workflow_recipient_runs/schemas/workflow_recipient_run"
+  />
+</Attributes>
+
+### `workflow_recipient_run.error`
+
+Occurs when an error is encountered during a workflow recipient run.
+
+<Attributes>
+  <Attribute
+    name="data"
+    type="WorkflowRecipientRun"
+    description="The associated workflow recipient run."
+    typeSlug="/api-reference/workflow_recipient_runs/schemas/workflow_recipient_run"
+  />
+</Attributes>
+
 ## Workflow events
 
 ### `workflow.updated`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Documents the new `workflow_recipient_run.{started, completed, error}` outbound webhook events shipped in knocklabs/control#10382.

Adds a **Workflow recipient run events** section to the webhook event types page with:

- Event definitions for `started`, `completed`, and `error`, each with a `WorkflowRecipientRun` `data` payload
- A beta callout noting these events are enabled on demand, with a link to get in touch at `support@knock.app`
- Links to the workflow recipient run concept docs and API reference

### Todos

- [ ] Confirm whether any of these events include `event_data` fields that should be documented (no access to the private control PR payload details from this environment)

### Tasks

Related: https://github.com/knocklabs/control/pull/10382

### Screenshots

N/A (docs-only change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-163b4727-a117-4182-8cd1-45bf06c95cb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-163b4727-a117-4182-8cd1-45bf06c95cb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

