### PR TITLE
docs: wait-for-event available in broadcast

### DIFF
--- a/content/concepts/broadcasts.mdx
+++ b/content/concepts/broadcasts.mdx
@@ -50,6 +50,7 @@ To manage the contents of a broadcast, click the "Edit steps" button in the broa
 In the broadcast builder, you can add:
 
 - [Delay functions](/designing-workflows/delay-function): to pause the execution of a broadcast for a specific amount of time.
+- [Wait for event functions](/designing-workflows/wait-for-event-function): to pause the execution of a broadcast until a matching event is received or until a wait time expires.
 - [Branch functions](/designing-workflows/branch-function): to conditionally execute steps based on the value of a variable.
 - [Experiment functions](/designing-workflows/experiment-function): to randomly assign recipients to percentage-based cohorts for A/B testing and experimentation.
 - [Channel steps](/designing-workflows/channel-step): to send a message to a user on a specific channel.

--- a/content/designing-workflows/wait-for-event-function.mdx
+++ b/content/designing-workflows/wait-for-event-function.mdx
@@ -15,7 +15,7 @@ tags:
 section: Designing workflows
 ---
 
-A wait for event function pauses a workflow until a matching event is received, or until a configured wait time expires. Use it when the next step in your workflow should depend on something that happens after the run starts — such as a payment completing in an external system, a message being delivered, another workflow finishing for the same recipient, an audience membership change, or a recipient property update.
+A wait for event function pauses a workflow or broadcast until a matching event is received, or until a configured wait time expires. Use it when the next step in your workflow or broadcast should depend on something that happens after the run starts — such as a payment completing in an external system, a message being delivered, another workflow finishing for the same recipient, an audience membership change, or a recipient property update.
 
 ## How it works
 
@@ -249,6 +249,10 @@ When match conditions reject an incoming event, Knock logs a `wait_conditions_ev
     Yes. The workflow trigger type does not affect the wait for event step. The
     step listens for the configured event type independently of how the workflow
     was triggered.
+  </Accordion>
+  <Accordion title="Can I use wait for event in broadcasts?">
+    Yes. Wait for event functions are supported in broadcasts as well as
+    workflows.
   </Accordion>
   <Accordion title="Can a workflow wait for its own message events?">
     Yes. Select message as the event type, set the source type to workflow, and


### PR DESCRIPTION
### Description

Updated docs to specify that wait for event steps are available in the broadcast builder after https://github.com/knocklabs/control/pull/10706