### PR TITLE
fix(KNO-14676): fix broken OG images

### DIFF
--- a/pages/api/og.tsx
+++ b/pages/api/og.tsx
@@ -21,6 +21,10 @@ export default async function handler(request: NextRequest) {
     new URL("../../assets/og_background.png", import.meta.url),
   ).then((res) => res.arrayBuffer());
 
+  const backgroundImageSrc = `data:image/png;base64,${Buffer.from(
+    backgroundImageData,
+  ).toString("base64")}`;
+
   const fontDataMedium = await fetch(
     new URL("../../assets/Inter_28pt-Medium.ttf", import.meta.url),
   ).then((res) => res.arrayBuffer());
@@ -37,8 +41,7 @@ export default async function handler(request: NextRequest) {
           fontFamily: "Inter",
         }}
       >
-        {/* @ts-ignore */}
-        <img width="1200" height="630" src={backgroundImageData} alt="" />
+        <img width={1200} height={630} src={backgroundImageSrc} alt="" />
         <div
           style={{
             position: "absolute",


### PR DESCRIPTION
## Summary
OG images were broken. Main fix was changing image to use numbers instead of strings. Also uses base64 data URL to fix the TS error (but that wasn't the source of the error)

Example fix: https://docs-git-fix-kno-14676-broken-og-images-knocklabs.vercel.app/api/og?title=Documentation&description=Explore%20our%20guides%20and%20examples%20to%20integrate%20Knock.

## Test plan
- [ ] Hit `/api/og?title=Documentation&description=Test` and confirm it returns a real image (logo + text), not a blank PNG
- [ ] Spot-check `og:image` on a docs page in Slack / LinkedIn / opengraph.xyz


Made with [Cursor](https://cursor.com)