### PR TITLE
fix(KNO-14545): Fix lists inside accordions on environments page

### DIFF
--- a/content/version-control/environments.mdx
+++ b/content/version-control/environments.mdx
@@ -54,10 +54,19 @@ With Knock environments you:
 Each environment has a set of **data resources** that are per-environment and will never be shared between environments. These data resources are not version-controlled.
 
 <AccordionGroup>
-  <Accordion title="Data resources">
-    The following data resources are per-environment and not version-controlled.
-    - Users - Audiences - Tenants - Objects - Messages - Analytics - Logs -
-    Events - Broadcasts
+  <Accordion title="See all per-environment data resources">
+    The following data resources are per-environment and not version-controlled:
+
+    - Users
+    - Audiences
+    - Tenants
+    - Objects
+    - Messages
+    - Analytics
+    - Logs
+    - Events
+    - Broadcasts
+
   </Accordion>
 </AccordionGroup>
 
@@ -67,12 +76,19 @@ Each environment has its own set of API keys which you use to send data to the e
 
 ### Create content in environments
 
-Each environment has a set of **content resources** that are managed via version control. These are resources associated with the creation and orchestration of the content you send to your customers, such as workflows, layouts, and templates.
+Each environment has a set of **content resources** that are managed via version control. These are resources associated with the creation and orchestration of the content you send to your customers.
 
 <AccordionGroup>
-  <Accordion title="Content resources">
-    The following content resources are version-controlled. - Workflows - Guides
-    - Layouts - Partials - Translations - Reusable requests
+  <Accordion title="See all version-controlled content resources">
+    The following content resources are version-controlled:
+
+    - Workflows
+    - Guides
+    - Layouts
+    - Partials
+    - Translations
+    - Reusable requests
+
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
### Description

The lists under two accordions on the version-control/environments.mdx page weren't rendering correctly (they needed to be on their own line). This fixes them so they render correctly.

Additionally, I updated the leading paragraph and accordion titles to make things clearer and less repetitive. 

### Tasks

[KNO-14545](https://linear.app/knock/issue/KNO-14545/docs-fix-content-resources-list-under-environments-page)

### Screenshots

#### Before
<img width="842" height="850" alt="Screenshot 2026-07-29 at 2 28 33 PM" src="https://github.com/user-attachments/assets/f15e8594-b3ed-49dc-8b95-8da9d2910ed3" />

#### After
<img width="819" height="1140" alt="Screenshot 2026-07-29 at 2 28 13 PM" src="https://github.com/user-attachments/assets/cb1ead8c-228a-44c0-a6d4-023334d1088e" />
