### PR TITLE
chore: remove callout re: dist/index.css import for toolbar 

### DIFF
--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -30,6 +30,17 @@ To ensure consistency between the dashboard's template preview and the guide com
 
 The guides toolbar is a floating panel that enables you to inspect and debug guides on any page of your application. Use it to understand why a guide is or isn't showing in a given context, force guides to display for testing, and inspect the targeting parameters being evaluated for the current user.
 
+<Callout
+  type="warning"
+  title="Technical requirements."
+  text={
+    <>
+      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.12.01.
+    </>
+
+}
+/>
+
 ### Activating the toolbar
 
 1. In the Knock dashboard, click the **Preview** option above your list of guides, or at the top of the guide editor's preview pane.

--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -30,17 +30,6 @@ To ensure consistency between the dashboard's template preview and the guide com
 
 The guides toolbar is a floating panel that enables you to inspect and debug guides on any page of your application. Use it to understand why a guide is or isn't showing in a given context, force guides to display for testing, and inspect the targeting parameters being evaluated for the current user.
 
-<Callout
-  type="warning"
-  title="Technical requirements."
-  text={
-    <>
-      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.11.13 or higher and import <code>@knocklabs/react/dist/index.css</code>.
-    </>
-
-}
-/>
-
 ### Activating the toolbar
 
 1. In the Knock dashboard, click the **Preview** option above your list of guides, or at the top of the guide editor's preview pane.

--- a/content/in-app-ui/guides/debugging-guides.mdx
+++ b/content/in-app-ui/guides/debugging-guides.mdx
@@ -35,7 +35,7 @@ The guides toolbar is a floating panel that enables you to inspect and debug gui
   title="Technical requirements."
   text={
     <>
-      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.12.01.
+      To use the guides toolbar, your application must use <code>@knocklabs/react</code> v0.12.01 or higher.
     </>
 
 }


### PR DESCRIPTION
### Description

Updates the callout to use [knocklabs/react 0.12.1](https://www.npmjs.com/package/@knocklabs/react/v/0.12.1) for guide toolbar. Also removes the bit about having to import dist/index.css, as it injects its own subset of css necessary to render and no longer requires an explicit import.