### PR TITLE
chore(KNO-14668): Add FAQ about merging users with in-flight runs

### DIFF
--- a/content/managing-recipients/merging-users.mdx
+++ b/content/managing-recipients/merging-users.mdx
@@ -9,7 +9,6 @@ You might run into the scenario where you've identified an invited user to send 
 Merging two users will merge the `secondary` user (the invited user in our example) into the `primary` user (the signed-up user), and the secondary user will be deleted in the process.
 
 <MultiLangCodeBlock snippet="users.merge" title="Merge two users together" />
-<br />
 
 <Callout
   type="alert"
@@ -20,7 +19,7 @@ Merging two users will merge the `secondary` user (the invited user in our examp
   }
 />
 
-### What's merged?
+## What's merged?
 
 - **Properties**: Properties are deep merged, but if there are any conflicts between the secondary and primary user then the value is selected from the primary user.
 - **Preferences**: Preference sets are shallow merged between the users. Any preference sets that don't exist on the primary from the secondary are added.
@@ -29,3 +28,14 @@ Merging two users will merge the `secondary` user (the invited user in our examp
 - **Activities**: Any activities from the past 30 days that the secondary user was an `actor` or `recipient` of will be transferred to the primary user.
 
 If you need to retain more than 30 days worth of history, please contact us.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="What happens to in-flight workflows or broadcasts for the secondary user?">
+    Merging does not transfer in-flight workflow or broadcast runs to the primary user. If a run for the secondary user is paused at a delay, batch, or wait-for-event step, it remains associated with that user. When the run resumes, it is stopped before sending a notification because the secondary user has been deleted. Knock does not redirect the run to the primary user.
+
+    To make sure an in-flight notification is still delivered, wait for the workflow or broadcast to complete before merging the users.
+
+  </Accordion>
+</AccordionGroup>


### PR DESCRIPTION
### Description

Adds an FAQ to the merging users page to clarify what happens when the secondary user has an in-flight workflow run. 

https://docs-git-rt-kno-14668-clarify-merging-users-knocklabs.vercel.app/managing-recipients/merging-users#frequently-asked-questions

### Tasks

[KNO-14668](https://linear.app/knock/issue/KNO-14668/docs-add-information-about-in-flight-workflows-to-merging-users-page)