### PR TITLE
chore: small clarification on hosted pref center

### DIFF
--- a/content/preferences/hosted-preference-center.mdx
+++ b/content/preferences/hosted-preference-center.mdx
@@ -11,7 +11,7 @@ Knock's hosted preference center is a page where your users manage their `defaul
 - **Knock hosts the page.** Users access their preferences through a signed URL.
 - **Configure in the dashboard.** Set rows, labels, and branding under <a href="https://dashboard.knock.app/~/preferences?tab=preference_center" target="_blank">**Platform** > **Preferences** > **Preference center**</a>.
 - **No code required.** Enable the preference center and [link to it from your notifications](#linking-to-the-preference-center).
-- **User default preferences only.** The hosted preference center does not support [per-tenant](/multi-tenancy/per-tenant-preferences), [object](/preferences/object-preferences), or non-default preference sets.
+- **User default preferences only.** The hosted preference center does not support [per-tenant](/multi-tenancy/per-tenant-preferences) or [object](/preferences/object-preferences) preferences.
 
 The hosted preference center enables you to give users a way to manage their notification preferences without building or hosting the UI yourself. If you need more control over the experience, see the [custom preference center](/preferences/custom-preference-center). Not sure which approach fits? See [Going live with preferences](/preferences/overview#going-live-with-preferences).
 


### PR DESCRIPTION
### Description

Removes a mention of "non-default preference sets," as these are the same thing as per-tenant preferences. I caught this in review on the custom preference center page but missed this mention.