### PR TITLE
feat(KNO-14609): add PostHog events for agents page CTAs and Knock AI banner

### DIFF
--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -98,12 +98,10 @@ type CodingToolTrackingProps = {
 /** Track a prompt action click (copy or coding-tool) before the side effect. */
 export const trackCodingToolClicked = (
   action: AgentPromptAction,
-  prompt: string,
   tracking?: CodingToolTrackingProps,
 ) => {
   posthog.track("agents-coding-tool-clicked-client", {
     action,
-    prompt_length: prompt.length,
     ...tracking,
   });
 };
@@ -114,7 +112,7 @@ export const openCodingToolDeeplink = (
   prompt: string,
   tracking?: CodingToolTrackingProps,
 ) => {
-  trackCodingToolClicked(tool, prompt, tracking);
+  trackCodingToolClicked(tool, tracking);
 
   const url = DEEPLINK_BUILDERS[tool](prompt);
   if (!isAllowedDeeplink(tool, url)) {
@@ -123,7 +121,6 @@ export const openCodingToolDeeplink = (
 
   posthog.track("agents-coding-tool-opened-client", {
     action: tool,
-    prompt_length: prompt.length,
     ...tracking,
   });
 
@@ -260,7 +257,7 @@ export const AgentPromptActionButton = ({
     selectionMethod: "primary" | "menu",
   ) => {
     if (action === "copy") {
-      trackCodingToolClicked("copy", prompt, {
+      trackCodingToolClicked("copy", {
         ...trackingProps,
         selection_method: selectionMethod,
       });

--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -23,15 +23,9 @@ export const PREFERRED_CODING_TOOL_CHANGE_EVENT =
 
 export type AgentPromptAction = "copy" | CodingToolValue;
 
-export type AgentPromptTrackingSource =
-  | "hero"
-  | "hero_wordmark"
-  | "skill_card"
-  | "setup_prompt";
-
-export type AgentPromptTrack = {
-  source: AgentPromptTrackingSource;
-  skillName?: string;
+type AgentPromptTrack = {
+  source: "hero" | "skill_card";
+  skill_name?: string;
 };
 
 type AgentPromptActionButtonProps = {
@@ -43,7 +37,6 @@ type AgentPromptActionButtonProps = {
   size?: "1" | "2";
   /** When true, hide the primary button label and show only the icon. */
   hideLabel?: boolean;
-  /** PostHog location for where this control is rendered. */
   track?: AgentPromptTrack;
 };
 
@@ -93,28 +86,16 @@ const isCodingToolValue = (value: unknown): value is CodingToolValue =>
   typeof value === "string" && value in CODING_TOOL_BY_VALUE;
 
 type CodingToolTrackingProps = AgentPromptTrack & {
-  selection_method?: "primary" | "menu" | "wordmark";
+  selection_method: "primary" | "menu" | "wordmark";
 };
 
-const toPostHogProps = (tracking?: CodingToolTrackingProps) => {
-  if (!tracking) return {};
-
-  const { source, skillName, selection_method } = tracking;
-  return {
-    source,
-    ...(selection_method ? { selection_method } : {}),
-    ...(skillName ? { skill_name: skillName } : {}),
-  };
-};
-
-/** Track a prompt action click (copy or coding-tool) before the side effect. */
 export const trackCodingToolClicked = (
   action: AgentPromptAction,
-  tracking?: CodingToolTrackingProps,
+  tracking: CodingToolTrackingProps,
 ) => {
   posthog.track("agents-coding-tool-clicked-client", {
     action,
-    ...toPostHogProps(tracking),
+    ...tracking,
   });
 };
 
@@ -124,31 +105,34 @@ export const openCodingToolDeeplink = (
   prompt: string,
   tracking?: CodingToolTrackingProps,
 ) => {
-  trackCodingToolClicked(tool, tracking);
+  if (tracking) {
+    trackCodingToolClicked(tool, tracking);
+  }
 
   const url = DEEPLINK_BUILDERS[tool](prompt);
   if (!isAllowedDeeplink(tool, url)) {
     return;
   }
 
-  posthog.track("agents-coding-tool-opened-client", {
-    action: tool,
-    ...toPostHogProps(tracking),
-  });
-
   if (url.protocol === "https:") {
     window.open(url.toString(), "_blank", "noopener,noreferrer");
-    return;
+  } else {
+    // Custom app schemes: trigger via a temporary anchor so we never assign
+    // unvalidated strings to window.location.href.
+    const anchor = document.createElement("a");
+    anchor.href = url.toString();
+    anchor.rel = "noopener noreferrer";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
   }
 
-  // Custom app schemes: trigger via a temporary anchor so we never assign
-  // unvalidated strings to window.location.href.
-  const anchor = document.createElement("a");
-  anchor.href = url.toString();
-  anchor.rel = "noopener noreferrer";
-  document.body.appendChild(anchor);
-  anchor.click();
-  anchor.remove();
+  if (tracking) {
+    posthog.track("agents-coding-tool-opened-client", {
+      action: tool,
+      ...tracking,
+    });
+  }
 };
 
 export const readStoredAction = (): AgentPromptAction => {
@@ -208,7 +192,7 @@ export const AgentPromptActionButton = ({
   color = "accent",
   size = "2",
   hideLabel = false,
-  track = { source: "setup_prompt" },
+  track,
 }: AgentPromptActionButtonProps) => {
   const isMounted = useIsMounted();
   const [isOpen, setIsOpen] = useState(false);
@@ -262,19 +246,19 @@ export const AgentPromptActionButton = ({
     action: AgentPromptAction,
     selectionMethod: "primary" | "menu",
   ) => {
+    const tracking = track
+      ? { ...track, selection_method: selectionMethod }
+      : undefined;
+
     if (action === "copy") {
-      trackCodingToolClicked("copy", {
-        ...track,
-        selection_method: selectionMethod,
-      });
+      if (tracking) {
+        trackCodingToolClicked("copy", tracking);
+      }
       copy();
       return;
     }
 
-    openCodingToolDeeplink(action, prompt, {
-      ...track,
-      selection_method: selectionMethod,
-    });
+    openCodingToolDeeplink(action, prompt, tracking);
   };
 
   const handlePrimaryClick = () => {

--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -95,19 +95,34 @@ type CodingToolTrackingProps = {
   selection_method?: "primary" | "menu" | "wordmark";
 };
 
+/** Track a prompt action click (copy or coding-tool) before the side effect. */
+export const trackCodingToolClicked = (
+  action: AgentPromptAction,
+  prompt: string,
+  tracking?: CodingToolTrackingProps,
+) => {
+  posthog.track("agents-coding-tool-clicked-client", {
+    action,
+    prompt_length: prompt.length,
+    ...tracking,
+  });
+};
+
 /** Open a coding-tool deeplink after allowlisting protocol (and host for https). */
 export const openCodingToolDeeplink = (
   tool: CodingToolValue,
   prompt: string,
   tracking?: CodingToolTrackingProps,
 ) => {
+  trackCodingToolClicked(tool, prompt, tracking);
+
   const url = DEEPLINK_BUILDERS[tool](prompt);
   if (!isAllowedDeeplink(tool, url)) {
     return;
   }
 
   posthog.track("agents-coding-tool-opened-client", {
-    tool,
+    action: tool,
     prompt_length: prompt.length,
     ...tracking,
   });
@@ -245,9 +260,8 @@ export const AgentPromptActionButton = ({
     selectionMethod: "primary" | "menu",
   ) => {
     if (action === "copy") {
-      posthog.track("agents-copy-prompt-clicked-client", {
+      trackCodingToolClicked("copy", prompt, {
         ...trackingProps,
-        prompt_length: prompt.length,
         selection_method: selectionMethod,
       });
       copy();

--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -114,25 +114,26 @@ export const openCodingToolDeeplink = (
     return;
   }
 
-  if (url.protocol === "https:") {
-    window.open(url.toString(), "_blank", "noopener,noreferrer");
-  } else {
-    // Custom app schemes: trigger via a temporary anchor so we never assign
-    // unvalidated strings to window.location.href.
-    const anchor = document.createElement("a");
-    anchor.href = url.toString();
-    anchor.rel = "noopener noreferrer";
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
-  }
-
   if (tracking) {
     posthog.track("agents-coding-tool-opened-client", {
       action: tool,
       ...tracking,
     });
   }
+
+  if (url.protocol === "https:") {
+    window.open(url.toString(), "_blank", "noopener,noreferrer");
+    return;
+  }
+
+  // Custom app schemes: trigger via a temporary anchor so we never assign
+  // unvalidated strings to window.location.href.
+  const anchor = document.createElement("a");
+  anchor.href = url.toString();
+  anchor.rel = "noopener noreferrer";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
 };
 
 export const readStoredAction = (): AgentPromptAction => {

--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -13,6 +13,7 @@ import {
   CodingToolIcon,
   type CodingToolValue,
 } from "@/components/ui/CodingToolIcon";
+import * as posthog from "@/lib/posthog";
 
 export const PREFERRED_CODING_TOOL_STORAGE_KEY =
   "@knocklabs/preferred-coding-tool";
@@ -21,6 +22,12 @@ export const PREFERRED_CODING_TOOL_CHANGE_EVENT =
   "knock:preferred-coding-tool-change";
 
 export type AgentPromptAction = "copy" | CodingToolValue;
+
+export type AgentPromptTrackingSource =
+  | "hero"
+  | "hero_wordmark"
+  | "skill_card"
+  | "setup_prompt";
 
 type AgentPromptActionButtonProps = {
   prompt: string;
@@ -31,6 +38,10 @@ type AgentPromptActionButtonProps = {
   size?: "1" | "2";
   /** When true, hide the primary button label and show only the icon. */
   hideLabel?: boolean;
+  /** PostHog source for where this control is rendered. */
+  trackingSource?: AgentPromptTrackingSource;
+  /** Optional skill identifier when rendered on a skill card. */
+  skillName?: string;
 };
 
 const MENU_ACTIONS: AgentPromptAction[] = [
@@ -78,15 +89,28 @@ const isAllowedDeeplink = (tool: CodingToolValue, url: URL): boolean => {
 const isCodingToolValue = (value: unknown): value is CodingToolValue =>
   typeof value === "string" && value in CODING_TOOL_BY_VALUE;
 
+type CodingToolTrackingProps = {
+  source?: AgentPromptTrackingSource;
+  skill_name?: string;
+  selection_method?: "primary" | "menu" | "wordmark";
+};
+
 /** Open a coding-tool deeplink after allowlisting protocol (and host for https). */
 export const openCodingToolDeeplink = (
   tool: CodingToolValue,
   prompt: string,
+  tracking?: CodingToolTrackingProps,
 ) => {
   const url = DEEPLINK_BUILDERS[tool](prompt);
   if (!isAllowedDeeplink(tool, url)) {
     return;
   }
+
+  posthog.track("agents-coding-tool-opened-client", {
+    tool,
+    prompt_length: prompt.length,
+    ...tracking,
+  });
 
   if (url.protocol === "https:") {
     window.open(url.toString(), "_blank", "noopener,noreferrer");
@@ -160,6 +184,8 @@ export const AgentPromptActionButton = ({
   color = "accent",
   size = "2",
   hideLabel = false,
+  trackingSource = "setup_prompt",
+  skillName,
 }: AgentPromptActionButtonProps) => {
   const isMounted = useIsMounted();
   const [isOpen, setIsOpen] = useState(false);
@@ -209,23 +235,39 @@ export const AgentPromptActionButton = ({
     ? preferredTool
     : "copy";
 
-  const runAction = (action: AgentPromptAction) => {
+  const trackingProps = {
+    source: trackingSource,
+    ...(skillName ? { skill_name: skillName } : {}),
+  };
+
+  const runAction = (
+    action: AgentPromptAction,
+    selectionMethod: "primary" | "menu",
+  ) => {
     if (action === "copy") {
+      posthog.track("agents-copy-prompt-clicked-client", {
+        ...trackingProps,
+        prompt_length: prompt.length,
+        selection_method: selectionMethod,
+      });
       copy();
       return;
     }
 
-    openCodingToolDeeplink(action, prompt);
+    openCodingToolDeeplink(action, prompt, {
+      ...trackingProps,
+      selection_method: selectionMethod,
+    });
   };
 
   const handlePrimaryClick = () => {
-    runAction(activeAction);
+    runAction(activeAction, "primary");
   };
 
   const handleSelectAction = (action: AgentPromptAction) => {
     setPreferredTool(action);
     persistAction(action);
-    runAction(action);
+    runAction(action, "menu");
     setIsOpen(false);
   };
 

--- a/components/ui/AgentPromptActionButton.tsx
+++ b/components/ui/AgentPromptActionButton.tsx
@@ -29,6 +29,11 @@ export type AgentPromptTrackingSource =
   | "skill_card"
   | "setup_prompt";
 
+export type AgentPromptTrack = {
+  source: AgentPromptTrackingSource;
+  skillName?: string;
+};
+
 type AgentPromptActionButtonProps = {
   prompt: string;
   /** Defaults to solid accent (primary). Use outline for secondary. */
@@ -38,10 +43,8 @@ type AgentPromptActionButtonProps = {
   size?: "1" | "2";
   /** When true, hide the primary button label and show only the icon. */
   hideLabel?: boolean;
-  /** PostHog source for where this control is rendered. */
-  trackingSource?: AgentPromptTrackingSource;
-  /** Optional skill identifier when rendered on a skill card. */
-  skillName?: string;
+  /** PostHog location for where this control is rendered. */
+  track?: AgentPromptTrack;
 };
 
 const MENU_ACTIONS: AgentPromptAction[] = [
@@ -89,10 +92,19 @@ const isAllowedDeeplink = (tool: CodingToolValue, url: URL): boolean => {
 const isCodingToolValue = (value: unknown): value is CodingToolValue =>
   typeof value === "string" && value in CODING_TOOL_BY_VALUE;
 
-type CodingToolTrackingProps = {
-  source?: AgentPromptTrackingSource;
-  skill_name?: string;
+type CodingToolTrackingProps = AgentPromptTrack & {
   selection_method?: "primary" | "menu" | "wordmark";
+};
+
+const toPostHogProps = (tracking?: CodingToolTrackingProps) => {
+  if (!tracking) return {};
+
+  const { source, skillName, selection_method } = tracking;
+  return {
+    source,
+    ...(selection_method ? { selection_method } : {}),
+    ...(skillName ? { skill_name: skillName } : {}),
+  };
 };
 
 /** Track a prompt action click (copy or coding-tool) before the side effect. */
@@ -102,7 +114,7 @@ export const trackCodingToolClicked = (
 ) => {
   posthog.track("agents-coding-tool-clicked-client", {
     action,
-    ...tracking,
+    ...toPostHogProps(tracking),
   });
 };
 
@@ -121,7 +133,7 @@ export const openCodingToolDeeplink = (
 
   posthog.track("agents-coding-tool-opened-client", {
     action: tool,
-    ...tracking,
+    ...toPostHogProps(tracking),
   });
 
   if (url.protocol === "https:") {
@@ -196,8 +208,7 @@ export const AgentPromptActionButton = ({
   color = "accent",
   size = "2",
   hideLabel = false,
-  trackingSource = "setup_prompt",
-  skillName,
+  track = { source: "setup_prompt" },
 }: AgentPromptActionButtonProps) => {
   const isMounted = useIsMounted();
   const [isOpen, setIsOpen] = useState(false);
@@ -247,18 +258,13 @@ export const AgentPromptActionButton = ({
     ? preferredTool
     : "copy";
 
-  const trackingProps = {
-    source: trackingSource,
-    ...(skillName ? { skill_name: skillName } : {}),
-  };
-
   const runAction = (
     action: AgentPromptAction,
     selectionMethod: "primary" | "menu",
   ) => {
     if (action === "copy") {
       trackCodingToolClicked("copy", {
-        ...trackingProps,
+        ...track,
         selection_method: selectionMethod,
       });
       copy();
@@ -266,7 +272,7 @@ export const AgentPromptActionButton = ({
     }
 
     openCodingToolDeeplink(action, prompt, {
-      ...trackingProps,
+      ...track,
       selection_method: selectionMethod,
     });
   };

--- a/components/ui/KnockAiBanner/KnockAiBanner.tsx
+++ b/components/ui/KnockAiBanner/KnockAiBanner.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { Button } from "@telegraph/button";
 import { TgphComponentProps } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
@@ -7,6 +8,7 @@ import { ArrowRight } from "lucide-react";
 import type { CSSProperties } from "react";
 
 import { AnimatedDotGrid } from "@/components/ui/AnimatedDotGrid";
+import * as posthog from "@/lib/posthog";
 
 import "./KnockAiBanner.css";
 
@@ -22,6 +24,7 @@ type KnockAiBannerProps = {
  * a surface-colored gradient keeps copy readable on the left.
  */
 export const KnockAiBanner = ({ subheadingProps }: KnockAiBannerProps = {}) => {
+  const router = useRouter();
   const {
     style: subheadingStyle,
     className: subheadingClassName,
@@ -31,7 +34,14 @@ export const KnockAiBanner = ({ subheadingProps }: KnockAiBannerProps = {}) => {
     {}) as CSSProperties;
 
   return (
-    <Link href="/agents">
+    <Link
+      href="/agents"
+      onClick={() => {
+        posthog.track("knock-ai-banner-clicked-client", {
+          path: router.asPath,
+        });
+      }}
+    >
       <Box
         className="knock-ai-banner"
         position="relative"

--- a/components/ui/KnockAiBanner/KnockAiBanner.tsx
+++ b/components/ui/KnockAiBanner/KnockAiBanner.tsx
@@ -37,7 +37,7 @@ export const KnockAiBanner = ({ subheadingProps }: KnockAiBannerProps = {}) => {
     <Link
       href="/agents"
       onClick={() => {
-        posthog.track("knock-ai-banner-clicked-client", {
+        posthog.track("agents-banner-clicked-client", {
           path: router.asPath,
         });
       }}

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -22,6 +22,7 @@ import { PLATFORM_SIDEBAR } from "@/data/sidebars/platformSidebar";
 import {
   AgentPromptActionButton,
   openCodingToolDeeplink,
+  trackCodingToolClicked,
 } from "@/components/ui/AgentPromptActionButton";
 import { AnimatedDotGrid } from "@/components/ui/AnimatedDotGrid";
 import { MarketingFooter } from "@/components/ui/MarketingFooter";
@@ -35,7 +36,6 @@ import {
   fetchAgentSkills,
   type AgentSkill,
 } from "@/lib/agentSkills";
-import * as posthog from "@/lib/posthog";
 
 type AgentsPageProps = {
   skills: AgentSkill[];
@@ -56,9 +56,8 @@ const CopyPromptButton = ({
       color="accent"
       size="2"
       onClick={() => {
-        posthog.track("agents-copy-prompt-clicked-client", {
+        trackCodingToolClicked("copy", prompt, {
           source: "hero",
-          prompt_length: prompt.length,
           selection_method: "primary",
         });
         copy();

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -127,7 +127,7 @@ const CodingToolWordmarks = ({ prompt }: { prompt: string }) => {
             p="0"
             onClick={() =>
               openCodingToolDeeplink(option.value, prompt, {
-                source: "hero_wordmark",
+                source: "hero",
                 selection_method: "wordmark",
               })
             }
@@ -309,7 +309,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                       variant="outline"
                       size="1"
                       hideLabel
-                      track={{ source: "skill_card", skillName: skill.name }}
+                      track={{ source: "skill_card", skill_name: skill.name }}
                     />
                   </Box>
                 </Stack>

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -56,7 +56,7 @@ const CopyPromptButton = ({
       color="accent"
       size="2"
       onClick={() => {
-        trackCodingToolClicked("copy", prompt, {
+        trackCodingToolClicked("copy", {
           source: "hero",
           selection_method: "primary",
         });

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -35,6 +35,7 @@ import {
   fetchAgentSkills,
   type AgentSkill,
 } from "@/lib/agentSkills";
+import * as posthog from "@/lib/posthog";
 
 type AgentsPageProps = {
   skills: AgentSkill[];
@@ -54,7 +55,14 @@ const CopyPromptButton = ({
       variant="solid"
       color="accent"
       size="2"
-      onClick={copy}
+      onClick={() => {
+        posthog.track("agents-copy-prompt-clicked-client", {
+          source: "hero",
+          prompt_length: prompt.length,
+          selection_method: "primary",
+        });
+        copy();
+      }}
       icon={{
         icon: isCopied ? Check : Copy,
         "aria-hidden": true,
@@ -118,7 +126,12 @@ const CodingToolWordmarks = ({ prompt }: { prompt: string }) => {
             alignItems="center"
             bg="transparent"
             p="0"
-            onClick={() => openCodingToolDeeplink(option.value, prompt)}
+            onClick={() =>
+              openCodingToolDeeplink(option.value, prompt, {
+                source: "hero_wordmark",
+                selection_method: "wordmark",
+              })
+            }
             onMouseEnter={() => setHovered(option.value)}
             onMouseLeave={() => setHovered(null)}
             style={{
@@ -297,6 +310,8 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                       variant="outline"
                       size="1"
                       hideLabel
+                      trackingSource="skill_card"
+                      skillName={skill.name}
                     />
                   </Box>
                 </Stack>

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -309,8 +309,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                       variant="outline"
                       size="1"
                       hideLabel
-                      trackingSource="skill_card"
-                      skillName={skill.name}
+                      track={{ source: "skill_card", skillName: skill.name }}
                     />
                   </Box>
                 </Stack>


### PR DESCRIPTION
## Summary
Adds posthog eventing to agent page surfaces

## Events
- `agents-coding-tool-clicked-client`: `action`, `source`, `selection_method`, and optional `skill_name`
- `agents-coding-tool-opened-client`: the same properties when invoking an allowlisted coding-tool deeplink
- `agents-banner-clicked-client`: `path`

## Test plan
- [ ] Copy the hero prompt
- [ ] Open a hero coding-tool wordmark
- [ ] Use primary and menu actions on a skill card
- [ ] Click the Knock AI banner from the homepage and AI overview