### PR TITLE
docs(KNO-14711): extend roles and permissions docs for permission groups

### DIFF
--- a/content/manage-your-account/managing-members.mdx
+++ b/content/manage-your-account/managing-members.mdx
@@ -32,7 +32,7 @@ Account owners and admins will find the **Members** page in the Knock dashboard'
 
 ### Inviting members
 
-You can invite new members to your account by selecting the "New member" button on the **Members** page. Members are always invited via their email address and must be assigned [a role](/manage-your-account/roles-and-permissions). You can optionally include a message that will appear in the invitation email.
+You can invite new members to your account by selecting the "New member" button on the **Members** page. Members are always invited via their email address and must be assigned [a role](/manage-your-account/roles-and-permissions). On Enterprise plans, you can assign one or more [custom permission groups](/manage-your-account/roles-and-permissions#custom-permission-groups) instead of a built-in role. You can optionally include a message that will appear in the invitation email.
 
 The member will be sent a reminder email if the invite is not accepted within 3 days. Account invites will automatically expire after 2 weeks.
 
@@ -98,7 +98,7 @@ The following restrictions apply when managing members:
 
 ### Updating member roles
 
-Account members with appropriate [permissions](/manage-your-account/roles-and-permissions) can update the roles of others by selecting "Change role" from the three-dot menu. The role change will take effect immediately.
+Account members with appropriate [permissions](/manage-your-account/roles-and-permissions) can update the roles of others by selecting "Change role" from the three-dot menu. You can switch a member between a built-in role and custom permission groups, or update which custom groups they belong to. The change takes effect immediately.
 
 ### Removing members
 

--- a/content/manage-your-account/roles-and-permissions.mdx
+++ b/content/manage-your-account/roles-and-permissions.mdx
@@ -37,9 +37,9 @@ Here's an overview of the built-in roles available to Knock account members:
   text={
     <>
       On Enterprise plans, you can create{" "}
-      <a href="#custom-permission-groups">custom permission groups</a> to
-      define your own roles with per-environment access controls. You can see
-      the permission groups available to your account under{" "}
+      <a href="#custom-permission-groups">custom permission groups</a> to define
+      your own roles with per-environment access controls. You can see the
+      permission groups available to your account under{" "}
       <span className="font-semibold">Settings</span> &gt;{" "}
       <span className="font-semibold">Permissions</span>.
     </>

--- a/content/manage-your-account/roles-and-permissions.mdx
+++ b/content/manage-your-account/roles-and-permissions.mdx
@@ -1,11 +1,18 @@
 ---
 title: Roles and permissions
-description: Learn about roles and permissions in Knock.
-tags: ["team", "team members", "account members", "invites", "inviting"]
+description: Learn about roles, permissions, and custom permission groups in Knock.
+tags:
+  [
+    "team",
+    "team members",
+    "account members",
+    "invites",
+    "inviting",
+    "permission groups",
+    "custom roles",
+  ]
 section: Manage your account
 ---
-
-Learn more about the roles available to members of your Knock account.
 
 ## Overview
 
@@ -13,7 +20,9 @@ Knock uses an account-level roles model, where a given account member's role det
 
 You set an account member's role when you invite them to the Knock dashboard. You can update their role on the **Members** page under the **Admin** section of your account settings. Learn more in our [managing members documentation](/manage-your-account/managing-members).
 
-Here's an overview of the roles available to Knock account members:
+Knock provides a set of built-in roles for common team functions.
+
+Here's an overview of the built-in roles available to Knock account members:
 
 - **Owner.** For your primary admin who manages billing. This role can invite and manage members, manage billing, and do anything available in the admin role. Your account must always have at least one account owner.
 - **Admin.** For admins who need to manage account-level settings. This role can invite and manage members (excluding owner and billing roles), manage account branding, manage environments, and manage advanced developer concepts such as signing keys, enhanced security mode, variables, and webhooks. This role has all permissions available to the member role.
@@ -22,7 +31,22 @@ Here's an overview of the roles available to Knock account members:
 - **Support.** For users who shouldn't have access to workflows and templates, but should be able to dig into message and API logs for debugging purposes.
 - **Billing.** For account members who shouldn't have access to anything in Knock but billing.
 
-For a complete overview of which permissions are available to which roles, see our lookup table below.
+<Callout
+  type="enterprise"
+  title="Custom permission groups."
+  text={
+    <>
+      On Enterprise plans, you can create{" "}
+      <a href="#custom-permission-groups">custom permission groups</a> to
+      define your own roles with per-environment access controls. You can see
+      the permission groups available to your account under{" "}
+      <span className="font-semibold">Settings</span> &gt;{" "}
+      <span className="font-semibold">Permissions</span>.
+    </>
+  }
+/>
+
+For a complete overview of which permissions are available to which built-in roles, see our lookup table below.
 
 ## Roles and permissions lookup table
 
@@ -107,3 +131,48 @@ For a complete overview of which permissions are available to which roles, see o
   title="Production Member environment access."
   text="The Production Member role can only access the production environment."
 />
+
+## Custom permission groups
+
+<Callout
+  type="enterprise"
+  style={{ alignItems: "center" }}
+  title="Enterprise plan feature."
+  text={
+    <>
+      Custom permission groups are only available on our{" "}
+      <a href="https://knock.app/pricing" target="_blank" rel="noopener">
+        Enterprise plan.
+      </a>
+    </>
+  }
+/>
+
+Custom permission groups enable you to define your own roles with specific capabilities. Create and manage them under **Settings** > **Permissions**.
+
+### Capabilities
+
+When you create a permission group, you choose which capabilities members in that group receive. Capabilities fall into two scopes:
+
+- **Account.** Settings and resources that apply across the whole account, such as members, billing, integrations, and API keys.
+- **Environment.** Resources that live in an environment, such as workflows, guides, content, broadcasts, audiences, recipient data, observability, and release management.
+
+Most capabilities support levels such as view and manage. Release management uses a publish level for committing and promoting changes.
+
+### Environment access
+
+For environment-scoped capabilities, you control both what members can do and which environments they can access:
+
+1. **Same access in every environment.** Apply one set of environment capabilities across development, production, and any additional environments.
+2. **Per-environment access.** Use granular mode to set different capability levels in each environment. For example, grant manage access to workflows in development, and view-only access in production.
+3. **No access to an environment.** Deny an environment to hide it from members in the group and block all environment-scoped permissions there, including on its branches. Account-level capabilities still apply. At least one environment must remain accessible.
+
+### Assigning permission groups
+
+You assign custom permission groups when you [invite a member](/manage-your-account/managing-members) or change their role. You can also add members from a permission group's detail page.
+
+- Choose either a built-in role **or** one or more custom permission groups. You cannot combine a built-in role with custom groups on the same member.
+- When you assign custom groups, the member's role becomes **Custom**. Their effective permissions are the union of every assigned group.
+- An environment is accessible to a custom member if any of their assigned groups grants access to it.
+
+Archiving a custom permission group removes its grants from any members who had it assigned.

--- a/content/version-control/environments.mdx
+++ b/content/version-control/environments.mdx
@@ -222,7 +222,7 @@ We recognize the importance of protecting your sensitive data, so we designed Kn
 
 There are two tools you can use to control access to your data in the Knock dashboard:
 
-- [Roles and permissions.](/manage-your-account/roles-and-permissions) Knock offers granular roles for the different functions your team members may want to carry out in Knock, such as support team members that need to debug issues for customers but shouldn't be making changes to notification logic.
+- [Roles and permissions.](/manage-your-account/roles-and-permissions) Knock offers built-in roles for common team functions, and on Enterprise plans [custom permission groups](/manage-your-account/roles-and-permissions#custom-permission-groups) with per-environment access controls. For example, you can give support team members access to debug issues without permission to change notification logic, or deny access to an environment entirely.
 - [Customer data obfuscation.](/manage-your-account/data-obfuscation) You can use our per-environment data obfuscation controls to configure whether you want your team members to be able to view customer data in the Knock dashboard.
 
 ## Frequently asked questions


### PR DESCRIPTION
## Summary
- Documents Enterprise custom permission groups on the roles and permissions page, including capabilities, per-environment access, environment denial, and assignment
- Updates managing members invite/change-role flows to cover custom permission groups
- Links environment access controls to custom permission groups

## Test plan
- [ ] Preview `/manage-your-account/roles-and-permissions` and confirm Enterprise callouts, custom permission groups section, and Settings > Permissions guidance render correctly
- [ ] Confirm in-page and cross-page links to `#custom-permission-groups` resolve
- [ ] Spot-check `/manage-your-account/managing-members` and `/version-control/environments` for the new Enterprise references


Made with [Cursor](https://cursor.com)