### PR TITLE
fix(kno-14560): add billing callout to account deletion docs

### DIFF
--- a/content/manage-your-account/account-deletion.mdx
+++ b/content/manage-your-account/account-deletion.mdx
@@ -17,6 +17,20 @@ Consider the following before deleting your account:
 - **API keys.** All API keys will be revoked immediately. Any applications or services using these keys will lose access to Knock.
 - **Account members.** All [account members](/manage-your-account/managing-members) will lose access. They will receive an email informing them that the account has been deleted.
 - **Integrations.** Any active channel integrations (email, push, chat, SMS) will stop working.
+- **Billing.** If you are on a paid plan, cancel your subscription before deleting your account. Deleting your account does not cancel billing.
+
+<Callout
+  type="warning"
+  title="Cancel your subscription first."
+  text={
+    <>
+      Deleting your account does not automatically cancel billing. If you are on
+      a paid plan, cancel your subscription before you delete your account, or
+      you will continue to be charged. If you need help canceling,{" "}
+      <a href="mailto:support@knock.app">contact support</a>.
+    </>
+  }
+/>
 
 ## Data deletion
 


### PR DESCRIPTION
## KNO-14560: Add interim callout about canceling billing before deleting an account

### Summary
- Adds a **Billing** bullet and a warning callout to the **Before you delete** section of the account deletion page.
- Deleting an account does not cancel the customer's Orb subscription, so paid-plan customers keep getting billed after deletion. The docs are the only warning until the fix ships.
- To be removed after automatic subscription cancellation is enabled. 

### Changes
- `content/manage-your-account/account-deletion.mdx` — added a billing bullet to **Before you delete** and a warning callout telling paid-plan customers to cancel their subscription first, with a support email link.