### PR TITLE
feat(KNO-14481): Add information about retrying delivery

### DIFF
--- a/content/send-notifications/delivering-notifications.mdx
+++ b/content/send-notifications/delivering-notifications.mdx
@@ -52,6 +52,12 @@ For specific providers, on failure we will update the delivery status to `undeli
 
 We will retry delivery status checks up to **10 times over a 30-minute window,** utilizing an exponential back-off strategy with jitter.
 
+### Manually retrying delivery
+
+If a message is in an `undelivered` [state](/send-notifications/message-statuses#1-undelivered) and you would like to re-attempt delivery, you can manually retry delivery from the Knock dashboard. Navigate to the message and select the "Retry delivery" button in the upper right-hand corner of the message detail view.
+
+Retrying delivery re-enqueues the message for a new delivery attempt, moving it back through the delivery lifecycle. This is helpful once you've resolved the underlying cause of the failure, such as correcting recipient data or updating your provider configuration.
+
 ## Sending logs and debugging
 
 For all out-of-app providers you can find logs of the requests we make and the responses we receive under the "Logs" tab of an individual message in the dashboard. You can use these logs to understand any errors coming from the provider while we were executing your requests.

--- a/content/send-notifications/message-statuses.mdx
+++ b/content/send-notifications/message-statuses.mdx
@@ -50,7 +50,9 @@ Below we break down each status in detail (including any channel-specific limita
 
 We attempted to deliver your message, we encountered an error, and _we will not retry delivery_. Your message has not made it from Knock to your provider.
 
-You can use the message delivery logs to help debug what may have gone wrong between Knock and the downstream provider. See our documentation on [message delivery retries](/send-notifications/delivering-notifications#retry-logic) for more details on how delivery attempts and retries at Knock work.
+You can use the message delivery logs to help identify what went wrong between Knock and the downstream provider. For more information about how Knock handles delivery attempts and retries, see our documentation on [message delivery retries](/send-notifications/delivering-notifications#retry-logic).
+
+After you've resolved the underlying issue, you can [manually retry delivery](/send-notifications/delivering-notifications#manually-retrying-delivery) from the message detail view in the dashboard.
 
 ### 2) Bounced
 


### PR DESCRIPTION
### Description

Adds information to the following pages about the new dashboard option for customers to manually retry delivery for undelivered messages:
- Delivering notifications: https://docs-git-rt-kno-14481-retry-delivery-knocklabs.vercel.app/send-notifications/delivering-notifications#manually-retrying-delivery
- Message statuses (under undelivered): https://docs-git-rt-kno-14481-retry-delivery-knocklabs.vercel.app/send-notifications/message-statuses#1-undelivered

### Tasks

[KNO-14481](https://linear.app/knock/issue/KNO-14481/docs-add-retry-delivery-information-to-the-docs)
