### PR TITLE
feat(KNO-14428): document OpenAPI endpoints in API intros

### DIFF
--- a/content/__api-reference/content.mdx
+++ b/content/__api-reference/content.mdx
@@ -113,6 +113,21 @@ Knock offers native SDKs in several popular programming languages:
 </ContentColumn>
 </Section>
 
+<Section title="OpenAPI" slug="openapi" path="/overview/openapi">
+<ContentColumn>
+
+Knock publishes an [OpenAPI](https://spec.openapis.org/oas/latest.html) document for the API. Use it to generate clients, import the API into tools like Postman or Insomnia, or inspect request and response schemas.
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="OpenAPI document"
+https://api.knock.app/v1/openapi
+```
+
+</ExampleColumn>
+</Section>
+
 <Section title="API keys" slug="api-keys" path="/overview/api-keys">
 <ContentColumn>
 

--- a/content/__mapi-reference/content.mdx
+++ b/content/__mapi-reference/content.mdx
@@ -74,6 +74,21 @@ Knock offers a Node.js SDK for the management API:
 </ContentColumn>
 </Section>
 
+<Section title="OpenAPI" slug="openapi" path="/overview/openapi">
+<ContentColumn>
+
+Knock publishes an [OpenAPI](https://spec.openapis.org/oas/latest.html) document for the Management API. Use it to generate clients, import the API into tools like Postman or Insomnia, or inspect request and response schemas.
+
+</ContentColumn>
+<ExampleColumn>
+
+```bash title="OpenAPI document"
+https://control.knock.app/v1/openapi
+```
+
+</ExampleColumn>
+</Section>
+
 <Section title="Authentication" slug="authentication" path="/overview/authentication">
 <ContentColumn>
 

--- a/data/sidebars/apiOverviewSidebar.ts
+++ b/data/sidebars/apiOverviewSidebar.ts
@@ -24,6 +24,7 @@ export const API_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [
     pages: [
       { slug: "/", title: "Overview" },
       { slug: "/client-libraries", title: "Client libraries" },
+      { slug: "/openapi", title: "OpenAPI" },
       { slug: "/api-keys", title: "API keys" },
       { slug: "/authentication", title: "Authentication" },
       { slug: "/rate-limits", title: "Rate limits" },

--- a/data/sidebars/mapiOverviewSidebar.ts
+++ b/data/sidebars/mapiOverviewSidebar.ts
@@ -37,6 +37,10 @@ export const MAPI_REFERENCE_OVERVIEW_CONTENT: SidebarSection[] = [
         slug: `/client-libraries`,
       },
       {
+        title: "OpenAPI",
+        slug: `/openapi`,
+      },
+      {
         title: "Authentication",
         slug: `/authentication`,
       },

--- a/next.config.js
+++ b/next.config.js
@@ -71,6 +71,13 @@ const nextConfig = {
 
   async redirects() {
     return [
+      // RFC 9727: docs is a discovery host; canonical API catalog lives on knock.app.
+      // Permanent redirect (308) keeps a single source of truth for the catalog.
+      {
+        source: "/.well-known/api-catalog",
+        destination: "https://knock.app/.well-known/api-catalog",
+        permanent: true,
+      },
       {
         source: "/developer-tools/integrating-into-cicd",
         destination: "/tutorials/integrating-into-cicd",


### PR DESCRIPTION
Adds a redirect to root domain API catalog for resource discovery. Also adds OpenAPI section to API and mAPI.

<img width="1162" height="308" alt="Screenshot 2026-07-24 at 2 21 03 PM 1" src="https://github.com/user-attachments/assets/e3d826dd-cbca-47aa-ad75-7f1c11fff7c4" />

## Before / after

| | API catalog |
| --- | --- |
| Before | https://docs.knock.app/.well-known/api-catalog |
| After | https://docs-git-mc-openapi-docs-intro-knocklabs.vercel.app/.well-known/api-catalog → https://knock.app/.well-known/api-catalog |