### PR TITLE
docs: mention CLI vs MCP routing for knock-setup

### DIFF
--- a/content/ai/skills.mdx
+++ b/content/ai/skills.mdx
@@ -52,7 +52,7 @@ The open-source package and dashboard-authored skills are complementary. A team 
 
 ### `knock-setup`
 
-The `knock-setup` skill connects Knock to a coding agent, discovers high-value workflows from a product, and helps wire triggers into the application.
+The `knock-setup` skill connects Knock to a coding agent, discovers high-value workflows from a product, and helps wire triggers into the application. It routes by surface: interactive clients (Cursor editor, Claude app, Codex IDE/app) use the [MCP server](/ai/mcp-server), while CLI agents (Cursor CLI, Claude Code, Codex CLI, and similar) use the [Knock CLI](/ai/cli).
 
 **Complements.** The [MCP server](/ai/mcp-server) and [Knock CLI](/ai/cli).
 
@@ -116,7 +116,7 @@ Skills are not tied to a single tool surface. Different skills complement differ
 
 | Skill                               | Pairs with                                               | What it adds                                                                |
 | ----------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `knock-setup`                       | The [MCP server](/ai/mcp-server) and [CLI](/ai/cli)      | Connect tooling, discover workflows, and wire triggers.                     |
+| `knock-setup`                       | The [MCP server](/ai/mcp-server) and [CLI](/ai/cli)      | Connect tooling (MCP or Knock CLI by surface), discover workflows, and wire triggers. |
 | `knock-cli`                         | The [Knock CLI](/ai/cli)                                 | How to scaffold, edit, and push resource files from your codebase.          |
 | `knock-notification-best-practices` | Any surface (CLI, MCP, dashboard agent)                  | How to write effective notifications across channels.                       |
 | `knock-in-app-ui`                   | In-app SDKs and the [CLI](/ai/cli)                       | How to implement and debug Knock guides.                                    |

--- a/lib/agentSkills.ts
+++ b/lib/agentSkills.ts
@@ -38,7 +38,7 @@ export const AGENT_SKILL_CARDS: AgentSkillCard[] = [
     name: "knock-setup",
     title: "Set up Knock",
     description:
-      "Connect MCP and skills, then discover and build your first workflows.",
+      "Connect via MCP or the Knock CLI, then discover and build your first workflows.",
   },
   {
     name: "knock-lifecycle-opportunities",

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -130,7 +130,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
     <Page.Container>
       <Meta
         title="Agents | Knock Docs"
-        description="Set up Knock with your coding agent. Install skills, connect the MCP server, and build notification workflows."
+        description="Set up Knock with your coding agent. Install skills, connect via MCP or the Knock CLI, and build notification workflows."
       />
       <Page.Masthead
         skipHighlight


### PR DESCRIPTION
## Summary
- Updates knock-setup copy so docs match the skill's MCP vs Knock CLI surface routing
- Touches the agents page meta description, skill card blurb, skills page section, and skills comparison table

Stacked on `mc-agents-page` (where the agents / skills docs live).

## Test plan
- [ ] `/ai/skills` knock-setup section mentions MCP for interactive clients and Knock CLI for CLI agents
- [ ] `/agents` skill card description and page meta no longer imply MCP-only setup


Made with [Cursor](https://cursor.com)