### PR TITLE
fix(KNO-14582): tighten wordmark spacing in header and footer

### DIFF
--- a/components/ui/MarketingFooter.tsx
+++ b/components/ui/MarketingFooter.tsx
@@ -57,7 +57,7 @@ export const MarketingFooter = () => (
           >
             <KnockWordmark width={84} />
           </Link>
-          <Heading as="h2" size="4" weight="semi-bold" style={{ margin: 0 }}>
+          <Heading as="h2" size="4" weight="medium" style={{ margin: 0 }}>
             Customer engagement infrastructure for growth.
           </Heading>
         </Stack>

--- a/components/ui/MarketingFooter.tsx
+++ b/components/ui/MarketingFooter.tsx
@@ -53,11 +53,11 @@ export const MarketingFooter = () => (
           <Link
             href="https://knock.app"
             aria-label="Knock"
-            style={{ display: "inline-block", marginLeft: "-10px" }}
+            style={{ display: "inline-block" }}
           >
             <KnockWordmark width={84} />
           </Link>
-          <Heading as="h2" size="6" weight="medium" style={{ margin: 0 }}>
+          <Heading as="h2" size="4" weight="semi-bold" style={{ margin: 0 }}>
             Customer engagement infrastructure for growth.
           </Heading>
         </Stack>

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -55,7 +55,7 @@ const PageHeader = ({ skipHighlight, mobileSidebar }: PageHeaderProps) => {
           {/* Left section: Logo + Search (mobile only) */}
           <Stack direction="row" alignItems="flex-end" style={{ minWidth: 0 }}>
             <Stack direction="row" alignItems="flex-end" pb="1">
-              <Box as={Link} href="/" display="block" mr="2">
+              <Box as={Link} href="/" display="block" ml="2" mr="2">
                 <KnockWordmark width={67} />
               </Box>
               <Text as="span" style={{ lineHeight: "1", marginBottom: "2px" }}>

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -55,7 +55,7 @@ const PageHeader = ({ skipHighlight, mobileSidebar }: PageHeaderProps) => {
           {/* Left section: Logo + Search (mobile only) */}
           <Stack direction="row" alignItems="flex-end" style={{ minWidth: 0 }}>
             <Stack direction="row" alignItems="flex-end" pb="1">
-              <Box as={Link} href="/" display="block" ml="2" mr="2">
+              <Box as={Link} href="/" display="block" ml="1_5" mr="2">
                 <KnockWordmark width={67} />
               </Box>
               <Text as="span" style={{ lineHeight: "1", marginBottom: "2px" }}>

--- a/components/ui/PageHeader.tsx
+++ b/components/ui/PageHeader.tsx
@@ -55,9 +55,9 @@ const PageHeader = ({ skipHighlight, mobileSidebar }: PageHeaderProps) => {
           {/* Left section: Logo + Search (mobile only) */}
           <Stack direction="row" alignItems="flex-end" style={{ minWidth: 0 }}>
             <Stack direction="row" alignItems="flex-end" pb="1">
-              <Link href="/" style={{ display: "block" }}>
+              <Box as={Link} href="/" display="block" mr="2">
                 <KnockWordmark width={67} />
-              </Link>
+              </Box>
               <Text as="span" style={{ lineHeight: "1", marginBottom: "2px" }}>
                 Docs
               </Text>


### PR DESCRIPTION
Forgot to fix this before merging the original PR
<img width="1225" height="329" alt="Screenshot 2026-07-31 at 2 58 18 PM" src="https://github.com/user-attachments/assets/28fe197f-dd7e-4e22-bce4-4e101ce69b72" />

<img width="196" height="139" alt="Screenshot 2026-07-31 at 2 59 54 PM" src="https://github.com/user-attachments/assets/6454a743-2acf-4bd9-bb5e-8bc641f203bf" />


## Summary
- Adds a bit of space between the header wordmark and "Docs"
- Keeps the footer wordmark inside the content boundary (was pulling left with negative margin)
- Shrinks the footer headline to match the Related section sizing on `/agents`

## Test plan
- [ ] Header wordmark ↔ Docs spacing looks right on desktop and mobile
- [ ] Footer wordmark aligns with the left content edge
- [ ] Footer headline size matches Related on `/agents`


Made with [Cursor](https://cursor.com)