### PR TITLE
Unfurl MultiLangCodeBlock examples in generated markdown

### DIFF
--- a/components/ui/MultiLangCodeBlock.tsx
+++ b/components/ui/MultiLangCodeBlock.tsx
@@ -6,6 +6,11 @@ import { useEffect, useMemo } from "react";
 import { useIsMounted } from "../../hooks/useIsMounted";
 import useLocalStorage from "../../hooks/useLocalStorage";
 import { useEventEmitter } from "../../lib/eventEmitter";
+import {
+  getSnippetLanguages,
+  PREFERRED_SNIPPET_LANGUAGE,
+  snippets,
+} from "../../data/code/snippets";
 import { CodeBlock, SupportedLanguage } from "./CodeBlock";
 
 type Props = {
@@ -16,148 +21,12 @@ type Props = {
 export const LOCAL_STORAGE_KEY = "@knocklabs/example-lang";
 export const EVENT_NAME = "language.change";
 
-const snippets = {
-  "api.idempotency": require("../../data/code/api/idempotency").default,
-  "sdks.install": require("../../data/code/sdks/install").default,
-  // Users
-  "users.bulkIdentify": require("../../data/code/users/bulk-identify").default,
-  "users.bulkDelete": require("../../data/code/users/bulk-delete").default,
-  "users.identify": require("../../data/code/users/identify").default,
-  "users.get": require("../../data/code/users/get").default,
-  "users.delete": require("../../data/code/users/delete").default,
-  "users.merge": require("../../data/code/users/merge").default,
-  "users.messages": require("../../data/code/users/messages").default,
-  "users.setPreferences": require("../../data/code/users/set-preferences")
-    .default,
-  "users.setPreferences.conditions":
-    require("../../data/code/users/set-preferences-with-conditions").default,
-  "users.setPreferences.perTenant":
-    require("../../data/code/users/set-preferences-per-tenant").default,
-  "users.bulkSetPreferences":
-    require("../../data/code/users/bulk-set-preferences").default,
-  "users.listPreferences": require("../../data/code/users/list-preferences")
-    .default,
-  "users.getPreferences": require("../../data/code/users/get-preferences")
-    .default,
-  "users.getChannelData": require("../../data/code/users/get-channel-data")
-    .default,
-  "users.setChannelData": require("../../data/code/users/set-channel-data")
-    .default,
-  "users.setChannelDataDevices":
-    require("../../data/code/users/set-channel-data-devices").default,
-  "users.setChannelData-push":
-    require("../../data/code/users/set-channel-data-push").default,
-  "users.setChannelData-one-signal":
-    require("../../data/code/users/set-channel-data-one-signal").default,
-  "users.setChannelData-aws-sns":
-    require("../../data/code/users/set-channel-data-aws-sns").default,
-  "users.unsetChannelData": require("../../data/code/users/unset-channel-data")
-    .default,
-  "users.identifyChannelData":
-    require("../../data/code/users/identify-channel-data").default,
-
-  // Messages
-  "messages.list": require("../../data/code/messages/list").default,
-  "messages.get": require("../../data/code/messages/get").default,
-  "messages.getActivities": require("../../data/code/messages/get-activities")
-    .default,
-  "messages.getContent": require("../../data/code/messages/get-content")
-    .default,
-  "messages.getEvents": require("../../data/code/messages/get-events").default,
-
-  // Objects
-  "objects.list": require("../../data/code/objects/list").default,
-  "objects.set": require("../../data/code/objects/set").default,
-  "objects.get": require("../../data/code/objects/get").default,
-  "objects.delete": require("../../data/code/objects/delete").default,
-  "objects.bulkSet": require("../../data/code/objects/bulk-set").default,
-  "objects.bulkDelete": require("../../data/code/objects/bulk-delete").default,
-  "objects.messages": require("../../data/code/objects/messages").default,
-  "objects.setChannelData.slack":
-    require("../../data/code/objects/set-channel-data-slack").default,
-  "objects.setChannelData.msTeams":
-    require("../../data/code/objects/set-channel-data-ms-teams").default,
-  "objects.setChannelData.discord.webhook":
-    require("../../data/code/objects/set-channel-data-discord-webhook").default,
-  "objects.setChannelData.discord.bot":
-    require("../../data/code/objects/set-channel-data-discord-bot").default,
-  "objects.unsetChannelData":
-    require("../../data/code/objects/unset-channel-data").default,
-  "objects.getChannelData": require("../../data/code/objects/get-channel-data")
-    .default,
-  "objects.listPreferences": require("../../data/code/objects/list-preferences")
-    .default,
-  "objects.getPreferences": require("../../data/code/objects/get-preferences")
-    .default,
-  "objects.setPreferences": require("../../data/code/objects/set-preferences")
-    .default,
-
-  // Tenants
-  "tenants.list": require("../../data/code/tenants/list").default,
-  "tenants.get": require("../../data/code/tenants/get").default,
-  "tenants.set": require("../../data/code/tenants/set").default,
-  "tenants.delete": require("../../data/code/tenants/delete").default,
-
-  // Workflows
-  "workflows.cancel": require("../../data/code/workflows/cancel").default,
-  "workflows.cancel-with-recipients":
-    require("../../data/code/workflows/cancel-with-recipients").default,
-  "workflows.trigger": require("../../data/code/workflows/trigger").default,
-  "workflows.trigger-with-identification":
-    require("../../data/code/workflows/trigger-with-identification").default,
-  "workflows.trigger-with-user-identification":
-    require("../../data/code/workflows/trigger-with-user-identification")
-      .default,
-  "workflows.trigger-with-object-identification":
-    require("../../data/code/workflows/trigger-with-object-identification")
-      .default,
-  "workflows.trigger-with-actor":
-    require("../../data/code/workflows/trigger-with-actor").default,
-  "workflows.trigger-with-object-as-recipient":
-    require("../../data/code/workflows/trigger-with-object-as-recipient")
-      .default,
-  "workflows.trigger-with-object-as-actor":
-    require("../../data/code/workflows/trigger-with-object-as-actor").default,
-  "workflows.trigger-with-tenant":
-    require("../../data/code/workflows/trigger-with-tenant").default,
-  "workflows.trigger-with-branding-tenant":
-    require("../../data/code/workflows/trigger-with-branding-tenant").default,
-  "workflows.trigger-with-attachment":
-    require("../../data/code/workflows/trigger-with-attachment").default,
-  "workflows.trigger-with-user-channel-data":
-    require("../../data/code/workflows/trigger-with-user-channel-data").default,
-  "workflows.trigger-with-user-preferences":
-    require("../../data/code/workflows/trigger-with-user-preferences").default,
-  "workflows.playground": require("../../data/code/workflows/playground")
-    .default,
-};
-/* eslint-enable */
-
-const DEFAULT_ORDER: SupportedLanguage[] = [
-  "curl",
-  "shell",
-  "node",
-  "javascript",
-  "jsweb",
-  "ruby",
-  "python",
-  "php",
-  "go",
-  "java",
-  "csharp",
-  "elixir",
-  "swift",
-  "kotlin",
-  "json",
-  "yaml",
-];
-
 const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet, ...props }) => {
   const isMounted = useIsMounted();
   const eventEmitter = useEventEmitter();
   const [language, setLanguage] = useLocalStorage<SupportedLanguage>(
     LOCAL_STORAGE_KEY,
-    "node",
+    PREFERRED_SNIPPET_LANGUAGE,
   );
 
   useEffect(() => {
@@ -174,7 +43,7 @@ const MultiLangCodeBlock: React.FC<Props> = ({ title, snippet, ...props }) => {
   // Set the list of languages in the switcher according to the languages in the snippet and ordered by the DEFAULT_ORDER
   const languages = useMemo(() => {
     const snippetCode = snippets[snippet];
-    return DEFAULT_ORDER.filter((key) => key in snippetCode);
+    return getSnippetLanguages(snippetCode);
   }, [snippet]);
 
   const content = useMemo(() => {

--- a/data/code/snippets.ts
+++ b/data/code/snippets.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared registry of multi-language example snippets used by
+ * `<MultiLangCodeBlock />` in the docs UI and by the LLM markdown converter.
+ *
+ * When unfurling a snippet into plain markdown we pick a single language so the
+ * generated pages stay readable. Preference matches the docs UI default (`node`),
+ * then falls back to the first language present in `DEFAULT_LANGUAGE_ORDER`.
+ */
+
+export type SnippetLanguage =
+  | "curl"
+  | "shell"
+  | "node"
+  | "javascript"
+  | "jsweb"
+  | "ruby"
+  | "python"
+  | "php"
+  | "go"
+  | "java"
+  | "csharp"
+  | "elixir"
+  | "swift"
+  | "kotlin"
+  | "json"
+  | "yaml";
+
+export type CodeSnippet = Partial<Record<SnippetLanguage, string>>;
+
+export const PREFERRED_SNIPPET_LANGUAGE: SnippetLanguage = "node";
+
+export const DEFAULT_LANGUAGE_ORDER: SnippetLanguage[] = [
+  "curl",
+  "shell",
+  "node",
+  "javascript",
+  "jsweb",
+  "ruby",
+  "python",
+  "php",
+  "go",
+  "java",
+  "csharp",
+  "elixir",
+  "swift",
+  "kotlin",
+  "json",
+  "yaml",
+];
+
+export const snippets: Record<string, CodeSnippet> = {
+  "api.idempotency": require("./api/idempotency").default,
+  "sdks.install": require("./sdks/install").default,
+  // Users
+  "users.bulkIdentify": require("./users/bulk-identify").default,
+  "users.bulkDelete": require("./users/bulk-delete").default,
+  "users.identify": require("./users/identify").default,
+  "users.get": require("./users/get").default,
+  "users.delete": require("./users/delete").default,
+  "users.merge": require("./users/merge").default,
+  "users.messages": require("./users/messages").default,
+  "users.setPreferences": require("./users/set-preferences").default,
+  "users.setPreferences.conditions":
+    require("./users/set-preferences-with-conditions").default,
+  "users.setPreferences.perTenant":
+    require("./users/set-preferences-per-tenant").default,
+  "users.bulkSetPreferences": require("./users/bulk-set-preferences").default,
+  "users.listPreferences": require("./users/list-preferences").default,
+  "users.getPreferences": require("./users/get-preferences").default,
+  "users.getChannelData": require("./users/get-channel-data").default,
+  "users.setChannelData": require("./users/set-channel-data").default,
+  "users.setChannelDataDevices": require("./users/set-channel-data-devices")
+    .default,
+  "users.setChannelData-push": require("./users/set-channel-data-push").default,
+  "users.setChannelData-one-signal":
+    require("./users/set-channel-data-one-signal").default,
+  "users.setChannelData-aws-sns": require("./users/set-channel-data-aws-sns")
+    .default,
+  "users.unsetChannelData": require("./users/unset-channel-data").default,
+  "users.identifyChannelData": require("./users/identify-channel-data").default,
+
+  // Messages
+  "messages.list": require("./messages/list").default,
+  "messages.get": require("./messages/get").default,
+  "messages.getActivities": require("./messages/get-activities").default,
+  "messages.getContent": require("./messages/get-content").default,
+  "messages.getEvents": require("./messages/get-events").default,
+
+  // Objects
+  "objects.list": require("./objects/list").default,
+  "objects.set": require("./objects/set").default,
+  "objects.get": require("./objects/get").default,
+  "objects.delete": require("./objects/delete").default,
+  "objects.bulkSet": require("./objects/bulk-set").default,
+  "objects.bulkDelete": require("./objects/bulk-delete").default,
+  "objects.messages": require("./objects/messages").default,
+  "objects.setChannelData.slack": require("./objects/set-channel-data-slack")
+    .default,
+  "objects.setChannelData.msTeams":
+    require("./objects/set-channel-data-ms-teams").default,
+  "objects.setChannelData.discord.webhook":
+    require("./objects/set-channel-data-discord-webhook").default,
+  "objects.setChannelData.discord.bot":
+    require("./objects/set-channel-data-discord-bot").default,
+  "objects.unsetChannelData": require("./objects/unset-channel-data").default,
+  "objects.getChannelData": require("./objects/get-channel-data").default,
+  "objects.listPreferences": require("./objects/list-preferences").default,
+  "objects.getPreferences": require("./objects/get-preferences").default,
+  "objects.setPreferences": require("./objects/set-preferences").default,
+
+  // Tenants
+  "tenants.list": require("./tenants/list").default,
+  "tenants.get": require("./tenants/get").default,
+  "tenants.set": require("./tenants/set").default,
+  "tenants.delete": require("./tenants/delete").default,
+
+  // Workflows
+  "workflows.cancel": require("./workflows/cancel").default,
+  "workflows.cancel-with-recipients":
+    require("./workflows/cancel-with-recipients").default,
+  "workflows.trigger": require("./workflows/trigger").default,
+  "workflows.trigger-with-identification":
+    require("./workflows/trigger-with-identification").default,
+  "workflows.trigger-with-user-identification":
+    require("./workflows/trigger-with-user-identification").default,
+  "workflows.trigger-with-object-identification":
+    require("./workflows/trigger-with-object-identification").default,
+  "workflows.trigger-with-actor": require("./workflows/trigger-with-actor")
+    .default,
+  "workflows.trigger-with-object-as-recipient":
+    require("./workflows/trigger-with-object-as-recipient").default,
+  "workflows.trigger-with-object-as-actor":
+    require("./workflows/trigger-with-object-as-actor").default,
+  "workflows.trigger-with-tenant": require("./workflows/trigger-with-tenant")
+    .default,
+  "workflows.trigger-with-branding-tenant":
+    require("./workflows/trigger-with-branding-tenant").default,
+  "workflows.trigger-with-attachment":
+    require("./workflows/trigger-with-attachment").default,
+  "workflows.trigger-with-user-channel-data":
+    require("./workflows/trigger-with-user-channel-data").default,
+  "workflows.trigger-with-user-preferences":
+    require("./workflows/trigger-with-user-preferences").default,
+  "workflows.playground": require("./workflows/playground").default,
+};
+
+/** Languages available on a snippet, ordered for the docs language switcher. */
+export const getSnippetLanguages = (snippet: CodeSnippet): SnippetLanguage[] =>
+  DEFAULT_LANGUAGE_ORDER.filter((language) => language in snippet);
+
+/**
+ * Picks a single language for markdown unfurling.
+ * Prefers Node.js (the docs UI default), otherwise the first language in the
+ * shared switcher order that the snippet actually defines.
+ */
+export const pickBestSnippetLanguage = (
+  snippet: CodeSnippet,
+): SnippetLanguage | undefined => {
+  if (snippet[PREFERRED_SNIPPET_LANGUAGE]) {
+    return PREFERRED_SNIPPET_LANGUAGE;
+  }
+  return getSnippetLanguages(snippet)[0];
+};

--- a/lib/mdxToLlmMarkdown.ts
+++ b/lib/mdxToLlmMarkdown.ts
@@ -1,12 +1,13 @@
 import fs from "fs";
 import path from "path";
+import { pickBestSnippetLanguage, snippets } from "../data/code/snippets";
 
 /**
  * Helpers for turning the custom MDX components used in our docs into plain
  * markdown for the "Copy for LLM" / llms.txt output.
  *
  * The docs render several React components that have no markdown equivalent. The
- * two that matter here are:
+ * ones that matter here are:
  *
  *   - `<Typedoc file="..." />`, which inlines an auto-generated SDK reference
  *     page from `/typedocs`. Without resolving it, an SDK component page like
@@ -14,8 +15,11 @@ import path from "path";
  *   - `<Attributes>` / `<Attribute>`, which render a property reference table.
  *     Those appear both inside the inlined typedoc content and directly in
  *     hand-written pages.
+ *   - `<MultiLangCodeBlock />`, which loads a multi-language example from
+ *     `/data/code`. We unfurl a single preferred language (Node.js by default)
+ *     rather than emitting every variant.
  *
- * We convert both to markdown so the copied content is actually useful to an
+ * We convert these to markdown so the copied content is actually useful to an
  * LLM. The attribute list format mirrors the one produced by
  * `scripts/generateApiMarkdown.ts` (`- **name** (type) *required* - description`).
  */
@@ -376,14 +380,95 @@ export const resolveTypedocReferences = (
   });
 
 /**
- * Prepares raw MDX for LLM/markdown output: inlines `<Typedoc>` references, then
- * converts the `<Attributes>` components (including any that came from the
- * inlined typedoc content) into markdown lists.
+ * Renders one multi-language snippet as a fenced markdown code block using the
+ * single preferred language for that snippet.
+ */
+const renderSnippetMarkdown = (snippetKey: string, title: string): string => {
+  const snippet = snippets[snippetKey];
+  if (!snippet) {
+    console.warn(
+      `Warning: MultiLangCodeBlock snippet not found for LLM markdown: ${snippetKey}`,
+    );
+    return "";
+  }
+
+  const language = pickBestSnippetLanguage(snippet);
+  if (!language) {
+    console.warn(
+      `Warning: MultiLangCodeBlock snippet has no languages for LLM markdown: ${snippetKey}`,
+    );
+    return "";
+  }
+
+  const code = (snippet[language] ?? "").trim();
+  const fenceInfo = title
+    ? `${language} title="${title.replace(/"/g, '\\"')}"`
+    : language;
+
+  return `\n\`\`\`${fenceInfo}\n${code}\n\`\`\`\n`;
+};
+
+/**
+ * Replaces every `<MultiLangCodeBlock />` with a single-language fenced code
+ * block. Prefers Node.js to match the docs UI default language; if that variant
+ * is missing, falls back to the first language in the shared switcher order.
+ */
+export const convertMultiLangCodeBlocksToMarkdown = (
+  content: string,
+): string => {
+  let result = content;
+  let start = result.indexOf("<MultiLangCodeBlock");
+
+  while (start !== -1) {
+    const openInnerStart = start + "<MultiLangCodeBlock".length;
+    const { end, selfClosing } = findOpeningTagEnd(result, openInnerStart);
+    const openInner = result.slice(
+      openInnerStart,
+      selfClosing ? end - 2 : end - 1,
+    );
+    const attributes = parseJsxAttributes(openInner);
+    const snippetKey = asString(attributes.snippet);
+    const title = asString(attributes.title);
+    const markdown = renderSnippetMarkdown(snippetKey, title);
+
+    let replaceEnd = end;
+    if (!selfClosing) {
+      const closeIndex = result.indexOf("</MultiLangCodeBlock>", end);
+      replaceEnd =
+        closeIndex === -1 ? end : closeIndex + "</MultiLangCodeBlock>".length;
+    }
+
+    const before = result.slice(0, start);
+    const after = result.slice(replaceEnd);
+
+    // Avoid stacking blank lines where the surrounding MDX already has them.
+    const withoutLeadingBlank =
+      markdown.startsWith("\n") && /\n[ \t]*\n[ \t]*$/.test(before)
+        ? markdown.slice(1)
+        : markdown;
+    const normalized =
+      withoutLeadingBlank.endsWith("\n") && /^[ \t]*\n/.test(after)
+        ? withoutLeadingBlank.slice(0, -1)
+        : withoutLeadingBlank;
+
+    result = before + normalized + after;
+    start = result.indexOf("<MultiLangCodeBlock", start + normalized.length);
+  }
+
+  return result;
+};
+
+/**
+ * Prepares raw MDX for LLM/markdown output: inlines `<Typedoc>` references,
+ * converts `<Attributes>` components (including any that came from the inlined
+ * typedoc content) into markdown lists, and unfurls `<MultiLangCodeBlock />`
+ * examples into a single preferred-language fenced code block.
  */
 export const convertMdxForLlm = (
   content: string,
   typedocsDir: string,
 ): string => {
   const withTypedocs = resolveTypedocReferences(content, typedocsDir);
-  return convertAttributesToMarkdown(withTypedocs);
+  const withAttributes = convertAttributesToMarkdown(withTypedocs);
+  return convertMultiLangCodeBlocksToMarkdown(withAttributes);
 };

--- a/scripts/generateApiMarkdown.ts
+++ b/scripts/generateApiMarkdown.ts
@@ -6,7 +6,10 @@ import { unified } from "unified";
 import remarkParse from "remark-parse";
 import remarkFrontmatter from "remark-frontmatter";
 import yaml from "yaml";
-import { resolveEndpointFromMethod } from "../components/ui/ApiReference/helpers";
+import {
+  augmentSnippetsWithCurlRequest,
+  resolveEndpointFromMethod,
+} from "../components/ui/ApiReference/helpers";
 import { getAtPointer } from "../lib/jsonPointer";
 import { convertMultiLangCodeBlocksToMarkdown } from "../lib/mdxToLlmMarkdown";
 import { readOpenApiSpec, readStainlessSpec } from "../lib/openApiSpec";
@@ -186,6 +189,7 @@ async function generateApiReferenceMarkdownFiles(
     // Get API specs
     const openApiSpec = await readOpenApiSpec(apiType);
     const stainlessSpec = await readStainlessSpec(apiType);
+    const baseUrl = stainlessSpec.environments?.production ?? "";
 
     // Get the appropriate sidebar content and resource order
     const { overviewContent, resourceOrder } =
@@ -278,6 +282,7 @@ async function generateApiReferenceMarkdownFiles(
             methodName,
             method,
             openApiSpec,
+            baseUrl,
           );
           combinedContent += methodContent;
           resourceContent += methodContent;
@@ -305,6 +310,7 @@ async function generateApiReferenceMarkdownFiles(
             subresourceName,
             subresource,
             openApiSpec,
+            baseUrl,
           );
           combinedContent += subresourceContent;
           resourceContent += subresourceContent;
@@ -316,6 +322,7 @@ async function generateApiReferenceMarkdownFiles(
             [subresourceName],
             subresource,
             openApiSpec,
+            baseUrl,
           );
         }
       }
@@ -378,6 +385,7 @@ function generateSubresourcePages(
   subresourcePath: string[],
   subresource: any,
   openApiSpec: any,
+  baseUrl: string,
 ) {
   // Build the directory path for this subresource
   const subresourceDir = path.join(
@@ -435,6 +443,7 @@ function generateSubresourcePages(
         methodName,
         method,
         openApiSpec,
+        baseUrl,
       );
 
       if (methodContent.trim()) {
@@ -475,6 +484,7 @@ function generateSubresourcePages(
         [...subresourcePath, nestedName],
         nestedSubresource,
         openApiSpec,
+        baseUrl,
       );
     }
   }
@@ -515,10 +525,38 @@ function getResourceOverviewContent(
   return content;
 }
 
+/**
+ * Picks a single request example language for API markdown. Prefers cURL so the
+ * generated page stays language-agnostic and matches the request example the UI
+ * shows first in the language switcher. Falls back to TypeScript/Node, then the
+ * first available snippet — never every language.
+ */
+function pickBestApiRequestExample(
+  examples: Record<string, string>,
+): { language: string; code: string } | null {
+  const preferredLanguages = ["curl", "typescript", "node"];
+  for (const language of preferredLanguages) {
+    const code = examples[language]?.trim();
+    if (code) {
+      return { language, code };
+    }
+  }
+
+  for (const [language, rawCode] of Object.entries(examples)) {
+    const code = rawCode?.trim();
+    if (code) {
+      return { language, code };
+    }
+  }
+
+  return null;
+}
+
 function getMethodMarkdownContent(
   methodName: string,
   method: any,
   openApiSpec: any,
+  baseUrl: string,
 ): string {
   const [methodType, endpoint] = resolveEndpointFromMethod(
     method as string | { endpoint: string },
@@ -573,12 +611,12 @@ function getMethodMarkdownContent(
   const requestBodyContent =
     openApiOperation.requestBody?.content?.["application/json"];
   const requestBody = requestBodyContent?.schema;
+  const requestExample = requestBodyContent?.example || requestBody?.example;
   if (requestBody) {
     content += `#### Request body\n\n`;
     if (requestBody.description) {
       content += `${requestBody.description}\n\n`;
     }
-    const requestExample = requestBodyContent?.example || requestBody.example;
     if (requestExample) {
       content += `##### Example\n\n`;
       content += `\`\`\`json\n${JSON.stringify(
@@ -587,6 +625,33 @@ function getMethodMarkdownContent(
         2,
       )}\n\`\`\`\n\n`;
     }
+  }
+
+  // Unfurl the same request example the UI builds from stainless snippets +
+  // synthesized cURL, but emit only the preferred language.
+  const requestExamples = augmentSnippetsWithCurlRequest(
+    openApiOperation["x-stainless-snippets"] ?? {},
+    {
+      baseUrl,
+      methodType,
+      endpoint,
+      body: requestExample,
+    },
+  );
+  const bestRequestExample = pickBestApiRequestExample(requestExamples);
+  if (bestRequestExample) {
+    const title = `${openApiOperation.summary || methodName} (example)`;
+    // The shared curl helper always ends the Authorization header with a line
+    // continuation; strip a dangling one when there is no request body line.
+    const code =
+      bestRequestExample.language === "curl"
+        ? bestRequestExample.code.replace(/\\\s*$/, "").trim()
+        : bestRequestExample.code;
+    content += `#### Request example\n\n`;
+    content += `\`\`\`${bestRequestExample.language} title="${title.replace(
+      /"/g,
+      '\\"',
+    )}"\n${code}\n\`\`\`\n\n`;
   }
 
   // Add response information
@@ -622,6 +687,7 @@ function getSubresourceMarkdownContent(
   subresourceName: string,
   subresource: any,
   openApiSpec: any,
+  baseUrl: string,
 ): string {
   let content = "";
 
@@ -650,7 +716,12 @@ function getSubresourceMarkdownContent(
   // Add method content for subresource
   if (subresource.methods) {
     for (const [methodName, method] of Object.entries(subresource.methods)) {
-      content += getMethodMarkdownContent(methodName, method, openApiSpec);
+      content += getMethodMarkdownContent(
+        methodName,
+        method,
+        openApiSpec,
+        baseUrl,
+      );
     }
   }
 

--- a/scripts/generateApiMarkdown.ts
+++ b/scripts/generateApiMarkdown.ts
@@ -8,6 +8,7 @@ import remarkFrontmatter from "remark-frontmatter";
 import yaml from "yaml";
 import { resolveEndpointFromMethod } from "../components/ui/ApiReference/helpers";
 import { getAtPointer } from "../lib/jsonPointer";
+import { convertMultiLangCodeBlocksToMarkdown } from "../lib/mdxToLlmMarkdown";
 import { readOpenApiSpec, readStainlessSpec } from "../lib/openApiSpec";
 import {
   MAPI_REFERENCE_OVERVIEW_CONTENT,
@@ -47,8 +48,12 @@ function writeMarkdownFile(filePath: string, content: string) {
 
 // Clean JSX content to plain markdown
 function cleanJsxContent(content: string): string {
+  // Unfurl multi-language examples to a single preferred language first so the
+  // later JSX cleanup passes don't strip the component tags without content.
+  const withCodeBlocks = convertMultiLangCodeBlocksToMarkdown(content);
+
   return (
-    content
+    withCodeBlocks
       // Remove ContentColumn and ExampleColumn wrappers
       .replace(/<ContentColumn>/g, "")
       .replace(/<\/ContentColumn>/g, "")
@@ -98,8 +103,6 @@ function cleanJsxContent(content: string): string {
       })
       // Remove Endpoints/Endpoint components
       .replace(/<Endpoints[\s\S]*?<\/Endpoints>/g, "")
-      // Remove MultiLangCodeBlock
-      .replace(/<MultiLangCodeBlock[^>]*\/>/g, "")
       // Remove ErrorExample components
       .replace(/<ErrorExample[\s\S]*?\/>/g, "")
       // Remove RateLimit components


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Generated markdown pages (`Copy for LLM`, `Accept: text/markdown`, `llms.txt`) were missing usable example code in two places:

1. **Docs pages** left `<MultiLangCodeBlock />` tags unresolved (or stripped them in API overview content).
2. **API reference method pages** only emitted params + response JSON, and omitted the request example the UI shows (cURL / SDK snippets from `x-stainless-snippets`).

This unfurls a **single** preferred example per block:

- Docs `MultiLangCodeBlock`: prefer Node.js (docs UI default)
- API method request examples: prefer cURL (language-agnostic, matches the request switcher's first option)
- Never emit every language variant

Changes:

- Extract the docs snippet registry into `data/code/snippets.ts`
- Convert `<MultiLangCodeBlock />` in `convertMdxForLlm` and API overview markdown
- Extend `getMethodMarkdownContent` to emit a request example via `augmentSnippetsWithCurlRequest`, preferring cURL

### Tasks

- [KNO-14441](https://linear.app/knock/issue/KNO-14441/docs-code-block-unfurling-in-markdown-pages)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-14441](https://linear.app/knock/issue/KNO-14441/docs-code-block-unfurling-in-markdown-pages)

<div><a href="https://cursor.com/agents/bc-ddbf4c74-8a3c-46f8-8f5c-5c6eeabd7430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddbf4c74-8a3c-46f8-8f5c-5c6eeabd7430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

