### PR TITLE
fix(KNO-14623): scale down agents hero typography on mobile

### DIFF
--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -244,7 +244,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                 className="agents-hero__heading"
                 style={{ position: "relative", zIndex: 1 }}
               >
-                Agent-first customer{"\u00A0"}messaging
+                Agent-first customer&nbsp;messaging
               </Heading>
               <Text
                 as="p"

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -244,7 +244,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                 className="agents-hero__heading"
                 style={{ position: "relative", zIndex: 1 }}
               >
-                Agent-first customer messaging
+                Agent-first customer{"\u00A0"}messaging
               </Heading>
               <Text
                 as="p"

--- a/pages/agents.tsx
+++ b/pages/agents.tsx
@@ -241,6 +241,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                 as="h1"
                 size="9"
                 align="center"
+                className="agents-hero__heading"
                 style={{ position: "relative", zIndex: 1 }}
               >
                 Agent-first customer messaging
@@ -250,6 +251,7 @@ export default function AgentsPage({ skills }: AgentsPageProps) {
                 size="3"
                 color="gray"
                 align="center"
+                className="agents-hero__subheading"
                 style={{
                   margin: 0,
                   maxWidth: "36rem",

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -101,9 +101,9 @@
   /* Override font-size directly: Telegraph sets --font-size inline, so
      class-level custom property overrides never win. */
   .tgph-heading.agents-hero__heading {
-    font-size: var(--tgph-text-7);
-    line-height: var(--tgph-leading-7);
-    letter-spacing: var(--tgph-tracking-7);
+    font-size: var(--tgph-text-8);
+    line-height: var(--tgph-leading-8);
+    letter-spacing: var(--tgph-tracking-8);
   }
 
   .tgph-text.agents-hero__subheading {

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -97,6 +97,18 @@
   [data-search-results-container] {
     left: 5%;
   }
+
+  .agents-hero__heading {
+    --font-size: var(--tgph-text-7);
+    --leading: var(--tgph-leading-7);
+    --tracking: var(--tgph-tracking-7);
+  }
+
+  .agents-hero__subheading {
+    --font-size: var(--tgph-text-2);
+    --leading: var(--tgph-leading-2);
+    --tracking: var(--tgph-tracking-2);
+  }
 }
 
 /* Phones */

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -98,16 +98,18 @@
     left: 5%;
   }
 
-  .agents-hero__heading {
-    --font-size: var(--tgph-text-7);
-    --leading: var(--tgph-leading-7);
-    --tracking: var(--tgph-tracking-7);
+  /* Override font-size directly: Telegraph sets --font-size inline, so
+     class-level custom property overrides never win. */
+  .tgph-heading.agents-hero__heading {
+    font-size: var(--tgph-text-7);
+    line-height: var(--tgph-leading-7);
+    letter-spacing: var(--tgph-tracking-7);
   }
 
-  .agents-hero__subheading {
-    --font-size: var(--tgph-text-2);
-    --leading: var(--tgph-leading-2);
-    --tracking: var(--tgph-tracking-2);
+  .tgph-text.agents-hero__subheading {
+    font-size: var(--tgph-text-2);
+    line-height: var(--tgph-leading-2);
+    letter-spacing: var(--tgph-tracking-2);
   }
 }
 


### PR DESCRIPTION
### Description

Scales down the agents page hero heading / subheading on mobile. Size 9 was too big on small screens.

### Tasks

[KNO-14623](https://linear.app/knock/issue/KNO-14623/scale-down-agents-page-hero-typography-on-mobile)